### PR TITLE
Correctly compare paths to files in the current directory.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -143,11 +143,12 @@ function createSourceReplacingCompilerHost(
       fileName: string, languageVersion: ts.ScriptTarget,
       onError?: (message: string) => void): ts.SourceFile {
     let sourceText: string;
-    if (substituteSource.hasOwnProperty(fileName)) {
-      sourceText = substituteSource[fileName];
-      return ts.createSourceFile(fileName, sourceText, languageVersion);
+    let path: string = ts.sys.resolvePath(fileName);
+    if (substituteSource.hasOwnProperty(path)) {
+      sourceText = substituteSource[path];
+      return ts.createSourceFile(path, sourceText, languageVersion);
     }
-    return delegate.getSourceFile(fileName, languageVersion, onError);
+    return delegate.getSourceFile(path, languageVersion, onError);
   }
 }
 
@@ -182,7 +183,7 @@ function toClosureJS(options: ts.CompilerOptions, fileNames: string[]):
     if (diagnostics.length > 0) {
       return {errors: diagnostics};
     }
-    tsickleOutput[fileName] = output;
+    tsickleOutput[ts.sys.resolvePath(fileName)] = output;
     if (externs) {
       tsickleExterns += externs;
     }


### PR DESCRIPTION
If the tsickle main function is run against files in the same directory,
then closure type comments are not added to the outputted JavaScript. For
example, if you run tsickle against './hello.ts' then the outputted
hello.js will not have type comments.

This occurs because the sourceReplacingCompilerHost compares fileNames to
determine whether we ran tsickle on the source file. 'hello.ts' is compared
to './hello.ts' and we incorrectly skip the file.

This is fixed by comparing the path to the files using the TypeScript
sys utilities.