### PR TITLE
Remove closure compilation from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ well.
 
 ### Invocation
 
-Run `tsickle --help` for the full syntax, but basically you specify the minified
-output bundle path and the input TypeScript project.
+Run `tsickle --help` for the full syntax, but basically you provide any tsickle
+specific options and use it as a TypeScript compiler.
 
 ## Development
 


### PR DESCRIPTION
This removes the need for google-closure-compiler to be a dependency. Now
it can be a dev dependency and the CLI should just work when downloaded
from npm.