### PR TITLE
Add declareLegacyNamespace option for codebases migrating to goog.module

### DIFF
--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -165,9 +165,11 @@ describe('getJSDocAnnotation', () => {
 });
 
 describe('convertCommonJsToGoogModule', () => {
-  function expectCommonJs(fileName: string, content: string) {
+  function expectCommonJs(fileName: string, content: string, useDeclareLegacyNamespace = false) {
     return expect(
-        tsickle.convertCommonJsToGoogModule(fileName, content, cli_support.pathToModuleName)
+        tsickle
+            .convertCommonJsToGoogModule(
+                fileName, content, cli_support.pathToModuleName, useDeclareLegacyNamespace)
             .output);
   }
 
@@ -175,6 +177,12 @@ describe('convertCommonJsToGoogModule', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`)
         .to.equal(`goog.module('a');var module = module || {id: 'a.js'};console.log('hello');`);
+  });
+
+  it('adds declareLegacyNamespace when specified', () => {
+    expectCommonJs('a.js', `console.log('hello');`, true)
+        .to.equal(
+            `goog.module('a');goog.module.declareLegacyNamespace();var module = module || {id: 'a.js'};console.log('hello');`);
   });
 
   it('adds a goog.module call to empty files', () => {


### PR DESCRIPTION
tsickle uses goog.module. Not all closure codebases have fully migrated to
goog.module. In an attempt to support codebases which still use
goog.provide and goog.require, enable tsickle to output
goog.module.declareLegacyNamespace().