### PR TITLE
In the CLI, do not run module converison on sourcemaps.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -187,9 +187,11 @@ function toClosureJS(options: ts.CompilerOptions, fileNames: string[]):
   }
 
   for (let fileName of Object.keys(jsFiles)) {
-    let {output} = tsickle.convertCommonJsToGoogModule(
-        fileName, jsFiles[fileName], cli_support.pathToModuleName);
-    jsFiles[fileName] = output;
+    if (path.extname(fileName) !== '.map') {
+      let {output} = tsickle.convertCommonJsToGoogModule(
+          fileName, jsFiles[fileName], cli_support.pathToModuleName);
+      jsFiles[fileName] = output;
+    }
   }
 
   jsFiles[internalExternsFileName] = tsickleExterns;


### PR DESCRIPTION
If you turn on sourcemaps in the TypeScript compiler, the CLI runs module conversion on them. This breaks the sourcemaps :( This change prevents them from being converted.