### PR TITLE
don't overide typescript source argument, mkdirp before write

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "minimist": "^1.2.0",
     "source-map": "^0.4.2",
-    "source-map-support": "^0.3.1"
+    "source-map-support": "^0.3.1",
+    "mkdirp": "^0.5.1"
   },
   "peerDependencies": {
     "typescript": "^1.8.0 || ^1.9.0-dev"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 
 import * as fs from 'fs';
 import * as minimist from 'minimist';
+import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -86,6 +87,9 @@ function loadTscConfig(args: string[]):
     return {errors};
   }
 
+  // Store file arguments
+  let tsFileArguments = fileNames;
+
   // Read further settings from tsconfig.json.
   let projectDir = options.project || '.';
   let configFileName = path.join(projectDir, 'tsconfig.json');
@@ -99,6 +103,9 @@ function loadTscConfig(args: string[]):
   if (errors.length > 0) {
     return {errors};
   }
+
+  // if file arguments were given to the typescript transpiler than transpile only those files
+  fileNames = tsFileArguments.length > 0 ? tsFileArguments : fileNames;
 
   return {options, fileNames};
 }
@@ -222,10 +229,12 @@ function main(args: string[]) {
   }
 
   for (let fileName of Object.keys(jsFiles)) {
+    mkdirp.sync(path.dirname(fileName));
     fs.writeFileSync(fileName, jsFiles[fileName]);
   }
 
   if (settings.externsPath) {
+    mkdirp.sync(path.dirname(settings.externsPath));
     fs.writeFileSync(settings.externsPath, externs);
   }
 }

--- a/tsd.json
+++ b/tsd.json
@@ -31,6 +31,9 @@
     },
     "google-closure-compiler/google-closure-compiler.d.ts": {
       "commit": "edb64e4a35896510ce02b93c0bca5ec3878db738"
+    },
+    "mkdirp/mkdirp.d.ts": {
+      "commit": "3bbe35a4cfdf09bd2a87ed660bf918131679da19"
     }
   }
 }


### PR DESCRIPTION
Currently Tsickle will always transpile the whole program every time it
is run. This pull request adds support for transpiling only the files
supplied to ts via the command line. For example tsickle -- foobar.ts
would now only transpile foobar.ts instead of the whole program.

This also calls mkdirp on the directory path of a file before it is
written. Previously, if an output directory was given to the ts
transpiler via the command line (i.e. tsickle -- --outDir build/)
tsickle would be unsuccessful in writing the file if the entire
directory tree had not been created at the specified output path.