### PR TITLE
everything in d.ts should show up in externs

### DIFF
--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -67,3 +67,9 @@ declare module CodeMirror {
     name: string;
   }
 }
+
+// An interface that is not tagged with "declare", but exists in a
+// d.ts file so it should show up in the externs anyway.
+interface BareInterface {
+  name: string;
+}

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -69,3 +69,9 @@ declare module CodeMirror {
     name: string;
   }
 }
+
+// An interface that is not tagged with "declare", but exists in a
+// d.ts file so it should show up in the externs anyway.
+interface BareInterface {
+  name: string;
+}

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -94,3 +94,7 @@ function CodeMirror(y, x) {}
 CodeMirror.Editor = function() {};
  /** @type {string} */
 CodeMirror.Editor.prototype.name;
+/** @record @struct */
+function BareInterface() {}
+ /** @type {string} */
+BareInterface.prototype.name;


### PR DESCRIPTION
Even if there's an "interface Foo" without a "declare" on
it, if it's in a d.ts file, it needs to show up in externs.