### PR TITLE
Update launch.json to call mocha directly.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Run Tests",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/node_modules/gulp-mocha/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "args": [
         "--colors",
         "--timeout=0",
@@ -18,7 +18,7 @@
       "env": {
         "NODE_ENV": "development"
       },
-      "externalConsole": false,
+      "console": "internalConsole",
       "sourceMaps": true,
       "outDir": "${workspaceRoot}/build"
     }


### PR DESCRIPTION
#214
- Change path to call mocha binary directly.

(unrelated)
- Update to new “console” attribute, set to “internalConsole”