### PR TITLE
avoid the parameter name 'arguments'

### DIFF
--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -73,3 +73,6 @@ declare module CodeMirror {
 interface BareInterface {
   name: string;
 }
+
+// Don't use a parameter named "arguments"; it's illegal in Closure.
+declare function usesArguments(arguments: string);

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -75,3 +75,6 @@ declare module CodeMirror {
 interface BareInterface {
   name: string;
 }
+
+// Don't use a parameter named "arguments"; it's illegal in Closure.
+declare function usesArguments(arguments: string);

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -98,3 +98,9 @@ CodeMirror.Editor.prototype.name;
 function BareInterface() {}
  /** @type {string} */
 BareInterface.prototype.name;
+
+/**
+ * @param {string} tsickle_arguments
+ * @return {?}
+ */
+function usesArguments(tsickle_arguments) {}


### PR DESCRIPTION
Refactor method writing to pass the argument list as an array
to a shared function, then filter the argument list in that
function.

Fixes #219.