### PR TITLE
avoid an error in ts 2.0

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -53,7 +53,8 @@ class ClassRewriter extends Rewriter {
   }
 
   private decoratorsToLower(n: ts.Node): ts.Decorator[] {
-    return (n.decorators as ts.NodeArray<ts.Decorator>|| []).filter(d => this.shouldLower(d));
+    let decorators = (n.decorators || []) as ts.NodeArray<ts.Decorator>;
+    return decorators.filter(d => this.shouldLower(d));
   }
 
   /**

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -53,8 +53,7 @@ class ClassRewriter extends Rewriter {
   }
 
   private decoratorsToLower(n: ts.Node): ts.Decorator[] {
-    let decorators = (n.decorators || []) as ts.NodeArray<ts.Decorator>;
-    return decorators.filter(d => this.shouldLower(d));
+    return (n.decorators as ts.NodeArray<ts.Decorator>|| []).filter(d => this.shouldLower(d));
   }
 
   /**

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -53,7 +53,10 @@ class ClassRewriter extends Rewriter {
   }
 
   private decoratorsToLower(n: ts.Node): ts.Decorator[] {
-    return (n.decorators as ts.NodeArray<ts.Decorator>|| []).filter(d => this.shouldLower(d));
+    if (n.decorators) {
+      return n.decorators.filter((d) => this.shouldLower(d));
+    }
+    return [];
   }
 
   /**


### PR DESCRIPTION
This change was necessary for the TS 2.0 migration inside Google.
It's not clear to me why the code works on Travis though.