### PR TITLE
feat: generate source mappings during rewriting.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Run Tests",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "args": [
         "--colors",
         "--timeout=0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/mkdirp": "^0.3.28",
     "@types/mocha": "^2.2.31",
     "@types/node": "^6.0.38",
+    "@types/source-map": "^0.1.27",
     "@types/source-map-support": "^0.2.27",
     "chai": "^3.5.0",
     "clang-format": "^1.0.45",

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1,3 +1,4 @@
+import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 import * as jsdoc from './jsdoc';
@@ -9,24 +10,30 @@ export {convertDecorators} from './decorator-annotator';
 export {processES5 as convertCommonJsToGoogModule} from './es5processor';
 
 export interface Options {
-  // If true, convert every type to the Closure {?} type, which means
-  // "don't check types".
+  /**
+   * If true, convert every type to the Closure {?} type, which means
+   * "don't check types".
+   */
   untyped?: boolean;
-  // If provided a function that logs an internal warning.
-  // These warnings are not actionable by an end user and should be hidden
-  // by default.
+  /**
+   * If provided a function that logs an internal warning.
+   * These warnings are not actionable by an end user and should be hidden
+   * by default.
+   */
   logWarning?: (warning: ts.Diagnostic) => void;
-  // If provided, a set of paths whose types should always generate as {?}.
+  /** If provided, a set of paths whose types should always generate as {?}. */
   typeBlackListPaths?: Set<string>;
 }
 
 export interface Output {
-  // The TypeScript source with Closure annotations inserted.
+  /** The TypeScript source with Closure annotations inserted. */
   output: string;
-  // Generated externs declarations, if any.
+  /** Generated externs declarations, if any. */
   externs: string|null;
-  // Error messages, if any.
+  /** Error messages, if any. */
   diagnostics: ts.Diagnostic[];
+  /** A source map mapping back into the original sources. */
+  sourceMap: SourceMapGenerator;
 }
 
 /**
@@ -384,6 +391,7 @@ class Annotator extends ClosureRewriter {
       output: annotated.output,
       externs: externsSource,
       diagnostics: externs.diagnostics.concat(annotated.diagnostics),
+      sourceMap: annotated.sourceMap,
     };
   }
   /**

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -1,0 +1,25 @@
+import {expect} from 'chai';
+import {SourceMapConsumer} from 'source-map';
+
+import {annotate} from '../src/tsickle';
+
+import {createProgram} from './test_support';
+
+describe('source maps', () => {
+  it('generates a source map', () => {
+    const sources = new Map<string, string>();
+    sources.set('input.ts', `
+      class X { field: number; }
+      class Y { field2: string; }`);
+    const program = createProgram(sources);
+    const annotated = annotate(program, program.getSourceFile('input.ts'));
+    const rawMap = (annotated.sourceMap as any).toJSON();
+    const consumer = new SourceMapConsumer(rawMap);
+    // Uncomment to debug contents:
+    // annotated.output.split('\n').forEach((v, i) => console.log(i + 1, v));
+    expect(consumer.originalPositionFor({line: 2, column: 20}).line)
+        .to.equal(2, 'first class definition');
+    expect(consumer.originalPositionFor({line: 9, column: 20}).line)
+        .to.equal(3, 'second class definition');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "test/e2e_test.ts",
     "test/es5processor_test.ts",
     "test/jsdoc_test.ts",
+    "test/source_map_test.ts",
     "test/test_support.ts",
     "test/tsickle_test.ts",
     "test/type-translator_test.ts"


### PR DESCRIPTION
This generates basic mappings for the intact pieces of the
original source code, which should be good enough for stack
traces (after combining with TypeScript's source map).