### PR TITLE
expose an API to provide the module id

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -219,8 +219,9 @@ function toClosureJS(
 
   for (let fileName of toArray(jsFiles.keys())) {
     if (path.extname(fileName) !== '.map') {
-      let {output} = tsickle.convertCommonJsToGoogModule(
-          fileName, jsFiles.get(fileName)!, cliSupport.pathToModuleName);
+      const moduleId = fileName;  // TODO: does anyone use this?
+      let {output} = tsickle.processES5(
+          fileName, moduleId, jsFiles.get(fileName)!, cliSupport.pathToModuleName);
       jsFiles.set(fileName, output);
     }
   }

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -7,7 +7,7 @@ import {assertTypeChecked, TypeTranslator} from './type-translator';
 import {toArray} from './util';
 
 export {convertDecorators} from './decorator-annotator';
-export {processES5 as convertCommonJsToGoogModule} from './es5processor';
+export {processES5} from './es5processor';
 
 export interface Options {
   /**

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -6,7 +6,8 @@ import * as es5processor from '../src/es5processor';
 describe('convertCommonJsToGoogModule', () => {
   function expectCommonJs(fileName: string, content: string, isES5 = true) {
     return expect(
-        es5processor.processES5(fileName, content, cliSupport.pathToModuleName, isES5).output);
+        es5processor.processES5(fileName, fileName, content, cliSupport.pathToModuleName, isES5)
+            .output);
   }
 
   it('adds a goog.module call', () => {
@@ -160,7 +161,7 @@ foo_1.A, foo_2.B, foo_2        , foo_3.default;
 
   it('gathers referenced modules', () => {
     let {referencedModules} = es5processor.processES5(
-        'a/b', `
+        'a/b', 'a/b', `
 require('../foo/bare_require');
 var googRequire = require('goog:foo.bar');
 var es6RelativeRequire = require('./relative');

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -61,8 +61,9 @@ export function createProgram(sources: Map<string, string>): ts.Program {
 export function emit(program: ts.Program): {[fileName: string]: string} {
   let transformed: {[fileName: string]: string} = {};
   let {diagnostics} = program.emit(undefined, (fileName: string, data: string) => {
+    const moduleId = fileName.replace(/^\.\//, '');
     transformed[fileName] =
-        tsickle.convertCommonJsToGoogModule(fileName, data, cliSupport.pathToModuleName).output;
+        tsickle.processES5(fileName, moduleId, data, cliSupport.pathToModuleName).output;
   });
   if (diagnostics.length > 0) {
     throw new Error(tsickle.formatDiagnostics(diagnostics));


### PR DESCRIPTION
This module.id stuff is only used by Angular 2, and
I think we'll remove it soon, but for now I'd like to
be able to control it separately from the filename for
an upcoming cleanup to how we handle module names.