### PR TITLE
add OSPO-required license headers to each src file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+Want to contribute?  Great! First, read this page (including the small print at
+the end).
+
+### Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License Agreement]
+(https://cla.developers.google.com/about/google-individual)
+(CLA), which you can do online.  The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code.  We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents.  You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you.  Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than
+the one above, the
+[Software Grant and Corporate Contributor License Agreement]
+(https://cla.developers.google.com/about/google-corporate).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 require('source-map-support').install();
 
 var clangFormat = require('clang-format');

--- a/src/cli_support.ts
+++ b/src/cli_support.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as path from 'path';
 
 // Postprocess generated JS.

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 import {Rewriter} from './rewriter';

--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 import {getIdentifierText, Rewriter} from './rewriter';

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -1,4 +1,12 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
  * TypeScript has an API for JSDoc already, but it's not exposed.
  * https://github.com/Microsoft/TypeScript/issues/7393
  * For now we create types that are similar to theirs so that migrating

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as fs from 'fs';
 import * as minimist from 'minimist';
 import * as mkdirp from 'mkdirp';

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 export function assertTypeChecked(sourceFile: ts.SourceFile) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // toArray is a temporary function to help in the use of
 // ES6 maps and sets when running on node 4, which doesn't
 // support Iterators completely.

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 import * as ts from 'typescript';
 

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as fs from 'fs';
 import * as closure from 'google-closure-compiler';
 

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 
 import * as cliSupport from '../src/cli_support';

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 
 import * as jsdoc from '../src/jsdoc';

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 import {SourceMapConsumer} from 'source-map';
 

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/test/type-translator_test.ts
+++ b/test/type-translator_test.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {expect} from 'chai';
 
 import * as typeTranslator from '../src/type-translator';


### PR DESCRIPTION
They should also be in test_files, but we'd have to get the formatting correct to avoid breaking the tests.