### PR TITLE
fix import error when running tsickle on valid tsc code

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -208,18 +208,14 @@ function toClosureJS(
   // place of the original source.
   let host = createSourceReplacingCompilerHost(tsickleOutput, ts.createCompilerHost(options));
   program = ts.createProgram(fileNames, options, host);
-  let diagnostics = ts.getPreEmitDiagnostics(program);
-  if (diagnostics.length > 0) {
-    allDiagnostics.push(...diagnostics);
-    return null;
-  }
 
   // Emit, creating a map of fileName => generated JS source.
   const jsFiles = new Map<string, string>();
   function writeFile(fileName: string, data: string): void {
     jsFiles.set(fileName, data);
   }
-  ({diagnostics} = program.emit(undefined, writeFile));
+
+  let {diagnostics} = program.emit(undefined, writeFile);
   if (diagnostics.length > 0) {
     allDiagnostics.push(...diagnostics);
     return null;


### PR DESCRIPTION
tsickle's current approach is to run TypeScript, modify the output, and pass it through TypeScript again.  This can cause TypeScript to think imports have been declared twice (and fail accordingly).

As @evmar discovered with the internal build of tsickle (b/30708240), this can be worked around by ensuring `getDeclarationDiagnostics` isn't called on the second pass.  A more permanent solution would eliminate the second pass entirely, solving #189.