### PR TITLE
Add @unrestricted to all generated Closure classes.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -654,6 +654,10 @@ class Annotator extends ClosureRewriter {
 
   private visitClassDeclaration(classDecl: ts.ClassDeclaration) {
     let jsDoc = this.getJSDoc(classDecl) || [];
+    // Always include @unrestricted so that Closure compiler does not complain if some class fields
+    // are not assigned in the constructor but declared (which tsickle always does in
+    // _tsickle_typeAnnotationsHelper).
+    jsDoc.push({tagName: 'unrestricted'});
     if ((classDecl.flags & ts.NodeFlags.Abstract) !== 0) {
       jsDoc.push({tagName: 'abstract'});
     }

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -25,9 +25,9 @@ describe('source maps', () => {
     const consumer = new SourceMapConsumer(rawMap);
     // Uncomment to debug contents:
     // annotated.output.split('\n').forEach((v, i) => console.log(i + 1, v));
-    expect(consumer.originalPositionFor({line: 2, column: 20}).line)
+    expect(consumer.originalPositionFor({line: 5, column: 20}).line)
         .to.equal(2, 'first class definition');
-    expect(consumer.originalPositionFor({line: 9, column: 20}).line)
+    expect(consumer.originalPositionFor({line: 15, column: 20}).line)
         .to.equal(3, 'second class definition');
   });
 });

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,4 +1,5 @@
 goog.module('test_files.abstract.abstract');var module = module || {id: 'test_files/abstract/abstract.js'};/**
+ * @unrestricted
  * @abstract
  */
 class Base {
@@ -39,6 +40,9 @@ class Base {
         this.hasReturnType();
     }
 }
+/**
+ * @unrestricted
+ */
 class Derived extends Base {
     constructor() {
         super();

--- a/test_files/abstract/abstract.tsickle.ts
+++ b/test_files/abstract/abstract.tsickle.ts
@@ -1,4 +1,5 @@
 /**
+ * @unrestricted
  * @abstract
  */
 abstract class Base {
@@ -40,6 +41,9 @@ bar() {
   }
 }
 
+/**
+ * @unrestricted
+ */
 class Derived extends Base {
 constructor() {
     super();

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -5,6 +5,9 @@ goog.module('test_files.basic.untyped.basic.untyped');var module = module || {id
 function func(arg1) {
     return [3];
 }
+/**
+ * @unrestricted
+ */
 class Foo {
     /**
      * @param {?} ctorArg

--- a/test_files/basic.untyped/basic.untyped.tsickle.ts
+++ b/test_files/basic.untyped/basic.untyped.tsickle.ts
@@ -7,6 +7,9 @@ function func(arg1: string): number[] {
   return [3];
 }
 
+/**
+ * @unrestricted
+ */
 class Foo {
   field: string;
 /**

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,4 +1,7 @@
-goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};class Comments {
+goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};/**
+ * @unrestricted
+ */
+class Comments {
     static _tsickle_typeAnnotationsHelper() {
         /** @export
         @type {string} */

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 class Comments {
   /** @export */
   export1: string;

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -10,6 +10,9 @@ function decorator(a, b) { }
  * @return {void}
  */
 function annotationDecorator(a, b) { }
+/**
+ * @unrestricted
+ */
 class DecoratorTest {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {Object<string,Array<DecoratorInvocation>>} */

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -12,6 +12,9 @@ function decorator(a: Object, b: string) {}
  */
 function annotationDecorator(a: Object, b: string) {}
 
+/**
+ * @unrestricted
+ */
 class DecoratorTest {
   @decorator
 private x: number;

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,4 +1,7 @@
-goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};class FieldsTest {
+goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};/**
+ * @unrestricted
+ */
+class FieldsTest {
     /**
      * @param {number} field3
      */

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -1,5 +1,8 @@
 Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
 ====
+/**
+ * @unrestricted
+ */
 class FieldsTest {
   field1: string;
   field2: number;

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,4 +1,7 @@
-goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
+goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};/**
+ * @unrestricted
+ */
+class NoCtor {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {number} */
         NoCtor.prototype.field1;

--- a/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
+++ b/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 class NoCtor {
   field1: number;
 

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -17,6 +17,9 @@ function returnsTest() {
  * @return {void}
  */
 function jsDocTestBadDoc(foo) { }
+/**
+ * @unrestricted
+ */
 class JSDocTest {
     static _tsickle_typeAnnotationsHelper() {
         /** @export

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -23,6 +23,9 @@ function returnsTest(): string {
  */
 function jsDocTestBadDoc(foo: string) {}
 
+/**
+ * @unrestricted
+ */
 class JSDocTest {
   /** @export */
   exported: string;

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,4 +1,7 @@
 goog.module('test_files.jsdoc_types.untyped.default');var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};
+/**
+ * @unrestricted
+ */
 class DefaultClass {
 }
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/test_files/jsdoc_types.untyped/default.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/default.tsickle.ts
@@ -1,1 +1,4 @@
+/**
+ * @unrestricted
+ */
 export default class DefaultClass {}

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,4 +1,7 @@
 goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};
+/**
+ * @unrestricted
+ */
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -1,2 +1,5 @@
+/**
+ * @unrestricted
+ */
 export class Class {}
 export interface Interface { x: number }

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,10 +1,19 @@
 goog.module('test_files.jsdoc_types.untyped.module2');var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};
+/**
+ * @unrestricted
+ */
 class ClassOne {
 }
 exports.ClassOne = ClassOne;
+/**
+ * @unrestricted
+ */
 class ClassTwo {
 }
 exports.ClassTwo = ClassTwo;
+/**
+ * @unrestricted
+ */
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;

--- a/test_files/jsdoc_types.untyped/module2.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module2.tsickle.ts
@@ -1,6 +1,15 @@
+/**
+ * @unrestricted
+ */
 export class ClassOne {}
+/**
+ * @unrestricted
+ */
 export class ClassTwo {}
 export interface Interface { x: number }
+/**
+ * @unrestricted
+ */
 export class ClassWithParams<T> {}
 
 // TODO(evanm):

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,4 +1,7 @@
 goog.module('test_files.jsdoc_types.default');var module = module || {id: 'test_files/jsdoc_types/default.js'};
+/**
+ * @unrestricted
+ */
 class DefaultClass {
 }
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/test_files/jsdoc_types/default.tsickle.ts
+++ b/test_files/jsdoc_types/default.tsickle.ts
@@ -1,1 +1,4 @@
+/**
+ * @unrestricted
+ */
 export default class DefaultClass {}

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,4 +1,7 @@
 goog.module('test_files.jsdoc_types.module1');var module = module || {id: 'test_files/jsdoc_types/module1.js'};
+/**
+ * @unrestricted
+ */
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 export class Class {}
 /** @record */
 export function Interface() {}

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,7 +1,13 @@
 goog.module('test_files.jsdoc_types.module2');var module = module || {id: 'test_files/jsdoc_types/module2.js'};
+/**
+ * @unrestricted
+ */
 class ClassOne {
 }
 exports.ClassOne = ClassOne;
+/**
+ * @unrestricted
+ */
 class ClassTwo {
 }
 exports.ClassTwo = ClassTwo;
@@ -10,6 +16,9 @@ function Interface() { }
 exports.Interface = Interface;
 /** @type {number} */
 Interface.prototype.x;
+/**
+ * @unrestricted
+ */
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;

--- a/test_files/jsdoc_types/module2.tsickle.ts
+++ b/test_files/jsdoc_types/module2.tsickle.ts
@@ -1,4 +1,10 @@
+/**
+ * @unrestricted
+ */
 export class ClassOne {}
+/**
+ * @unrestricted
+ */
 export class ClassTwo {}
 /** @record */
 export function Interface() {}
@@ -6,6 +12,9 @@ export function Interface() {}
 Interface.prototype.x;
 
 export interface Interface { x: number }
+/**
+ * @unrestricted
+ */
 export class ClassWithParams<T> {}
 
 // TODO(evanm):

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,4 +1,7 @@
-goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};class HasMethods {
+goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};/**
+ * @unrestricted
+ */
+class HasMethods {
     /**
      * @return {void}
      */

--- a/test_files/methods/methods.tsickle.ts
+++ b/test_files/methods/methods.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 class HasMethods {
   _f: number;
 /**

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -6,6 +6,9 @@ goog.module('test_files.optional.optional');var module = module || {id: 'test_fi
 function optionalArgument(x, y) {
 }
 optionalArgument(1);
+/**
+ * @unrestricted
+ */
 class OptionalTest {
     /**
      * @param {string} a

--- a/test_files/optional/optional.tsickle.ts
+++ b/test_files/optional/optional.tsickle.ts
@@ -8,6 +8,9 @@ function optionalArgument(x: number, y?: string) {
 }
 optionalArgument(1);
 
+/**
+ * @unrestricted
+ */
 class OptionalTest {
 /**
  * @param {string} a

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,4 +1,7 @@
-goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};class ParamProps {
+goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};/**
+ * @unrestricted
+ */
+class ParamProps {
     /**
      * @param {string} bar
      * @param {string} bar2

--- a/test_files/parameter_properties/parameter_properties.tsickle.ts
+++ b/test_files/parameter_properties/parameter_properties.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 class ParamProps {
 /**
  * @param {string} bar

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,4 +1,7 @@
-goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};class Static {
+goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};/**
+ * @unrestricted
+ */
+class Static {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {number} */
         Static.bar;

--- a/test_files/static/static.tsickle.ts
+++ b/test_files/static/static.tsickle.ts
@@ -1,3 +1,6 @@
+/**
+ * @unrestricted
+ */
 class Static {
   // This should not become a stub declaration.
   static bar = 3;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,5 +1,8 @@
 goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};// Ensure that a class is structurally equivalent to an object literal
 // with the same fields.
+/**
+ * @unrestricted
+ */
 class StructuralTest {
     /**
      * @return {?}

--- a/test_files/structural.untyped/structural.untyped.tsickle.ts
+++ b/test_files/structural.untyped/structural.untyped.tsickle.ts
@@ -1,5 +1,8 @@
 // Ensure that a class is structurally equivalent to an object literal
 // with the same fields.
+/**
+ * @unrestricted
+ */
 class StructuralTest {
   field1: string;
 /**

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,7 +1,13 @@
-goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};class SuperTestBaseNoArg {
+goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};/**
+ * @unrestricted
+ */
+class SuperTestBaseNoArg {
     constructor() {
     }
 }
+/**
+ * @unrestricted
+ */
 class SuperTestBaseOneArg {
     /**
      * @param {number} x
@@ -15,6 +21,9 @@ class SuperTestBaseOneArg {
     }
 }
 // A ctor with a parameter property.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     /**
      * @param {string} y
@@ -29,6 +38,9 @@ class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     }
 }
 // A ctor with an initialized property.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
     constructor() {
         super(3);
@@ -40,15 +52,24 @@ class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
     }
 }
 // A ctor with a super() but none of the above two details.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
     constructor() {
         super(3);
     }
 }
 // A class without a ctor, extending a one-arg ctor parent.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedNoCTorNoArg extends SuperTestBaseNoArg {
 }
 // A class without a ctor, extending a no-arg ctor parent.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
 }
 /** @record */
@@ -56,12 +77,18 @@ function SuperTestInterface() { }
 /** @type {number} */
 SuperTestInterface.prototype.foo;
 // A class implementing an interface.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedInterface {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {number} */
         SuperTestDerivedInterface.prototype.foo;
     }
 }
+/**
+ * @unrestricted
+ */
 class SuperTestStaticProp extends SuperTestBaseOneArg {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {number} */

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -1,7 +1,13 @@
+/**
+ * @unrestricted
+ */
 class SuperTestBaseNoArg {
 constructor() {}
 }
 
+/**
+ * @unrestricted
+ */
 class SuperTestBaseOneArg {
 /**
  * @param {number} x
@@ -16,6 +22,9 @@ SuperTestBaseOneArg.prototype.x;
 }
 
 // A ctor with a parameter property.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
 /**
  * @param {string} y
@@ -32,6 +41,9 @@ SuperTestDerivedParamProps.prototype.y;
 }
 
 // A ctor with an initialized property.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
   y: string = 'foo';
 constructor() {
@@ -46,6 +58,9 @@ SuperTestDerivedInitializedProps.prototype.y;
 }
 
 // A ctor with a super() but none of the above two details.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
 constructor() {
     super(3);
@@ -53,10 +68,16 @@ constructor() {
 }
 
 // A class without a ctor, extending a one-arg ctor parent.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedNoCTorNoArg extends SuperTestBaseNoArg {
 }
 
 // A class without a ctor, extending a no-arg ctor parent.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
   // NOTE: if this has any properties, we fail to generate it
   // properly because we generate a constructor that doesn't know
@@ -73,6 +94,9 @@ interface SuperTestInterface {
 }
 
 // A class implementing an interface.
+/**
+ * @unrestricted
+ */
 class SuperTestDerivedInterface implements SuperTestInterface {
   foo: number;
 
@@ -83,6 +107,9 @@ SuperTestDerivedInterface.prototype.foo;
 
 }
 
+/**
+ * @unrestricted
+ */
 class SuperTestStaticProp extends SuperTestBaseOneArg {
   static foo = 3;
 

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,5 +1,8 @@
 goog.module('test_files.type_and_value.module');var module = module || {id: 'test_files/type_and_value/module.js'};
 exports.TypeAndValue = 3;
+/**
+ * @unrestricted
+ */
 class Class {
     static _tsickle_typeAnnotationsHelper() {
         /** @type {number} */

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -3,6 +3,9 @@
 export interface TypeAndValue { z: number }
 export var /** @type {number} */ TypeAndValue = 3;
 
+/**
+ * @unrestricted
+ */
 export class Class { z: number
 
   static _tsickle_typeAnnotationsHelper() {

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -5,6 +5,9 @@ var export_underscore_1 = goog.require('test_files.underscore.export_underscore'
 exports.__test = export_underscore_1.__test;
 let /** @type {number} */ __foo = 3;
 exports.__bar = __foo;
+/**
+ * @unrestricted
+ */
 class __Class {
     /**
      * @param {string} __arg is __underscored

--- a/test_files/underscore/underscore.tsickle.ts
+++ b/test_files/underscore/underscore.tsickle.ts
@@ -5,6 +5,9 @@ export {__test} from './export_underscore';
 
 let /** @type {number} */ __foo = 3;
 export {__foo as __bar};
+/**
+ * @unrestricted
+ */
 class __Class {
   __member: string;
 /**


### PR DESCRIPTION
Closure compiler will in some mode complain about properties being defined outside of the constructor. @unrestricted makes sure it does not complain about adding properties outside of the constructor. This would still be an attractive check (adding properties after construction can cause performance issues), but this is better suited to a lint check or similar in tslint.