### PR TITLE
Hide property declaring code in a function.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -740,11 +740,12 @@ class Annotator extends ClosureRewriter {
     if (!classDecl.name) return;
     let className = getIdentifierText(classDecl.name);
 
-    this.emit('\n\n// tsickle -> Closure type declarations\n');
+    this.emit(`\n\nfunction ${className}_tsickle_Closure_declarations() {\n`);
     staticProps.forEach(p => this.visitProperty([className], p));
     let memberNamespace = [className, 'prototype'];
     nonStaticProps.forEach((p) => this.visitProperty(memberNamespace, p));
     paramProps.forEach((p) => this.visitProperty(memberNamespace, p));
+    this.emit(`}\n`);
   }
 
   private propertyName(prop: ts.Declaration): string|null {

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -14,11 +14,12 @@ class Foo {
         this.field = 'hello';
     }
 }
-// tsickle -> Closure type declarations
-/** @type {?} */
-Foo.prototype.field;
-/** @type {?} */
-Foo.prototype.ctorArg;
+function Foo_tsickle_Closure_declarations() {
+    /** @type {?} */
+    Foo.prototype.field;
+    /** @type {?} */
+    Foo.prototype.ctorArg;
+}
 // These two declarations should not have a @type annotation,
 // regardless of untyped.
 (function () {

--- a/test_files/basic.untyped/basic.untyped.tsickle.ts
+++ b/test_files/basic.untyped/basic.untyped.tsickle.ts
@@ -17,11 +17,12 @@ constructor(private ctorArg: string) {
   }
 }
 
-// tsickle -> Closure type declarations
+function Foo_tsickle_Closure_declarations() {
  /** @type {?} */
 Foo.prototype.field;
  /** @type {?} */
 Foo.prototype.ctorArg;
+}
 
 
 // These two declarations should not have a @type annotation,

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,20 +1,21 @@
 goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};class Comments {
 }
-// tsickle -> Closure type declarations
-/** @export
-@type {string} */
-Comments.prototype.export1;
-/** @type {string} */
-Comments.prototype.export2;
-/** @type {number} */
-Comments.prototype.nodoc1;
-/** @type {number} */
-Comments.prototype.nodoc2;
-/** @type {number} */
-Comments.prototype.nodoc3;
-/** inline jsdoc comment without type annotation
-@type {number} */
-Comments.prototype.jsdoc1;
-/** multi-line jsdoc comment without type annotation.
-@type {number} */
-Comments.prototype.jsdoc2;
+function Comments_tsickle_Closure_declarations() {
+    /** @export
+    @type {string} */
+    Comments.prototype.export1;
+    /** @type {string} */
+    Comments.prototype.export2;
+    /** @type {number} */
+    Comments.prototype.nodoc1;
+    /** @type {number} */
+    Comments.prototype.nodoc2;
+    /** @type {number} */
+    Comments.prototype.nodoc3;
+    /** inline jsdoc comment without type annotation
+    @type {number} */
+    Comments.prototype.jsdoc1;
+    /** multi-line jsdoc comment without type annotation.
+    @type {number} */
+    Comments.prototype.jsdoc2;
+}

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -20,7 +20,7 @@ class Comments {
   jsdoc2: number;
 }
 
-// tsickle -> Closure type declarations
+function Comments_tsickle_Closure_declarations() {
  /** @export
  @type {string} */
 Comments.prototype.export1;
@@ -38,4 +38,5 @@ Comments.prototype.jsdoc1;
  /** multi-line jsdoc comment without type annotation.
  @type {number} */
 Comments.prototype.jsdoc2;
+}
 

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -7,7 +7,8 @@ class X {
         this.a = a;
     }
 }
-// tsickle -> Closure type declarations
-/** @type {number} */
-X.prototype.a;
+function X_tsickle_Closure_declarations() {
+    /** @type {number} */
+    X.prototype.a;
+}
 let /** @type {function(new: X, number): ?} */ y = X;

--- a/test_files/ctors/ctors.tsickle.ts
+++ b/test_files/ctors/ctors.tsickle.ts
@@ -6,8 +6,9 @@ class X {
 constructor(private a: number) {}
 }
 
-// tsickle -> Closure type declarations
+function X_tsickle_Closure_declarations() {
  /** @type {number} */
 X.prototype.a;
+}
 
 let /** @type {function(new: X, number): ?} */ y: {new (a: number): X} = X;

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -34,27 +34,29 @@ __decorate([
     decorator, 
     __metadata('design:type', Number)
 ], DecoratorTest.prototype, "x", void 0);
-// tsickle -> Closure type declarations
-/** @type {Array<DecoratorInvocation>} */
-DecoratorTest.decorators;
-/** @nocollapse
-@type {Array<{type: ?, decorators: (Array<DecoratorInvocation>|undefined)}>} */
-DecoratorTest.ctorParameters;
-/** @type {Object<string,Array<DecoratorInvocation>>} */
-DecoratorTest.propDecorators;
-/** @type {number} */
-DecoratorTest.prototype.x;
-/** @type {number} */
-DecoratorTest.prototype.y;
+function DecoratorTest_tsickle_Closure_declarations() {
+    /** @type {Array<DecoratorInvocation>} */
+    DecoratorTest.decorators;
+    /** @nocollapse
+    @type {Array<{type: ?, decorators: (Array<DecoratorInvocation>|undefined)}>} */
+    DecoratorTest.ctorParameters;
+    /** @type {Object<string,Array<DecoratorInvocation>>} */
+    DecoratorTest.propDecorators;
+    /** @type {number} */
+    DecoratorTest.prototype.x;
+    /** @type {number} */
+    DecoratorTest.prototype.y;
+}
 let DecoratedClass = class DecoratedClass {
 };
 DecoratedClass = __decorate([
     classDecorator, 
     __metadata('design:paramtypes', [])
 ], DecoratedClass);
-// tsickle -> Closure type declarations
-/** @type {string} */
-DecoratedClass.prototype.z;
+function DecoratedClass_tsickle_Closure_declarations() {
+    /** @type {string} */
+    DecoratedClass.prototype.z;
+}
 /** @record */
 function DecoratorInvocation() { }
 /** @type {Function} */

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -38,7 +38,7 @@ static propDecorators: {[key: string]: DecoratorInvocation[]} = {
 };
 }
 
-// tsickle -> Closure type declarations
+function DecoratorTest_tsickle_Closure_declarations() {
  /** @type {Array<DecoratorInvocation>} */
 DecoratorTest.decorators;
  /** @nocollapse
@@ -50,6 +50,7 @@ DecoratorTest.propDecorators;
 DecoratorTest.prototype.x;
  /** @type {number} */
 DecoratorTest.prototype.y;
+}
 
 
 @classDecorator
@@ -57,9 +58,10 @@ class DecoratedClass {
   z: string;
 }
 
-// tsickle -> Closure type declarations
+function DecoratedClass_tsickle_Closure_declarations() {
  /** @type {string} */
 DecoratedClass.prototype.z;
+}
 
 /** @record */
 function DecoratorInvocation() {}

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -16,15 +16,16 @@ goog.module('test_files.fields.fields');var module = module || {id: 'test_files/
         return this.field1;
     }
 }
-// tsickle -> Closure type declarations
-/** @type {string} */
-FieldsTest.prototype.field1;
-/** @type {number} */
-FieldsTest.prototype.field2;
-/** @type {string} */
-FieldsTest.prototype.field4;
-/** @type {number} */
-FieldsTest.prototype.field3;
+function FieldsTest_tsickle_Closure_declarations() {
+    /** @type {string} */
+    FieldsTest.prototype.field1;
+    /** @type {number} */
+    FieldsTest.prototype.field2;
+    /** @type {string} */
+    FieldsTest.prototype.field4;
+    /** @type {number} */
+    FieldsTest.prototype.field3;
+}
 let /** @type {FieldsTest} */ fieldsTest = new FieldsTest(3);
 // Ensure the type is understood by Closure.
 fieldsTest.field1 = 'hi';

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -21,7 +21,7 @@ getF1() {
   }
 }
 
-// tsickle -> Closure type declarations
+function FieldsTest_tsickle_Closure_declarations() {
  /** @type {string} */
 FieldsTest.prototype.field1;
  /** @type {number} */
@@ -30,6 +30,7 @@ FieldsTest.prototype.field2;
 FieldsTest.prototype.field4;
  /** @type {number} */
 FieldsTest.prototype.field3;
+}
 
 
 let /** @type {FieldsTest} */ fieldsTest = new FieldsTest(3);

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,5 +1,6 @@
 goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
 }
-// tsickle -> Closure type declarations
-/** @type {number} */
-NoCtor.prototype.field1;
+function NoCtor_tsickle_Closure_declarations() {
+    /** @type {number} */
+    NoCtor.prototype.field1;
+}

--- a/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
+++ b/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
@@ -2,7 +2,8 @@ class NoCtor {
   field1: number;
 }
 
-// tsickle -> Closure type declarations
+function NoCtor_tsickle_Closure_declarations() {
  /** @type {number} */
 NoCtor.prototype.field1;
+}
 

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -19,16 +19,17 @@ function returnsTest() {
 function jsDocTestBadDoc(foo) { }
 class JSDocTest {
 }
-// tsickle -> Closure type declarations
-/** @export
-@type {string} */
-JSDocTest.prototype.exported;
-/** @type {string} */
-JSDocTest.prototype.badExport;
-/** @type {string} */
-JSDocTest.prototype.stringWithoutJSDoc;
-/** @type {number} */
-JSDocTest.prototype.typedThing;
+function JSDocTest_tsickle_Closure_declarations() {
+    /** @export
+    @type {string} */
+    JSDocTest.prototype.exported;
+    /** @type {string} */
+    JSDocTest.prototype.badExport;
+    /** @type {string} */
+    JSDocTest.prototype.stringWithoutJSDoc;
+    /** @type {number} */
+    JSDocTest.prototype.typedThing;
+}
 /**
  * @see This tag will be kept, because Closure allows it.
  * @return {void}

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -36,7 +36,7 @@ class JSDocTest {
   typedThing: number;
 }
 
-// tsickle -> Closure type declarations
+function JSDocTest_tsickle_Closure_declarations() {
  /** @export
  @type {string} */
 JSDocTest.prototype.exported;
@@ -46,6 +46,7 @@ JSDocTest.prototype.badExport;
 JSDocTest.prototype.stringWithoutJSDoc;
  /** @type {number} */
 JSDocTest.prototype.typedThing;
+}
 
 /**
  * @see This tag will be kept, because Closure allows it.

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -18,6 +18,7 @@ goog.module('test_files.methods.methods');var module = module || {id: 'test_file
      */
     set f(n) { this._f = n - 1; }
 }
-// tsickle -> Closure type declarations
-/** @type {number} */
-HasMethods.prototype._f;
+function HasMethods_tsickle_Closure_declarations() {
+    /** @type {number} */
+    HasMethods.prototype._f;
+}

--- a/test_files/methods/methods.tsickle.ts
+++ b/test_files/methods/methods.tsickle.ts
@@ -20,7 +20,8 @@ get f(): number { return this._f + 1; }
 set f(n: number) { this._f = n - 1; }
 }
 
-// tsickle -> Closure type declarations
+function HasMethods_tsickle_Closure_declarations() {
  /** @type {number} */
 HasMethods.prototype._f;
+}
 

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -8,9 +8,10 @@ goog.module('test_files.parameter_properties.parameter_properties');var module =
         this.bar2 = bar2;
     }
 }
-// tsickle -> Closure type declarations
-/** @export
-@type {string} */
-ParamProps.prototype.bar;
-/** @type {string} */
-ParamProps.prototype.bar2;
+function ParamProps_tsickle_Closure_declarations() {
+    /** @export
+    @type {string} */
+    ParamProps.prototype.bar;
+    /** @type {string} */
+    ParamProps.prototype.bar2;
+}

--- a/test_files/parameter_properties/parameter_properties.tsickle.ts
+++ b/test_files/parameter_properties/parameter_properties.tsickle.ts
@@ -8,10 +8,11 @@ public bar: string,
 public bar2: string) {}
 }
 
-// tsickle -> Closure type declarations
+function ParamProps_tsickle_Closure_declarations() {
  /** @export
  @type {string} */
 ParamProps.prototype.bar;
  /** @type {string} */
 ParamProps.prototype.bar2;
+}
 

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -3,8 +3,9 @@ goog.module('test_files.static.static');var module = module || {id: 'test_files/
 // This should not become a stub declaration.
 Static.bar = 3;
 Static.baz = 3;
-// tsickle -> Closure type declarations
-/** @type {number} */
-Static.bar;
-/** @type {number} */
-Static.baz;
+function Static_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Static.bar;
+    /** @type {number} */
+    Static.baz;
+}

--- a/test_files/static/static.tsickle.ts
+++ b/test_files/static/static.tsickle.ts
@@ -4,9 +4,10 @@ class Static {
 private static baz: number = 3;
 }
 
-// tsickle -> Closure type declarations
+function Static_tsickle_Closure_declarations() {
  /** @type {number} */
 Static.bar;
  /** @type {number} */
 Static.baz;
+}
 

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -6,9 +6,10 @@ class StructuralTest {
      */
     method() { return this.field1; }
 }
-// tsickle -> Closure type declarations
-/** @type {?} */
-StructuralTest.prototype.field1;
+function StructuralTest_tsickle_Closure_declarations() {
+    /** @type {?} */
+    StructuralTest.prototype.field1;
+}
 /**
  * @param {?} st
  * @return {?}

--- a/test_files/structural.untyped/structural.untyped.tsickle.ts
+++ b/test_files/structural.untyped/structural.untyped.tsickle.ts
@@ -8,9 +8,10 @@ class StructuralTest {
 method(): string { return this.field1; }
 }
 
-// tsickle -> Closure type declarations
+function StructuralTest_tsickle_Closure_declarations() {
  /** @type {?} */
 StructuralTest.prototype.field1;
+}
 
 /**
  * @param {?} st

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -10,9 +10,10 @@ class SuperTestBaseOneArg {
         this.x = x;
     }
 }
-// tsickle -> Closure type declarations
-/** @type {number} */
-SuperTestBaseOneArg.prototype.x;
+function SuperTestBaseOneArg_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SuperTestBaseOneArg.prototype.x;
+}
 // A ctor with a parameter property.
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     /**
@@ -23,9 +24,10 @@ class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
         this.y = y;
     }
 }
-// tsickle -> Closure type declarations
-/** @type {string} */
-SuperTestDerivedParamProps.prototype.y;
+function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
+    /** @type {string} */
+    SuperTestDerivedParamProps.prototype.y;
+}
 // A ctor with an initialized property.
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
     constructor() {
@@ -33,9 +35,10 @@ class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
         this.y = 'foo';
     }
 }
-// tsickle -> Closure type declarations
-/** @type {string} */
-SuperTestDerivedInitializedProps.prototype.y;
+function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
+    /** @type {string} */
+    SuperTestDerivedInitializedProps.prototype.y;
+}
 // A ctor with a super() but none of the above two details.
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
     constructor() {
@@ -55,12 +58,14 @@ SuperTestInterface.prototype.foo;
 // A class implementing an interface.
 class SuperTestDerivedInterface {
 }
-// tsickle -> Closure type declarations
-/** @type {number} */
-SuperTestDerivedInterface.prototype.foo;
+function SuperTestDerivedInterface_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SuperTestDerivedInterface.prototype.foo;
+}
 class SuperTestStaticProp extends SuperTestBaseOneArg {
 }
 SuperTestStaticProp.foo = 3;
-// tsickle -> Closure type declarations
-/** @type {number} */
-SuperTestStaticProp.foo;
+function SuperTestStaticProp_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SuperTestStaticProp.foo;
+}

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -9,9 +9,10 @@ class SuperTestBaseOneArg {
 constructor(public x: number) {}
 }
 
-// tsickle -> Closure type declarations
+function SuperTestBaseOneArg_tsickle_Closure_declarations() {
  /** @type {number} */
 SuperTestBaseOneArg.prototype.x;
+}
 
 
 // A ctor with a parameter property.
@@ -24,9 +25,10 @@ constructor(public y: string) {
   }
 }
 
-// tsickle -> Closure type declarations
+function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
  /** @type {string} */
 SuperTestDerivedParamProps.prototype.y;
+}
 
 
 // A ctor with an initialized property.
@@ -37,9 +39,10 @@ constructor() {
   }
 }
 
-// tsickle -> Closure type declarations
+function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
  /** @type {string} */
 SuperTestDerivedInitializedProps.prototype.y;
+}
 
 
 // A ctor with a super() but none of the above two details.
@@ -74,16 +77,18 @@ class SuperTestDerivedInterface implements SuperTestInterface {
   foo: number;
 }
 
-// tsickle -> Closure type declarations
+function SuperTestDerivedInterface_tsickle_Closure_declarations() {
  /** @type {number} */
 SuperTestDerivedInterface.prototype.foo;
+}
 
 
 class SuperTestStaticProp extends SuperTestBaseOneArg {
   static foo = 3;
 }
 
-// tsickle -> Closure type declarations
+function SuperTestStaticProp_tsickle_Closure_declarations() {
  /** @type {number} */
 SuperTestStaticProp.foo;
+}
 

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -3,6 +3,7 @@ exports.TypeAndValue = 3;
 class Class {
 }
 exports.Class = Class;
-// tsickle -> Closure type declarations
-/** @type {number} */
-Class.prototype.z;
+function Class_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Class.prototype.z;
+}

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -5,6 +5,7 @@ export var /** @type {number} */ TypeAndValue = 3;
 
 export class Class { z: number }
 
-// tsickle -> Closure type declarations
+function Class_tsickle_Closure_declarations() {
  /** @type {number} */
 Class.prototype.z;
+}

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -14,8 +14,9 @@ class __Class {
         return this.__member;
     }
 }
-// tsickle -> Closure type declarations
-/** @type {string} */
-__Class.prototype.__member;
+function __Class_tsickle_Closure_declarations() {
+    /** @type {string} */
+    __Class.prototype.__member;
+}
 /** @record */
 function __Interface() { }

--- a/test_files/underscore/underscore.tsickle.ts
+++ b/test_files/underscore/underscore.tsickle.ts
@@ -16,9 +16,10 @@ __method(__arg: string): string {
   }
 }
 
-// tsickle -> Closure type declarations
+function __Class_tsickle_Closure_declarations() {
  /** @type {string} */
 __Class.prototype.__member;
+}
 
 /** @record */
 function __Interface() {}


### PR DESCRIPTION
It turns out that a statement like "Foo.prototype.bar" might actually execute code if "bar" on Foo.prototype is a getter. That code then fails because its this pointer is not set in the invocation, breaking load of tsickle coverted code. Some users have an odd build setup where they execute tsickle-converted code in the browser, so we need to hide these statements in a function to avoid breaking code on load.