### PR TITLE
Assign a default export in goog.module()s

### DIFF
--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -54,6 +54,9 @@ class ES5Processor extends Rewriter {
     // so that @suppress statements work.
     const moduleName = this.pathToModuleName('', this.file.fileName);
     // NB: No linebreak after module call so sourcemaps are not offset.
+    // The `exports = {}` serves as a default export to disable Closure Compiler's error checking
+    // for mutable exports. That's OK because TS compiler makes sure that consuming code always
+    // accesses exports through the module object, so mutable exports work.
     this.emit(`goog.module('${moduleName}'); exports = {}; `);
     // Allow code to use `module.id` to discover its module URL, e.g. to resolve
     // a template URL against.

--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -54,7 +54,7 @@ class ES5Processor extends Rewriter {
     // so that @suppress statements work.
     const moduleName = this.pathToModuleName('', this.file.fileName);
     // NB: No linebreak after module call so sourcemaps are not offset.
-    this.emit(`goog.module('${moduleName}');`);
+    this.emit(`goog.module('${moduleName}'); exports = {}; `);
     // Allow code to use `module.id` to discover its module URL, e.g. to resolve
     // a template URL against.
     // Uses 'var', as this code is inserted in ES6 and ES5 modes.

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -21,43 +21,46 @@ describe('convertCommonJsToGoogModule', () => {
   it('adds a goog.module call', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`)
-        .to.equal(`goog.module('a');var module = module || {id: 'a.js'};console.log('hello');`);
+        .to.equal(
+            `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};console.log('hello');`);
   });
 
   it('adds a goog.module call for ES6 mode', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`, false)
-        .to.equal(`goog.module('a');var module = {id: 'a.js'};console.log('hello');`);
+        .to.equal(
+            `goog.module('a'); exports = {}; var module = {id: 'a.js'};console.log('hello');`);
   });
 
   it('adds a goog.module call to empty files', () => {
-    expectCommonJs('a.js', ``).to.equal(`goog.module('a');var module = module || {id: 'a.js'};`);
+    expectCommonJs('a.js', ``)
+        .to.equal(`goog.module('a'); exports = {}; var module = module || {id: 'a.js'};`);
   });
 
   it('adds a goog.module call to empty-looking files', () => {
     expectCommonJs('a.js', `// empty`)
-        .to.equal(`goog.module('a');var module = module || {id: 'a.js'};// empty`);
+        .to.equal(`goog.module('a'); exports = {}; var module = module || {id: 'a.js'};// empty`);
   });
 
   it('strips use strict directives', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `"use strict";
 console.log('hello');`)
-        .to.equal(`goog.module('a');var module = module || {id: 'a.js'};
+        .to.equal(`goog.module('a'); exports = {}; var module = module || {id: 'a.js'};
 console.log('hello');`);
   });
 
   it('converts require calls', () => {
     expectCommonJs('a.js', `var r = require('req/mod');`)
         .to.equal(
-            `goog.module('a');var module = module || {id: 'a.js'};` +
+            `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};` +
             `var r = goog.require('req.mod');`);
   });
 
   it('converts require calls without assignments on first line', () => {
     expectCommonJs('a.js', `require('req/mod');`)
         .to.equal(
-            `goog.module('a');var module = module || {id: 'a.js'};` +
+            `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};` +
             `var tsickle_module_0_ = goog.require('req.mod');`);
   });
 
@@ -65,7 +68,7 @@ console.log('hello');`);
     expectCommonJs('a.js', `
 require('req/mod');
 require('other');`)
-        .to.equal(`goog.module('a');var module = module || {id: 'a.js'};
+        .to.equal(`goog.module('a'); exports = {}; var module = module || {id: 'a.js'};
 var tsickle_module_0_ = goog.require('req.mod');
 var tsickle_module_1_ = goog.require('other');`);
   });
@@ -74,7 +77,7 @@ var tsickle_module_1_ = goog.require('other');`);
     expectCommonJs('a.js', `
 // Comment
 require('req/mod');`)
-        .to.equal(`goog.module('a');var module = module || {id: 'a.js'};
+        .to.equal(`goog.module('a'); exports = {}; var module = module || {id: 'a.js'};
 // Comment
 var tsickle_module_0_ = goog.require('req.mod');`);
   });
@@ -82,7 +85,7 @@ var tsickle_module_0_ = goog.require('req.mod');`);
   it('converts const require calls', () => {
     expectCommonJs('a.js', `const r = require('req/mod');`)
         .to.equal(
-            `goog.module('a');var module = module || {id: 'a.js'};` +
+            `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};` +
             `var r = goog.require('req.mod');`);
   });
 
@@ -90,20 +93,20 @@ var tsickle_module_0_ = goog.require('req.mod');`);
     it('converts export * statements', () => {
       expectCommonJs('a.js', `__export(require('req/mod'));`)
           .to.equal(
-              `goog.module('a');var module = module || {id: 'a.js'};var tsickle_module_0_ = goog.require('req.mod');__export(tsickle_module_0_);`);
+              `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};var tsickle_module_0_ = goog.require('req.mod');__export(tsickle_module_0_);`);
     });
     it('uses correct module name with subsequent exports', () => {
       expectCommonJs('a.js', `__export(require('req/mod'));
 var mod2 = require('req/mod');`)
           .to.equal(
-              `goog.module('a');var module = module || {id: 'a.js'};var tsickle_module_0_ = goog.require('req.mod');__export(tsickle_module_0_);
+              `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};var tsickle_module_0_ = goog.require('req.mod');__export(tsickle_module_0_);
 var mod2 = tsickle_module_0_;`);
     });
     it('reuses an existing imported variable name', () => {
       expectCommonJs('a.js', `var mod = require('req/mod');
 __export(require('req/mod'));`)
           .to.equal(
-              `goog.module('a');var module = module || {id: 'a.js'};var mod = goog.require('req.mod');
+              `goog.module('a'); exports = {}; var module = module || {id: 'a.js'};var mod = goog.require('req.mod');
 __export(mod);`);
     });
   });
@@ -112,13 +115,13 @@ __export(mod);`);
     // See below for more fine-grained unit tests.
     expectCommonJs('a/b.js', `var r = require('./req/mod');`)
         .to.equal(
-            `goog.module('a.b');var module = module || {id: 'a/b.js'};var r = goog.require('a.req.mod');`);
+            `goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};var r = goog.require('a.req.mod');`);
   });
 
   it('avoids mangling module names in goog: imports', () => {
     expectCommonJs('a/b.js', `
 var goog_use_Foo_1 = require('goog:foo_bar.baz');`)
-        .to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};
+        .to.equal(`goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};
 var goog_use_Foo_1 = goog.require('foo_bar.baz');`);
   });
 
@@ -126,7 +129,7 @@ var goog_use_Foo_1 = goog.require('foo_bar.baz');`);
     expectCommonJs('a/b.js', `
 var goog_use_Foo_1 = require('goog:use.Foo');
 console.log(goog_use_Foo_1.default);`)
-        .to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};
+        .to.equal(`goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};
 var goog_use_Foo_1 = goog.require('use.Foo');
 console.log(goog_use_Foo_1        );`);
     // NB: the whitespace above matches the .default part, so that
@@ -138,7 +141,7 @@ console.log(goog_use_Foo_1        );`);
     expectCommonJs('a/b.js', `
 console.log(this.default);
 console.log(foo.bar.default);`)
-        .to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};
+        .to.equal(`goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};
 console.log(this.default);
 console.log(foo.bar.default);`);
   });
@@ -149,7 +152,7 @@ console.log(foo.bar.default);`);
 */
 "use strict";
 var foo = bar;
-`).to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};/**
+`).to.equal(`goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};/**
 * docstring here
 */
 
@@ -161,7 +164,7 @@ var foo = bar;
     expectCommonJs('a/b.js', `var foo_1 = require('goog:foo');
 var foo_2 = require('goog:foo');
 foo_1.A, foo_2.B, foo_2.default, foo_3.default;
-`).to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};var foo_1 = goog.require('foo');
+`).to.equal(`goog.module('a.b'); exports = {}; var module = module || {id: 'a/b.js'};var foo_1 = goog.require('foo');
 var foo_2 = foo_1;
 foo_1.A, foo_2.B, foo_2        , foo_3.default;
 `);

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,4 +1,4 @@
-goog.module('test_files.abstract.abstract');var module = module || {id: 'test_files/abstract/abstract.js'};/**
+goog.module('test_files.abstract.abstract'); exports = {}; var module = module || {id: 'test_files/abstract/abstract.js'};/**
  * @abstract
  */
 class Base {

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,1 +1,1 @@
-goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');var module = module || {id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.js'};var /** @type {?} */ fn3 = (a) => 12;
+goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped'); exports = {}; var module = module || {id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.js'};var /** @type {?} */ fn3 = (a) => 12;

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,2 +1,2 @@
-goog.module('test_files.arrow_fn.arrow_fn');var module = module || {id: 'test_files/arrow_fn/arrow_fn.js'};var /** @type {function(number): number} */ fn3 = (a) => 12;
+goog.module('test_files.arrow_fn.arrow_fn'); exports = {}; var module = module || {id: 'test_files/arrow_fn/arrow_fn.js'};var /** @type {function(number): number} */ fn3 = (a) => 12;
 var /** @type {function(?): ?} */ fn4 = (a) => a + 12;

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,4 +1,4 @@
-goog.module('test_files.basic.untyped.basic.untyped');var module = module || {id: 'test_files/basic.untyped/basic.untyped.js'};/**
+goog.module('test_files.basic.untyped.basic.untyped'); exports = {}; var module = module || {id: 'test_files/basic.untyped/basic.untyped.js'};/**
  * @param {?} arg1
  * @return {?}
  */

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,4 +1,4 @@
-goog.module('test_files.coerce.coerce');var module = module || {id: 'test_files/coerce/coerce.js'};/**
+goog.module('test_files.coerce.coerce'); exports = {}; var module = module || {id: 'test_files/coerce/coerce.js'};/**
  * @param {string} arg
  * @return {string}
  */

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,4 +1,4 @@
-goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};class Comments {
+goog.module('test_files.comments.comments'); exports = {}; var module = module || {id: 'test_files/comments/comments.js'};class Comments {
 }
 function Comments_tsickle_Closure_declarations() {
     /** @export

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,4 +1,4 @@
-goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};let /** @type {function(new: Document): ?} */ x = Document;
+goog.module('test_files.ctors.ctors'); exports = {}; var module = module || {id: 'test_files/ctors/ctors.js'};let /** @type {function(new: Document): ?} */ x = Document;
 class X {
     /**
      * @param {number} a

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,1 +1,1 @@
-goog.module('test_files.declare_class_ns.declare_class_ns');var module = module || {id: 'test_files/declare_class_ns/declare_class_ns.js'};
+goog.module('test_files.declare_class_ns.declare_class_ns'); exports = {}; var module = module || {id: 'test_files/declare_class_ns/declare_class_ns.js'};

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,1 +1,1 @@
-goog.module('test_files.declare_class_overloads.declare_class_overloads');var module = module || {id: 'test_files/declare_class_overloads/declare_class_overloads.js'};
+goog.module('test_files.declare_class_overloads.declare_class_overloads'); exports = {}; var module = module || {id: 'test_files/declare_class_overloads/declare_class_overloads.js'};

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,4 +1,4 @@
-goog.module('test_files.decorator.decorator');var module = module || {id: 'test_files/decorator/decorator.js'};/**
+goog.module('test_files.decorator.decorator'); exports = {}; var module = module || {id: 'test_files/decorator/decorator.js'};/**
  * @param {Object} a
  * @param {string} b
  * @return {void}

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,4 +1,4 @@
-goog.module('test_files.default.default');var module = module || {id: 'test_files/default/default.js'};/**
+goog.module('test_files.default.default'); exports = {}; var module = module || {id: 'test_files/default/default.js'};/**
  * @param {number} x
  * @param {string=} y
  * @return {void}

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,4 +1,4 @@
-goog.module('test_files.enum.untyped.enum.untyped');var module = module || {id: 'test_files/enum.untyped/enum.untyped.js'};
+goog.module('test_files.enum.untyped.enum.untyped'); exports = {}; var module = module || {id: 'test_files/enum.untyped/enum.untyped.js'};
 let EnumUntypedTest1 = {};
 EnumUntypedTest1.XYZ = 0;
 EnumUntypedTest1.PI = 3.14159;

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,4 +1,4 @@
-goog.module('test_files.enum.enum');var module = module || {id: 'test_files/enum/enum.js'};
+goog.module('test_files.enum.enum'); exports = {}; var module = module || {id: 'test_files/enum/enum.js'};
 // Line with a missing semicolon should not break the following enum.
 const /** @type {Array<?>} */ EnumTestMissingSemi = [];
 let EnumTest1 = {};

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,4 +1,4 @@
-goog.module('test_files.export.export');var module = module || {id: 'test_files/export/export.js'};
+goog.module('test_files.export.export'); exports = {}; var module = module || {id: 'test_files/export/export.js'};
 var export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export2 = export_helper_1.export2;
 exports.Bar = export_helper_1.Bar;

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,4 +1,4 @@
-goog.module('test_files.export.export_helper');var module = module || {id: 'test_files/export/export_helper.js'};
+goog.module('test_files.export.export_helper'); exports = {}; var module = module || {id: 'test_files/export/export_helper.js'};
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.
 var export_helper_2_1 = goog.require('test_files.export.export_helper_2');

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,4 +1,4 @@
-goog.module('test_files.export.export_helper_2');var module = module || {id: 'test_files/export/export_helper_2.js'};
+goog.module('test_files.export.export_helper_2'); exports = {}; var module = module || {id: 'test_files/export/export_helper_2.js'};
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.
 exports.export2 = 3;

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,4 +1,4 @@
-goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};class FieldsTest {
+goog.module('test_files.fields.fields'); exports = {}; var module = module || {id: 'test_files/fields/fields.js'};class FieldsTest {
     /**
      * @param {number} field3
      */

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,4 +1,4 @@
-goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
+goog.module('test_files.fields_no_ctor.fields_no_ctor'); exports = {}; var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
 }
 function NoCtor_tsickle_Closure_declarations() {
     /** @type {number} */

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,4 +1,4 @@
-goog.module('test_files.file_comment.file_comment');var module = module || {id: 'test_files/file_comment/file_comment.js'};/**
+goog.module('test_files.file_comment.file_comment'); exports = {}; var module = module || {id: 'test_files/file_comment/file_comment.js'};/**
  * @return {string}
  */
 function foo() {

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,4 +1,4 @@
-goog.module('test_files.functions.untyped.functions');var module = module || {id: 'test_files/functions.untyped/functions.js'};/**
+goog.module('test_files.functions.untyped.functions'); exports = {}; var module = module || {id: 'test_files/functions.untyped/functions.js'};/**
  * @param {?} a
  * @return {?}
  */

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,4 +1,4 @@
-goog.module('test_files.functions.functions');var module = module || {id: 'test_files/functions/functions.js'};/**
+goog.module('test_files.functions.functions'); exports = {}; var module = module || {id: 'test_files/functions/functions.js'};/**
  * @param {number} a
  * @return {number}
  */

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,4 +1,4 @@
-goog.module('test_files.interface.interface');var module = module || {id: 'test_files/interface/interface.js'};/** @record */
+goog.module('test_files.interface.interface'); exports = {}; var module = module || {id: 'test_files/interface/interface.js'};/** @record */
 function Point() { }
 /** @type {number} */
 Point.prototype.x;

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc.jsdoc');var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
+goog.module('test_files.jsdoc.jsdoc'); exports = {}; var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
  * @param {string} foo a string.
  * @param {string} baz
  * @return {string} return comment.

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.untyped.default');var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};
+goog.module('test_files.jsdoc_types.untyped.default'); exports = {}; var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};
 class DefaultClass {
 }
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.untyped.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types.untyped/jsdoc_types.js'};/**
+goog.module('test_files.jsdoc_types.untyped.jsdoc_types'); exports = {}; var module = module || {id: 'test_files/jsdoc_types.untyped/jsdoc_types.js'};/**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.
  */

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};
+goog.module('test_files.jsdoc_types.untyped.module1'); exports = {}; var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.untyped.module2');var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};
+goog.module('test_files.jsdoc_types.untyped.module2'); exports = {}; var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,3 +1,3 @@
-goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/* This filename is specially marked in the tsickle test
+goog.module('test_files.jsdoc_types.untyped.nevertyped'); exports = {}; var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.default');var module = module || {id: 'test_files/jsdoc_types/default.js'};
+goog.module('test_files.jsdoc_types.default'); exports = {}; var module = module || {id: 'test_files/jsdoc_types/default.js'};
 class DefaultClass {
 }
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types/jsdoc_types.js'};/**
+goog.module('test_files.jsdoc_types.jsdoc_types'); exports = {}; var module = module || {id: 'test_files/jsdoc_types/jsdoc_types.js'};/**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.
  */

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.module1');var module = module || {id: 'test_files/jsdoc_types/module1.js'};
+goog.module('test_files.jsdoc_types.module1'); exports = {}; var module = module || {id: 'test_files/jsdoc_types/module1.js'};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.module2');var module = module || {id: 'test_files/jsdoc_types/module2.js'};
+goog.module('test_files.jsdoc_types.module2'); exports = {}; var module = module || {id: 'test_files/jsdoc_types/module2.js'};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsdoc_types.nevertyped');var module = module || {id: 'test_files/jsdoc_types/nevertyped.js'};
+goog.module('test_files.jsdoc_types.nevertyped'); exports = {}; var module = module || {id: 'test_files/jsdoc_types/nevertyped.js'};
 /** @record */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,4 +1,4 @@
-goog.module('test_files.jsx.jsx');var module = module || {id: 'test_files/jsx/jsx.js'};let /** @type {JSX.Element} */ simple = React.createElement("div", null);
+goog.module('test_files.jsx.jsx'); exports = {}; var module = module || {id: 'test_files/jsx/jsx.js'};let /** @type {JSX.Element} */ simple = React.createElement("div", null);
 let /** @type {string} */ hello = 'hello';
 let /** @type {JSX.Element} */ helloDiv = React.createElement("div", null, 
     hello, 

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,4 +1,4 @@
-goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};class HasMethods {
+goog.module('test_files.methods.methods'); exports = {}; var module = module || {id: 'test_files/methods/methods.js'};class HasMethods {
     /**
      * @return {void}
      */

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,4 +1,4 @@
-goog.module('test_files.optional.optional');var module = module || {id: 'test_files/optional/optional.js'};/**
+goog.module('test_files.optional.optional'); exports = {}; var module = module || {id: 'test_files/optional/optional.js'};/**
  * @param {number} x
  * @param {string=} y
  * @return {void}

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,4 +1,4 @@
-goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};class ParamProps {
+goog.module('test_files.parameter_properties.parameter_properties'); exports = {}; var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};class ParamProps {
     /**
      * @param {string} bar
      * @param {string} bar2

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,4 +1,4 @@
-goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};class Static {
+goog.module('test_files.static.static'); exports = {}; var module = module || {id: 'test_files/static/static.js'};class Static {
 }
 // This should not become a stub declaration.
 Static.bar = 3;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,4 +1,4 @@
-goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};// Ensure that a class is structurally equivalent to an object literal
+goog.module('test_files.structural.untyped.structural.untyped'); exports = {}; var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};// Ensure that a class is structurally equivalent to an object literal
 // with the same fields.
 class StructuralTest {
     /**

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,4 +1,4 @@
-goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};class SuperTestBaseNoArg {
+goog.module('test_files.super.super'); exports = {}; var module = module || {id: 'test_files/super/super.js'};class SuperTestBaseNoArg {
     constructor() {
     }
 }

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,4 +1,4 @@
-goog.module('test_files.type.type');var module = module || {id: 'test_files/type/type.js'};let /** @type {?} */ typeAny;
+goog.module('test_files.type.type'); exports = {}; var module = module || {id: 'test_files/type/type.js'};let /** @type {?} */ typeAny;
 let /** @type {Array<?>} */ typeArr = null;
 let /** @type {Array<?>} */ typeArr2 = null;
 let /** @type {Array<Array<{a: ?}>>} */ typeNestedArr = null;

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,4 +1,4 @@
-goog.module('test_files.type_and_value.module');var module = module || {id: 'test_files/type_and_value/module.js'};
+goog.module('test_files.type_and_value.module'); exports = {}; var module = module || {id: 'test_files/type_and_value/module.js'};
 exports.TypeAndValue = 3;
 class Class {
 }

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -1,4 +1,4 @@
-goog.module('test_files.type_and_value.type_and_value');var module = module || {id: 'test_files/type_and_value/type_and_value.js'};
+goog.module('test_files.type_and_value.type_and_value'); exports = {}; var module = module || {id: 'test_files/type_and_value/type_and_value.js'};
 var conflict = goog.require('test_files.type_and_value.module');
 // This test deals with symbols that are simultaneously types and values.
 // Use a browser built-in as both a type and a value.

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,2 +1,2 @@
-goog.module('test_files.typedef.untyped.typedef');var module = module || {id: 'test_files/typedef.untyped/typedef.js'};
+goog.module('test_files.typedef.untyped.typedef'); exports = {}; var module = module || {id: 'test_files/typedef.untyped/typedef.js'};
 var /** @type {?} */ y = 3;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,4 +1,4 @@
-goog.module('test_files.typedef.typedef');var module = module || {id: 'test_files/typedef/typedef.js'};
+goog.module('test_files.typedef.typedef'); exports = {}; var module = module || {id: 'test_files/typedef/typedef.js'};
 /** @typedef {number} */
 var MyType;
 var /** @type {number} */ y = 3;

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,2 +1,2 @@
-goog.module('test_files.underscore.export_underscore');var module = module || {id: 'test_files/underscore/export_underscore.js'};
+goog.module('test_files.underscore.export_underscore'); exports = {}; var module = module || {id: 'test_files/underscore/export_underscore.js'};
 exports.__test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,4 +1,4 @@
-goog.module('test_files.underscore.underscore');var module = module || {id: 'test_files/underscore/underscore.js'};// Verify that double-underscored names in various places don't get corrupted.
+goog.module('test_files.underscore.underscore'); exports = {}; var module = module || {id: 'test_files/underscore/underscore.js'};// Verify that double-underscored names in various places don't get corrupted.
 // See getIdentifierText() in tsickle.ts.
 
 var export_underscore_1 = goog.require('test_files.underscore.export_underscore');

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,2 +1,2 @@
-goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};var /** @type {string} */ v1;
+goog.module('test_files.variables.variables'); exports = {}; var module = module || {id: 'test_files/variables/variables.js'};var /** @type {string} */ v1;
 var /** @type {string} */ v2, /** @type {number} */ v3;


### PR DESCRIPTION
Closure Compiler works on improving strictness for goog.module(), in particular enforcing that named exports are immutable. The exports = {} statement indicates to Closure Compiler that there is a default export, so Closure Compiler does not error on mutating/accessing named exports on it.

This is more of a workaround than a fix, but TypeScript users are guaranteed to only ever access named exports through indirection off of the module export object (that is, TypeScript compiler makes sure to implement mutable exports on the usage site), so for TS users the error that Closure Compiler tries to prevent here does not actually occur.