### PR TITLE
Make the tsickle ES6 emit CommonJS compatible by excluding the export…

### DIFF
--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -68,7 +68,8 @@ class ES5Processor extends Rewriter {
       // accesses exports through the module object, so mutable exports work.
       // It is only inserted in ES6 because we strip `.default` accesses in ES5 mode, which breaks
       // when assigning an `exports = {}` object and then later accessing it.
-      this.emit(` exports = {}; var module = {id: '${moduleId}'};`);
+      // module.exports is set to be compatible with CommonJS modules.
+      this.emit(` exports = {}; var module = {id: '${moduleId}', exports: exports};`);
     }
 
     let pos = 0;

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -28,7 +28,9 @@ describe('convertCommonJsToGoogModule', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`, false)
         .to.equal(
-            `goog.module('a'); exports = {}; var module = {id: 'a.js'};console.log('hello');`);
+            `goog.module('a'); ` +
+            `exports = {}; var module = {id: 'a.js', exports: exports};` +
+            `console.log('hello');`);
   });
 
   it('adds a goog.module call to empty files', () => {


### PR DESCRIPTION
…s object in the expected module.exports location.

This helps if infrastructure ends up loading ES6 code to run in CommonJS.