### PR TITLE
fix(jsdoc): preserve newlines in multi-line JSDoc comments

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -184,7 +184,7 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
       if (tags.length === 0) {
         tags.push({text: line.trim()});
       } else {
-        tags[tags.length - 1].text += ' ' + line.trim();
+        tags[tags.length - 1].text += '\n ' + line.trim();
       }
     }
   }

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -30,7 +30,7 @@ describe('jsdoc.parse', () => {
     expect(jsdoc.parse(source)).to.deep.equal({
       tags: [
         {tagName: 'param', parameterName: 'foo'},
-        {tagName: 'param', parameterName: 'bar', text: 'multiple line comment'},
+        {tagName: 'param', parameterName: 'bar', text: 'multiple\n line comment'},
         {tagName: 'return', text: 'foobar'},
         {tagName: 'nosideeffects'},
       ]

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -15,7 +15,8 @@ function Comments_tsickle_Closure_declarations() {
     /** inline jsdoc comment without type annotation
     @type {number} */
     Comments.prototype.jsdoc1;
-    /** multi-line jsdoc comment without type annotation.
+    /** multi-line jsdoc comment without
+    type annotation.
     @type {number} */
     Comments.prototype.jsdoc2;
 }

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -35,7 +35,8 @@ Comments.prototype.nodoc3;
  /** inline jsdoc comment without type annotation
  @type {number} */
 Comments.prototype.jsdoc1;
- /** multi-line jsdoc comment without type annotation.
+ /** multi-line jsdoc comment without
+ type annotation.
  @type {number} */
 Comments.prototype.jsdoc2;
 }


### PR DESCRIPTION
fixes #267