### PR TITLE
strip @extends, @implements, and @constructor from user jsdoc

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -117,7 +117,7 @@ const JSDOC_TAGS_WHITELIST = [
  * These are Closure tags that can be expressed in the TypeScript surface
  * syntax.
  */
-const JSDOC_TAGS_BLACKLIST = ['private', 'public', 'type'];
+const JSDOC_TAGS_BLACKLIST = ['constructor', 'extends', 'implements', 'private', 'public', 'type'];
 
 /** A list of JSDoc @tags that might include a {type} after them. */
 const JSDOC_TAGS_WITH_TYPES = ['export', 'param', 'return'];

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -677,12 +677,8 @@ class Annotator extends ClosureRewriter {
     if ((classDecl.flags & ts.NodeFlags.Abstract) !== 0) {
       jsDoc.push({tagName: 'abstract'});
     }
-    if (jsDoc.length === 0) {
-      this.writeRange(classDecl.getFullStart(), classDecl.getStart());
-    } else {
-      this.emit('\n');
-      this.emit(jsdoc.toString(jsDoc));
-    }
+    this.emit('\n');
+    if (jsDoc.length > 0) this.emit(jsdoc.toString(jsDoc));
     if (classDecl.members.length > 0) {
       // We must visit all members individually, to strip out any
       // /** @export */ annotations that show up in the constructor

--- a/test_files/abstract/abstract.tsickle.ts
+++ b/test_files/abstract/abstract.tsickle.ts
@@ -40,7 +40,6 @@ bar() {
     this.hasReturnType();
   }
 }
-
 class Derived extends Base {
 constructor() {
     super();

--- a/test_files/basic.untyped/basic.untyped.tsickle.ts
+++ b/test_files/basic.untyped/basic.untyped.tsickle.ts
@@ -6,7 +6,6 @@
 function func(arg1: string): number[] {
   return [3];
 }
-
 class Foo {
   field: string;
 /**

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -1,3 +1,4 @@
+
 class Comments {
   /** @export */
   export1: string;

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -21,8 +21,6 @@ function classDecorator(t: any) { return t; }
  * @return {?}
  */
 function classAnnotation(t: any) { return t; }
-
-
 class DecoratorTest {
   @decorator
 private x: number;
@@ -53,7 +51,6 @@ DecoratorTest.prototype.x;
  /** @type {number} */
 DecoratorTest.prototype.y;
 }
-
 
 @classDecorator
 class DecoratedClass {

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -1,5 +1,6 @@
 Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
 ====
+
 class FieldsTest {
   field1: string;
   field2: number;

--- a/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
+++ b/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
@@ -1,3 +1,4 @@
+
 class NoCtor {
   field1: number;
 }

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -41,3 +41,11 @@ function JSDocTest_tsickle_Closure_declarations() {
  */
 function x() { }
 ;
+/**
+ *  This class has JSDoc, but some of it should be stripped.
+ * @see Nothing.
+ */
+class RedundantJSDocShouldBeStripped {
+    constructor() {
+    }
+}

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -40,3 +40,14 @@ class JSDocTest {
  * @see This tag will be kept, because Closure allows it.
  */
 function x() {};
+
+/**
+ * This class has JSDoc, but some of it should be stripped.
+ * @extends {IgnoreMe}
+ * @implements {IgnoreMeToo}
+ * @see Nothing.
+ */
+class RedundantJSDocShouldBeStripped {
+  /** @constructor */
+  constructor() {}
+}

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -1,6 +1,9 @@
 Warning at test_files/jsdoc/jsdoc.ts:16:1: type annotations (using {...}) are redundant with TypeScript types
 Warning at test_files/jsdoc/jsdoc.ts:29:3: type annotations (using {...}) are redundant with TypeScript types
 Warning at test_files/jsdoc/jsdoc.ts:34:3: @type annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:44:1: @extends annotations are redundant with TypeScript equivalents
+@implements annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:51:3: @constructor annotations are redundant with TypeScript equivalents
 ====
 
 /**
@@ -57,3 +60,10 @@ JSDocTest.prototype.typedThing;
  * @return {void}
  */
 function x() {};
+/**
+ *  This class has JSDoc, but some of it should be stripped.
+ * @see Nothing.
+ */
+class RedundantJSDocShouldBeStripped {
+constructor() {}
+}

--- a/test_files/jsdoc_types.untyped/default.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/default.tsickle.ts
@@ -1,1 +1,2 @@
+
 export default class DefaultClass {}

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -1,2 +1,3 @@
+
 export class Class {}
 export interface Interface { x: number }

--- a/test_files/jsdoc_types.untyped/module2.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module2.tsickle.ts
@@ -1,3 +1,4 @@
+
 export class ClassOne {}
 export class ClassTwo {}
 export interface Interface { x: number }

--- a/test_files/jsdoc_types/default.tsickle.ts
+++ b/test_files/jsdoc_types/default.tsickle.ts
@@ -1,1 +1,2 @@
+
 export default class DefaultClass {}

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -1,3 +1,4 @@
+
 export class Class {}
 /** @record */
 export function Interface() {}

--- a/test_files/jsdoc_types/module2.tsickle.ts
+++ b/test_files/jsdoc_types/module2.tsickle.ts
@@ -1,3 +1,4 @@
+
 export class ClassOne {}
 export class ClassTwo {}
 /** @record */

--- a/test_files/methods/methods.tsickle.ts
+++ b/test_files/methods/methods.tsickle.ts
@@ -1,3 +1,4 @@
+
 class HasMethods {
   _f: number;
 /**

--- a/test_files/nullable/nullable.tsickle.ts
+++ b/test_files/nullable/nullable.tsickle.ts
@@ -17,9 +17,7 @@ Primitives.prototype.nullableUndefinable;
 Primitives.prototype.optional;
 }
 
-
 class NonPrimitive {}
-
 class NonPrimitives {
   nonNull: NonPrimitive;
   nullable: NonPrimitive|null;

--- a/test_files/optional/optional.tsickle.ts
+++ b/test_files/optional/optional.tsickle.ts
@@ -7,7 +7,6 @@
 function optionalArgument(x: number, y?: string) {
 }
 optionalArgument(1);
-
 class OptionalTest {
 /**
  * @param {string} a

--- a/test_files/parameter_properties/parameter_properties.tsickle.ts
+++ b/test_files/parameter_properties/parameter_properties.tsickle.ts
@@ -1,3 +1,4 @@
+
 class ParamProps {
 /**
  * @param {string} bar

--- a/test_files/static/static.tsickle.ts
+++ b/test_files/static/static.tsickle.ts
@@ -1,3 +1,4 @@
+
 class Static {
   // This should not become a stub declaration.
   static bar = 3;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,6 +1,4 @@
-goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};// Ensure that a class is structurally equivalent to an object literal
-// with the same fields.
-class StructuralTest {
+goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};class StructuralTest {
     /**
      * @return {?}
      */

--- a/test_files/structural.untyped/structural.untyped.tsickle.ts
+++ b/test_files/structural.untyped/structural.untyped.tsickle.ts
@@ -1,5 +1,4 @@
-// Ensure that a class is structurally equivalent to an object literal
-// with the same fields.
+
 class StructuralTest {
   field1: string;
 /**

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -14,7 +14,6 @@ function SuperTestBaseOneArg_tsickle_Closure_declarations() {
     /** @type {number} */
     SuperTestBaseOneArg.prototype.x;
 }
-// A ctor with a parameter property.
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     /**
      * @param {string} y
@@ -28,7 +27,6 @@ function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
     /** @type {string} */
     SuperTestDerivedParamProps.prototype.y;
 }
-// A ctor with an initialized property.
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
     constructor() {
         super(3);
@@ -39,23 +37,19 @@ function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
     /** @type {string} */
     SuperTestDerivedInitializedProps.prototype.y;
 }
-// A ctor with a super() but none of the above two details.
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
     constructor() {
         super(3);
     }
 }
-// A class without a ctor, extending a one-arg ctor parent.
 class SuperTestDerivedNoCTorNoArg extends SuperTestBaseNoArg {
 }
-// A class without a ctor, extending a no-arg ctor parent.
 class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
 }
 /** @record */
 function SuperTestInterface() { }
 /** @type {number} */
 SuperTestInterface.prototype.foo;
-// A class implementing an interface.
 class SuperTestDerivedInterface {
 }
 function SuperTestDerivedInterface_tsickle_Closure_declarations() {

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -1,7 +1,7 @@
+
 class SuperTestBaseNoArg {
 constructor() {}
 }
-
 class SuperTestBaseOneArg {
 /**
  * @param {number} x
@@ -14,8 +14,6 @@ function SuperTestBaseOneArg_tsickle_Closure_declarations() {
 SuperTestBaseOneArg.prototype.x;
 }
 
-
-// A ctor with a parameter property.
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
 /**
  * @param {string} y
@@ -30,8 +28,6 @@ function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
 SuperTestDerivedParamProps.prototype.y;
 }
 
-
-// A ctor with an initialized property.
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
   y: string = 'foo';
 constructor() {
@@ -44,19 +40,13 @@ function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
 SuperTestDerivedInitializedProps.prototype.y;
 }
 
-
-// A ctor with a super() but none of the above two details.
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
 constructor() {
     super(3);
   }
 }
-
-// A class without a ctor, extending a one-arg ctor parent.
 class SuperTestDerivedNoCTorNoArg extends SuperTestBaseNoArg {
 }
-
-// A class without a ctor, extending a no-arg ctor parent.
 class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
   // NOTE: if this has any properties, we fail to generate it
   // properly because we generate a constructor that doesn't know
@@ -71,8 +61,6 @@ SuperTestInterface.prototype.foo;
 interface SuperTestInterface {
   foo: number;
 }
-
-// A class implementing an interface.
 class SuperTestDerivedInterface implements SuperTestInterface {
   foo: number;
 }
@@ -81,7 +69,6 @@ function SuperTestDerivedInterface_tsickle_Closure_declarations() {
  /** @type {number} */
 SuperTestDerivedInterface.prototype.foo;
 }
-
 
 class SuperTestStaticProp extends SuperTestBaseOneArg {
   static foo = 3;

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -2,7 +2,6 @@
 // but disallowed in Closure.
 export interface TypeAndValue { z: number }
 export var /** @type {number} */ TypeAndValue = 3;
-
 export class Class { z: number }
 
 function Class_tsickle_Closure_declarations() {


### PR DESCRIPTION
RxJS uses these and we need to remove them to make Closure happy.

Fixes #269.