### PR TITLE
handle "this" parameters

### DIFF
--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -26,6 +26,13 @@ function Test4(a) {
     return "a";
 }
 /**
+ * @this {?}
+ * @param {...?} params
+ * @return {?}
+ */
+function TestThisAndRest(...params) { }
+TestThisAndRest.call('foo', 'bar', 3);
+/**
  * @param {?} __0
  * @return {?}
  */

--- a/test_files/functions.untyped/functions.ts
+++ b/test_files/functions.untyped/functions.ts
@@ -13,6 +13,10 @@ function Test4(a: any): string {
   return "a";
 }
 
+// Test a "this" param and a rest param in the same function.
+function TestThisAndRest(this: string, ...params: any[]) {}
+TestThisAndRest.call('foo', 'bar', 3);
+
 function Destructuring({a, b}: {a: number, b: number}) {}
 function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
 function Destructuring3([a, b], [[c]]) {}

--- a/test_files/functions.untyped/functions.tsickle.ts
+++ b/test_files/functions.untyped/functions.tsickle.ts
@@ -30,6 +30,13 @@ function Test4(a: any): string {
   return "a";
 }
 /**
+ * @this {?}
+ * @param {...?} params
+ * @return {?}
+ */
+function TestThisAndRest(this: string, ...params: any[]) {}
+TestThisAndRest.call('foo', 'bar', 3);
+/**
  * @param {?} __0
  * @return {?}
  */

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -26,6 +26,13 @@ function Test4(a) {
     return "a";
 }
 /**
+ * @this {string}
+ * @param {...?} params
+ * @return {void}
+ */
+function TestThisAndRest(...params) { }
+TestThisAndRest.call('foo', 'bar', 3);
+/**
  * @param {{a: number, b: number}} __0
  * @return {void}
  */

--- a/test_files/functions/functions.ts
+++ b/test_files/functions/functions.ts
@@ -13,6 +13,10 @@ function Test4(a: any): string {
   return "a";
 }
 
+// Test a "this" param and a rest param in the same function.
+function TestThisAndRest(this: string, ...params: any[]) {}
+TestThisAndRest.call('foo', 'bar', 3);
+
 function Destructuring({a, b}: {a: number, b: number}) {}
 function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
 function Destructuring3([a, b], [[c]]) {}

--- a/test_files/functions/functions.tsickle.ts
+++ b/test_files/functions/functions.tsickle.ts
@@ -1,7 +1,7 @@
-Warning at test_files/functions/functions.ts:18:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:18:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:18:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:18:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
 ====
 
 /**
@@ -34,6 +34,13 @@ function Test4(a: number): string;
 function Test4(a: any): string {
   return "a";
 }
+/**
+ * @this {string}
+ * @param {...?} params
+ * @return {void}
+ */
+function TestThisAndRest(this: string, ...params: any[]) {}
+TestThisAndRest.call('foo', 'bar', 3);
 /**
  * @param {{a: number, b: number}} __0
  * @return {void}


### PR DESCRIPTION
When a function has a parameter with the special name "this", that
is specifying the type of the "this" object in the body of the function
and shouldn't show up in the parameter list.

It turns out that the issue in #280 was actually caused by us getting
confused about the function's parameter list.  Properly handling the
'this' argument lets us recognize that the parameter is actually a
...rest argument so fixing the 'this' issue fixes that as well.

Fixes #274 and #280!