### PR TITLE
escape "@" tags in jsdoc

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -218,7 +218,7 @@ function tagToString(tag: Tag): string {
     out += ' ' + tag.parameterName;
   }
   if (tag.text) {
-    out += ' ' + tag.text;
+    out += ' ' + tag.text.replace(/@/, '\\@');
   }
   return out;
 }

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -7,7 +7,7 @@ function jsDocTestFunction(foo, baz) {
     return foo;
 }
 /**
- * @return {string} return comment in a "@returns" block.
+ * @return {string} return comment in a "\@returns" block.
  */
 function returnsTest() {
     return 'abc';
@@ -49,3 +49,10 @@ class RedundantJSDocShouldBeStripped {
     constructor() {
     }
 }
+/**
+ * This comment has code that needs to be escaped to pass Closure checking.
+ *   \@Reflect
+ *   function example() {}
+ * @return {void}
+ */
+function JSDocWithBadTag() { }

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -51,3 +51,10 @@ class RedundantJSDocShouldBeStripped {
   /** @constructor */
   constructor() {}
 }
+
+/**
+ * This comment has code that needs to be escaped to pass Closure checking.
+ *   @Reflect
+ *   function example() {}
+ */
+function JSDocWithBadTag() {}

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -15,7 +15,7 @@ function jsDocTestFunction(foo: string, baz: string): string {
   return foo;
 }
 /**
- * @return {string} return comment in a "@returns" block.
+ * @return {string} return comment in a "\@returns" block.
  */
 function returnsTest(): string {
   return 'abc';
@@ -67,3 +67,10 @@ function x() {};
 class RedundantJSDocShouldBeStripped {
 constructor() {}
 }
+/**
+ * This comment has code that needs to be escaped to pass Closure checking.
+ *   \@Reflect
+ *   function example() {}
+ * @return {void}
+ */
+function JSDocWithBadTag() {}


### PR DESCRIPTION
I'm not clear on what the Closure rule is, but I do know that the
new test case fails to compile and the escaped output now compiles.