### PR TITLE
fix jsdoc escaping harder

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -134,7 +134,7 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
   if (!match) return null;
   comment = match[1].trim();
   // Strip all the " * " bits from the front of each line.
-  comment = comment.replace(/^\s*\*? /gm, '');
+  comment = comment.replace(/^\s*\*? ?/gm, '');
   let lines = comment.split('\n');
   let tags: Tag[] = [];
   let warnings: string[] = [];
@@ -218,7 +218,7 @@ function tagToString(tag: Tag): string {
     out += ' ' + tag.parameterName;
   }
   if (tag.text) {
-    out += ' ' + tag.text.replace(/@/, '\\@');
+    out += ' ' + tag.text.replace(/@/g, '\\@');
   }
   return out;
 }

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -51,8 +51,11 @@ class RedundantJSDocShouldBeStripped {
 }
 /**
  * This comment has code that needs to be escaped to pass Closure checking.
+ *
  *   \@Reflect
  *   function example() {}
+ *   \@Reflect.metadata(foo, bar)
+ *   function example2() {}
  * @return {void}
  */
 function JSDocWithBadTag() { }

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -54,7 +54,11 @@ class RedundantJSDocShouldBeStripped {
 
 /**
  * This comment has code that needs to be escaped to pass Closure checking.
+ * @example
+ *
  *   @Reflect
  *   function example() {}
+ *   @Reflect.metadata(foo, bar)
+ *   function example2() {}
  */
 function JSDocWithBadTag() {}

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -69,8 +69,11 @@ constructor() {}
 }
 /**
  * This comment has code that needs to be escaped to pass Closure checking.
+ * 
  *   \@Reflect
  *   function example() {}
+ *   \@Reflect.metadata(foo, bar)
+ *   function example2() {}
  * @return {void}
  */
 function JSDocWithBadTag() {}


### PR DESCRIPTION
The previous fix only escaped the first "@" to appear in the
docs, not all of them.  Make the test include multiple "@" to
exhibit the problem.