### PR TITLE
obey overloads in extern generation

### DIFF
--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -83,17 +83,11 @@ function MultipleConstructors(opt_a) {}
 Object.prototype.myMethod = function() {};
 
 /**
- * @param {string} x
+ * @param {string|number} x_or_y
+ * @param {string} opt_x
  * @return {!CodeMirror.Editor}
  */
-function CodeMirror(x) {}
-
-/**
- * @param {number} y
- * @param {string} x
- * @return {!CodeMirror.Editor}
- */
-function CodeMirror(y, x) {}
+function CodeMirror(x_or_y, opt_x) {}
 
 /** @record @struct */
 CodeMirror.Editor = function() {};


### PR DESCRIPTION
When emitting a function in externs, find all overloads of the
function and pass the full set to the function type emitter so
that overloads are properly unioned.

Fixes #291.