### PR TITLE
rearrange overload definition merging

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -247,3 +247,27 @@ export function toString(tags: Tag[]): string {
   out += ' */\n';
   return out;
 }
+
+/** Merges multiple tags (of the same tagName type) into a single unified tag. */
+export function merge(tags: Tag[]): Tag {
+  let tagNames = new Set<string>();
+  let parameterNames = new Set<string>();
+  let types = new Set<string>();
+  let texts = new Set<string>();
+  for (const tag of tags) {
+    if (tag.tagName) tagNames.add(tag.tagName);
+    if (tag.parameterName) parameterNames.add(tag.parameterName);
+    if (tag.type) types.add(tag.type);
+    if (tag.text) texts.add(tag.text);
+  }
+
+  if (tagNames.size !== 1) {
+    throw new Error(`cannot merge differing tags: ${JSON.stringify(tags)}`);
+  }
+  const tagName = tagNames.values().next().value;
+  const parameterName =
+      parameterNames.size > 0 ? Array.from(parameterNames).join('_or_') : undefined;
+  const type = types.size > 0 ? Array.from(types).join('|') : undefined;
+  const text = texts.size > 0 ? Array.from(texts).join(' / ') : undefined;
+  return {tagName, parameterName, type, text};
+}

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -73,9 +73,9 @@ DeclareTestInterface.prototype.foo;
 /**
  * @constructor
  * @struct
- * @param {number} opt_a
+ * @param {number=} a
  */
-function MultipleConstructors(opt_a) {}
+function MultipleConstructors(a) {}
 
 /**
  * @return {?}
@@ -84,10 +84,10 @@ Object.prototype.myMethod = function() {};
 
 /**
  * @param {string|number} x_or_y
- * @param {string} opt_x
+ * @param {string=} x
  * @return {!CodeMirror.Editor}
  */
-function CodeMirror(x_or_y, opt_x) {}
+function CodeMirror(x_or_y, x) {}
 
 /** @record @struct */
 CodeMirror.Editor = function() {};

--- a/test_files/declare_class_overloads/declare_class_overloads.ts
+++ b/test_files/declare_class_overloads/declare_class_overloads.ts
@@ -5,13 +5,13 @@ declare class MultipleConstructorsOptional {
 }
 
 // A class with an overloaded constructor with different types for the same parameter name.
-declare class MultipleConstructorsTypes { 
+declare class MultipleConstructorsTypes {
   constructor(a: boolean);
   constructor(a: number);
 }
 
 // A class with an overloaded constructor with different types and different param names.
-declare class MultipleConstructorsNamesAndTypes { 
+declare class MultipleConstructorsNamesAndTypes {
   constructor(a: boolean);
   constructor(b: number);
 }
@@ -41,7 +41,7 @@ declare class MultipleConstructorsVariadicNames {
   constructor(...points: number[]);
 }
 
-// Methods with a simple overload pattern. 
+// Methods with a simple overload pattern.
 declare class OverloadSimpleArgs {
   overloaded(a: string): void;
   overloaded(a: number, b: boolean): void;
@@ -75,7 +75,11 @@ declare class OverloadBigMix {
   overloaded(a: string, b: number): number;
   overloaded(c: number, b: number): number;
   overloaded(e: Array<OverloadBigMix>): boolean;
-  overloaded(...f: OverloadBigMix[]): number;
+  // Note: Closure doesn't allow rest params when they aren't the final
+  // param to the function, and the earlier overloads declare a second parameter.
+  // Not sure what to do with this function; perhaps just declare it as
+  // just a param of {...?}.  For now, just leave it out.
+  // overloaded(...f: OverloadBigMix[]): number;
 }
 
 // Use a builtin JS name.

--- a/test_files/declare_class_overloads/declare_class_overloads.tsickle.ts
+++ b/test_files/declare_class_overloads/declare_class_overloads.tsickle.ts
@@ -5,13 +5,13 @@ declare class MultipleConstructorsOptional {
 }
 
 // A class with an overloaded constructor with different types for the same parameter name.
-declare class MultipleConstructorsTypes { 
+declare class MultipleConstructorsTypes {
   constructor(a: boolean);
   constructor(a: number);
 }
 
 // A class with an overloaded constructor with different types and different param names.
-declare class MultipleConstructorsNamesAndTypes { 
+declare class MultipleConstructorsNamesAndTypes {
   constructor(a: boolean);
   constructor(b: number);
 }
@@ -41,7 +41,7 @@ declare class MultipleConstructorsVariadicNames {
   constructor(...points: number[]);
 }
 
-// Methods with a simple overload pattern. 
+// Methods with a simple overload pattern.
 declare class OverloadSimpleArgs {
   overloaded(a: string): void;
   overloaded(a: number, b: boolean): void;
@@ -75,7 +75,11 @@ declare class OverloadBigMix {
   overloaded(a: string, b: number): number;
   overloaded(c: number, b: number): number;
   overloaded(e: Array<OverloadBigMix>): boolean;
-  overloaded(...f: OverloadBigMix[]): number;
+  // Note: Closure doesn't allow rest params when they aren't the final
+  // param to the function, and the earlier overloads declare a second parameter.
+  // Not sure what to do with this function; perhaps just declare it as
+  // just a param of {...?}.  For now, just leave it out.
+  // overloaded(...f: OverloadBigMix[]): number;
 }
 
 // Use a builtin JS name.

--- a/test_files/declare_class_overloads/externs.js
+++ b/test_files/declare_class_overloads/externs.js
@@ -7,9 +7,9 @@
 /**
  * @constructor
  * @struct
- * @param {number} opt_a
+ * @param {number=} a
  */
-function MultipleConstructorsOptional(opt_a) {}
+function MultipleConstructorsOptional(a) {}
 
 /**
  * @constructor
@@ -31,23 +31,23 @@ function MultipleConstructorsNamesAndTypes(a_or_b) {}
  * @param {number} a
  * @param {number} b
  * @param {number} c
- * @param {(undefined|string)|(undefined|!Array<string>)} normal_or_vertexNormals
- * @param {(undefined|boolean)|(undefined|!Array<boolean>)} color_or_vertexColors
- * @param {(undefined|number)} materialIndex
+ * @param {(undefined|string)|(undefined|!Array<string>)=} normal_or_vertexNormals
+ * @param {(undefined|boolean)|(undefined|!Array<boolean>)=} color_or_vertexColors
+ * @param {(undefined|number)=} materialIndex
  */
 function MultipleConstructorsComplexMatrix(a, b, c, normal_or_vertexNormals, color_or_vertexColors, materialIndex) {}
 
 /**
  * @constructor
  * @struct
- * @param {number|!Array<number>} a
+ * @param {...number|!Array<number>} a
  */
 function MultipleConstructorsVariadic(a) {}
 
 /**
  * @constructor
  * @struct
- * @param {!Array<string>|!Array<number>|string|number} points
+ * @param {...!Array<string>|!Array<number>|string|number} points
  */
 function MultipleConstructorsVariadicNames(points) {}
 
@@ -56,11 +56,11 @@ function OverloadSimpleArgs() {}
 
 /**
  * @param {string|number} a
- * @param {boolean} opt_b
- * @param {number} opt_c
+ * @param {boolean=} b
+ * @param {number=} c
  * @return {void}
  */
-OverloadSimpleArgs.prototype.overloaded = function(a, opt_b, opt_c) {};
+OverloadSimpleArgs.prototype.overloaded = function(a, b, c) {};
 
 /** @constructor @struct */
 function OverloadNameVariants() {}
@@ -77,31 +77,31 @@ function OverloadReturnTypesNoVoid() {}
 /**
  * @param {string} a
  * @param {boolean} b
- * @param {number} opt_c
+ * @param {number=} c
  * @return {boolean|number}
  */
-OverloadReturnTypesNoVoid.prototype.overloaded = function(a, b, opt_c) {};
+OverloadReturnTypesNoVoid.prototype.overloaded = function(a, b, c) {};
 
 /** @constructor @struct */
 function OverloadReturnTypesWithVoid() {}
 
 /**
  * @param {string} a
- * @param {boolean} opt_b
- * @param {number} opt_c
+ * @param {boolean=} b
+ * @param {number=} c
  * @return {void|boolean|number}
  */
-OverloadReturnTypesWithVoid.prototype.overloaded = function(a, opt_b, opt_c) {};
+OverloadReturnTypesWithVoid.prototype.overloaded = function(a, b, c) {};
 
 /** @constructor @struct */
 function OverloadBigMix() {}
 
 /**
- * @param {string|number|!Array<!OverloadBigMix>|!OverloadBigMix} a_or_c_or_e_or_f
- * @param {number} opt_b
+ * @param {string|number|!Array<!OverloadBigMix>} a_or_c_or_e
+ * @param {number=} b
  * @return {void|number|boolean}
  */
-OverloadBigMix.prototype.overloaded = function(a_or_c_or_e_or_f, opt_b) {};
+OverloadBigMix.prototype.overloaded = function(a_or_c_or_e, b) {};
 
 /** @constructor @struct */
 function OverloadValueOf() {}


### PR DESCRIPTION
When merging multiple function overloads, we previously attempted
to collect up multiple parallel arrays of param names and types.
This approach dropped other metadata like rest params and optional
attributes.  It also had separate codepaths for overloaded functions
and non-overloaded functions.

Instead, merge overloaded functions by gathering up sets of JSDoc,
and then merge the JSDoc.  This brings the non-overload and overload
cases together, simplifies the code, and makes optional params
correctly gain the "=" suffix.