### PR TITLE
always use writeExternsVariable when writing out variables

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1108,10 +1108,12 @@ class ExternsWriter extends ClosureRewriter {
     }
   }
 
-  private writeExternsVariable(name: string, namespace: string[]) {
+  private writeExternsVariable(name: string, namespace: string[], value?: string) {
     let qualifiedName = namespace.concat([name]).join('.');
     if (namespace.length === 0) this.emit(`var `);
-    this.emit(`${qualifiedName};\n`);
+    this.emit(qualifiedName);
+    if (value) this.emit(` = ${value}`);
+    this.emit(';\n');
   }
 
   private writeExternsFunction(name: string, params: string[], namespace: string[]) {
@@ -1125,9 +1127,10 @@ class ExternsWriter extends ClosureRewriter {
   }
 
   private writeExternsEnum(decl: ts.EnumDeclaration, namespace: string[]) {
-    namespace = namespace.concat([getIdentifierText(decl.name)]);
+    const name = getIdentifierText(decl.name);
     this.emit('\n/** @const */\n');
-    this.emit(`${namespace.join('.')} = {};\n`);
+    this.writeExternsVariable(name, namespace, '{}');
+    namespace = namespace.concat([name]);
     for (let member of decl.members) {
       let memberName: string|undefined;
       switch (member.name.kind) {
@@ -1145,9 +1148,8 @@ class ExternsWriter extends ClosureRewriter {
         this.emit(`\n/* TODO: ${ts.SyntaxKind[member.name.kind]}: ${member.name.getText()} */\n`);
         continue;
       }
-      let name = namespace.concat([memberName]).join('.');
       this.emit('/** @const {number} */\n');
-      this.emit(`${name};\n`);
+      this.writeExternsVariable(memberName, namespace);
     }
   }
 

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -79,3 +79,8 @@ declare function usesArguments(arguments: string);
 
 // Avoid a Closure crash with destructuring.
 declare function destructures({a: number});
+
+// Properly generate top-level enums.
+declare enum ChartType {
+    line, bar
+}

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -81,3 +81,8 @@ declare function usesArguments(arguments: string);
 
 // Avoid a Closure crash with destructuring.
 declare function destructures({a: number});
+
+// Properly generate top-level enums.
+declare enum ChartType {
+    line, bar
+}

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -110,3 +110,10 @@ function usesArguments(tsickle_arguments) {}
  * @return {?}
  */
 function destructures(__0) {}
+
+/** @const */
+var ChartType = {};
+/** @const {number} */
+ChartType.line;
+/** @const {number} */
+ChartType.bar;


### PR DESCRIPTION
That function handles the "var x = " vs "foo.x =" distinction.

Fixes #271.