### PR TITLE
fix(test_files): remove committed warnings and error messages

### DIFF
--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -1,5 +1,3 @@
-Warning at test_files/declare/declare.d.ts:81:1: anonymous type has no symbol
-====
 declare namespace DeclareTestModule {
   namespace inner {
     var someBool: boolean;

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -1,6 +1,3 @@
-Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
-====
-
 class FieldsTest {
   field1: string;
   field2: number;

--- a/test_files/functions/functions.tsickle.ts
+++ b/test_files/functions/functions.tsickle.ts
@@ -1,9 +1,3 @@
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-====
-
 /**
  * @param {number} a
  * @return {number}

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -1,11 +1,3 @@
-Warning at test_files/jsdoc/jsdoc.ts:16:1: type annotations (using {...}) are redundant with TypeScript types
-Warning at test_files/jsdoc/jsdoc.ts:29:3: type annotations (using {...}) are redundant with TypeScript types
-Warning at test_files/jsdoc/jsdoc.ts:34:3: @type annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:44:1: @extends annotations are redundant with TypeScript equivalents
-@implements annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:51:3: @constructor annotations are redundant with TypeScript equivalents
-====
-
 /**
  * @param {string} foo a string.
  * @param {string} baz
@@ -69,7 +61,7 @@ constructor() {}
 }
 /**
  * This comment has code that needs to be escaped to pass Closure checking.
- * 
+ *
  *   \@Reflect
  *   function example() {}
  *   \@Reflect.metadata(foo, bar)

--- a/test_files/type/type.tsickle.ts
+++ b/test_files/type/type.tsickle.ts
@@ -1,7 +1,3 @@
-Warning at test_files/type/type.ts:13:5: unhandled type literal
-Warning at test_files/type/type.ts:28:1: unhandled type {type flags:0x4000 TypeParameter symbol.name:"T"}
-Warning at test_files/type/type.ts:28:1: unhandled type {type flags:0x4000 TypeParameter symbol.name:"T"}
-====
 // Ensure we still understand what Array is, even when it has been
 // monkeypatched -- issue #170.
 interface Array<T> {

--- a/test_files/type_and_value/type_and_value.tsickle.ts
+++ b/test_files/type_and_value/type_and_value.tsickle.ts
@@ -1,6 +1,3 @@
-Warning at test_files/type_and_value/type_and_value.ts:10:5: unhandled anonymous type
-Warning at test_files/type_and_value/type_and_value.ts:16:5: type/symbol conflict for TypeAndValue, using {?} for now
-====
 import * as conflict from './module';
 
 // This test deals with symbols that are simultaneously types and values.


### PR DESCRIPTION
Not sure if these lines were intentionally committed – they seem to be causing Typescript errors in downstream projects that aren't ignoring node_modules. This PR fixes https://github.com/driftyco/ionic-app-scripts/issues/468 for me. 