### PR TITLE
build(npmignore): remove tests and vscode config from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,6 @@
 .gitignore
 .idea
 .travis.yml
-build/test
+.vscode
+test
+test_files


### PR DESCRIPTION
This will ignore both `test` and `build/test`, `.vscode`, and `test_files`