### PR TITLE
drop hacks around not-null

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -314,7 +314,7 @@ class ClosureRewriter extends Rewriter {
     }
     let translator = new TypeTranslator(typeChecker, context, this.options.typeBlackListPaths);
     translator.warn = msg => this.debugWarn(context, msg);
-    return translator.translate(type, true);
+    return translator.translate(type);
   }
 
   /**

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,4 +1,4 @@
-goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};let /** @type {function(new: Document): ?} */ x = Document;
+goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};let /** @type {function(new: (!Document)): ?} */ x = Document;
 class X {
     /**
      * @param {number} a
@@ -11,4 +11,4 @@ function X_tsickle_Closure_declarations() {
     /** @type {number} */
     X.prototype.a;
 }
-let /** @type {function(new: X, number): ?} */ y = X;
+let /** @type {function(new: (!X), number): ?} */ y = X;

--- a/test_files/ctors/ctors.tsickle.ts
+++ b/test_files/ctors/ctors.tsickle.ts
@@ -1,4 +1,4 @@
-let /** @type {function(new: Document): ?} */ x = Document;
+let /** @type {function(new: (!Document)): ?} */ x = Document;
 class X {
 /**
  * @param {number} a
@@ -11,4 +11,4 @@ function X_tsickle_Closure_declarations() {
 X.prototype.a;
 }
 
-let /** @type {function(new: X, number): ?} */ y: {new (a: number): X} = X;
+let /** @type {function(new: (!X), number): ?} */ y: {new (a: number): X} = X;

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -2,7 +2,7 @@ goog.module('test_files.type_and_value.type_and_value');var module = module || {
 var conflict = goog.require('test_files.type_and_value.module');
 // This test deals with symbols that are simultaneously types and values.
 // Use a browser built-in as both a type and a value.
-let /** @type {function(new: Document): ?} */ useBuiltInAsValue = Document;
+let /** @type {function(new: (!Document)): ?} */ useBuiltInAsValue = Document;
 let /** @type {!Document} */ useBuiltInAsType;
 // Use a user-defined class as both a type and a value.
 let /** @type {?} */ useUserClassAsValue = conflict.Class;

--- a/test_files/type_and_value/type_and_value.tsickle.ts
+++ b/test_files/type_and_value/type_and_value.tsickle.ts
@@ -6,7 +6,7 @@ import * as conflict from './module';
 // This test deals with symbols that are simultaneously types and values.
 
 // Use a browser built-in as both a type and a value.
-let /** @type {function(new: Document): ?} */ useBuiltInAsValue = Document;
+let /** @type {function(new: (!Document)): ?} */ useBuiltInAsValue = Document;
 let /** @type {!Document} */ useBuiltInAsType: Document;
 
 // Use a user-defined class as both a type and a value.


### PR DESCRIPTION
We were passing around a special parameter to hack around adding
! on types, but it appears to not be necessary; instead always put
the ! on the type and trust that the type system is carrying around
not-nulls for you.

I verified this didn't break anything in google3.