### PR TITLE
always enable typed mode when destructuring

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -304,7 +304,15 @@ class ClosureRewriter extends Rewriter {
    *     bind patterns.
    */
   typeToClosure(context: ts.Node, type?: ts.Type, destructuring = false): string {
-    if (this.options.untyped) {
+    if (this.options.untyped && !destructuring) {
+      // Note: even in untyped mode, it's important we provide a type signature
+      // for destructured types, because of the case like:
+      //   function foo({bar}: {bar:number})
+      // we need "bar" to appear in the JSDoc.
+      // Rather than special-case destructuring in untyped mode, the above logic
+      // just always provides full types for destructured cases; we'd like
+      // to eliminate untyped mode anyway and hopefully there aren't enough
+      // cases of destructuring where typed mode will fall down.
       return '?';
     }
 

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -270,6 +270,9 @@ export class TypeTranslator {
         typeStr += this.translate(referenceType.target);
       }
       if (referenceType.typeArguments) {
+        // Closure doesn't accept a type like {?<...>}, so if the parameterized
+        // type itself is unknown just use that by itself.
+        if (typeStr === '?') return typeStr;
         let params = referenceType.typeArguments.map(t => this.translate(t));
         typeStr += isTuple ? `!Array` : `<${params.join(', ')}>`;
       }
@@ -398,6 +401,8 @@ export class TypeTranslator {
 
     if (!callable && !indexable) {
       // Not callable, not indexable; implies a plain object with fields in it.
+      // Note: {a:number} is already non-nullable in Closure, so no need to put
+      // a ! prefix on it.
       return `{${fields.join(', ')}}`;
     }
 

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -33,19 +33,19 @@ function Test4(a) {
 function TestThisAndRest(...params) { }
 TestThisAndRest.call('foo', 'bar', 3);
 /**
- * @param {?} __0
+ * @param {{a: number, b: number}} __0
  * @return {?}
  */
 function Destructuring({ a, b }) { }
 /**
- * @param {?} __0
- * @param {?} __1
+ * @param {!Array<number>} __0
+ * @param {!Array<!Array<string>>} __1
  * @return {?}
  */
 function Destructuring2([a, b], [[c]]) { }
 /**
- * @param {?} __0
- * @param {?} __1
+ * @param {!Array<?, ?>} __0
+ * @param {!Array<!Array<?>>} __1
  * @return {?}
  */
 function Destructuring3([a, b], [[c]]) { }

--- a/test_files/functions.untyped/functions.tsickle.ts
+++ b/test_files/functions.untyped/functions.tsickle.ts
@@ -1,3 +1,8 @@
+Warning at test_files/functions.untyped/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions.untyped/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions.untyped/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+Warning at test_files/functions.untyped/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
+====
 
 /**
  * @param {?} a
@@ -37,19 +42,19 @@ function Test4(a: any): string {
 function TestThisAndRest(this: string, ...params: any[]) {}
 TestThisAndRest.call('foo', 'bar', 3);
 /**
- * @param {?} __0
+ * @param {{a: number, b: number}} __0
  * @return {?}
  */
 function Destructuring({a, b}: {a: number, b: number}) {}
 /**
- * @param {?} __0
- * @param {?} __1
+ * @param {!Array<number>} __0
+ * @param {!Array<!Array<string>>} __1
  * @return {?}
  */
 function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
 /**
- * @param {?} __0
- * @param {?} __1
+ * @param {!Array<?, ?>} __0
+ * @param {!Array<!Array<?>>} __1
  * @return {?}
  */
 function Destructuring3([a, b], [[c]]) {}


### PR DESCRIPTION
Even in untyped mode, it's important we provide a type signature
for destructured types, because of the case like:
  function foo({bar}: {bar:number})
we need "bar" to appear in the JSDoc.

Rather than special-case destructuring in untyped mode, let's try
just always providing full types for destructured cases; we'd like
to eliminate untyped mode anyway and hopefully there aren't enough
cases of destructuring where typed mode will fall down.

Fixes issue #263.