### PR TITLE
properly handle reopened interfaces

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -129,6 +129,21 @@ class ClosureRewriter extends Rewriter {
   }
 
   /**
+   * isFirstDeclaration returns true if decl is the first declaration
+   * of its symbol.  E.g. imagine
+   *   interface Foo { x: number; }
+   *   interface Foo { y: number; }
+   * we only want to emit the "@record" for Foo on the first one.
+   */
+  isFirstDeclaration(decl: ts.Declaration): boolean {
+    if (!decl.name) return true;
+    const typeChecker = this.program.getTypeChecker();
+    const sym = typeChecker.getSymbolAtLocation(decl.name);
+    if (!sym.declarations || sym.declarations.length < 2) return true;
+    return decl === sym.declarations[0];
+  }
+
+  /**
    * Handles emittng the jsdoc for methods, including overloads.
    * If overloaded, merges the signatures in the list of SignatureDeclarations into a single jsdoc.
    * - Total number of parameters will be the maximum count found across all variants.
@@ -678,20 +693,25 @@ class Annotator extends ClosureRewriter {
     let sym = this.program.getTypeChecker().getSymbolAtLocation(iface.name);
     if (sym.flags & ts.SymbolFlags.Value) return;
 
-    this.emit(`\n/** @record */\n`);
-    if (iface.flags & ts.NodeFlags.Export) this.emit('export ');
-    let name = getIdentifierText(iface.name);
-    this.emit(`function ${name}() {}\n`);
-    if (iface.typeParameters) {
-      this.emit(`// TODO: type parameters.\n`);
-    }
-    if (iface.heritageClauses) {
-      this.emit(`// TODO: derived interfaces.\n`);
+    const name = getIdentifierText(iface.name);
+
+    if (this.isFirstDeclaration(iface)) {
+      this.emit(`\n/** @record */\n`);
+      if (iface.flags & ts.NodeFlags.Export) this.emit('export ');
+      this.emit(`function ${name}() {}\n`);
+      if (iface.typeParameters) {
+        this.emit(`// TODO: type parameters.\n`);
+      }
+      if (iface.heritageClauses) {
+        this.emit(`// TODO: derived interfaces.\n`);
+      }
     }
 
     const memberNamespace = [name, 'prototype'];
     for (let elem of iface.members) {
-      this.visitProperty(memberNamespace, elem);
+      if (this.isFirstDeclaration(elem)) {
+        this.visitProperty(memberNamespace, elem);
+      }
     }
   }
 
@@ -775,7 +795,7 @@ class Annotator extends ClosureRewriter {
       }
     }
     tags.push({tagName: 'type', type: this.typeToClosure(p)});
-    this.emit(jsdoc.toString(tags));
+    this.emit('\n' + jsdoc.toString(tags));
     namespace = namespace.concat([name]);
     this.emit(`${namespace.join('.')};\n`);
   }
@@ -963,21 +983,6 @@ class ExternsWriter extends ClosureRewriter {
         this.emit(`\n/* TODO: ${ts.SyntaxKind[node.kind]} in ${namespace.join('.')} */\n`);
         break;
     }
-  }
-
-  /**
-   * isFirstDeclaration returns true if decl is the first declaration
-   * of its symbol.  E.g. imagine
-   *   interface Foo { x: number; }
-   *   interface Foo { y: number; }
-   * we only want to emit the "@record" for Foo on the first one.
-   */
-  private isFirstDeclaration(decl: ts.DeclarationStatement): boolean {
-    if (!decl.name) return true;
-    const typeChecker = this.program.getTypeChecker();
-    const sym = typeChecker.getSymbolAtLocation(decl.name);
-    if (!sym.declarations || sym.declarations.length < 2) return true;
-    return decl === sym.declarations[0];
   }
 
   private writeExternsType(decl: ts.InterfaceDeclaration|ts.ClassDeclaration, namespace: string[]) {

--- a/test_files/basic.untyped/basic.untyped.tsickle.ts
+++ b/test_files/basic.untyped/basic.untyped.tsickle.ts
@@ -17,8 +17,10 @@ constructor(private ctorArg: string) {
 }
 
 function Foo_tsickle_Closure_declarations() {
+
 /** @type {?} */
 Foo.prototype.field;
+
 /** @type {?} */
 Foo.prototype.ctorArg;
 }

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -22,24 +22,31 @@ class Comments {
 }
 
 function Comments_tsickle_Closure_declarations() {
+
 /**
  * @export
  * @type {string}
  */
 Comments.prototype.export1;
+
 /** @type {string} */
 Comments.prototype.export2;
+
 /** @type {number} */
 Comments.prototype.nodoc1;
+
 /** @type {number} */
 Comments.prototype.nodoc2;
+
 /** @type {number} */
 Comments.prototype.nodoc3;
+
 /**
  * inline jsdoc comment without type annotation
  * @type {number}
  */
 Comments.prototype.jsdoc1;
+
 /**
  * multi-line jsdoc comment without
  * type annotation.

--- a/test_files/ctors/ctors.tsickle.ts
+++ b/test_files/ctors/ctors.tsickle.ts
@@ -7,6 +7,7 @@ constructor(private a: number) {}
 }
 
 function X_tsickle_Closure_declarations() {
+
 /** @type {number} */
 X.prototype.a;
 }

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -37,17 +37,22 @@ static propDecorators: {[key: string]: DecoratorInvocation[]} = {
 }
 
 function DecoratorTest_tsickle_Closure_declarations() {
+
 /** @type {!Array<!DecoratorInvocation>} */
 DecoratorTest.decorators;
+
 /**
  * @nocollapse
  * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<!DecoratorInvocation>)})>}
  */
 DecoratorTest.ctorParameters;
+
 /** @type {!Object<string,!Array<!DecoratorInvocation>>} */
 DecoratorTest.propDecorators;
+
 /** @type {number} */
 DecoratorTest.prototype.x;
+
 /** @type {number} */
 DecoratorTest.prototype.y;
 }
@@ -58,14 +63,17 @@ class DecoratedClass {
 }
 
 function DecoratedClass_tsickle_Closure_declarations() {
+
 /** @type {string} */
 DecoratedClass.prototype.z;
 }
 
 /** @record */
 function DecoratorInvocation() {}
+
 /** @type {!Function} */
 DecoratorInvocation.prototype.type;
+
 /** @type {(undefined|!Array<?>)} */
 DecoratorInvocation.prototype.args;
 

--- a/test_files/export/export_helper.tsickle.ts
+++ b/test_files/export/export_helper.tsickle.ts
@@ -5,6 +5,7 @@ export let /** @type {number} */ export1 = 3;
 export let /** @type {number} */ export2 = 3;
 /** @record */
 export function Bar() {}
+
 /** @type {number} */
 Bar.prototype.barField;
 

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -23,12 +23,16 @@ getF1() {
 }
 
 function FieldsTest_tsickle_Closure_declarations() {
+
 /** @type {string} */
 FieldsTest.prototype.field1;
+
 /** @type {number} */
 FieldsTest.prototype.field2;
+
 /** @type {string} */
 FieldsTest.prototype.field4;
+
 /** @type {number} */
 FieldsTest.prototype.field3;
 }

--- a/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
+++ b/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
@@ -4,6 +4,7 @@ class NoCtor {
 }
 
 function NoCtor_tsickle_Closure_declarations() {
+
 /** @type {number} */
 NoCtor.prototype.field1;
 }

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -27,3 +27,9 @@ TrickyInterface.prototype.foo;
 */
 /** @type {(undefined|string)} */
 TrickyInterface.prototype.foobar;
+/** @record */
+function Reopened() { }
+/** @type {number} */
+Reopened.prototype.x;
+/** @type {string} */
+Reopened.prototype.y;

--- a/test_files/interface/interface.ts
+++ b/test_files/interface/interface.ts
@@ -29,3 +29,14 @@ interface TrickyInterface {
   // TODO: handle optional members.  Should have |undefined type.
   'foobar'?: 'true'|'false';
 }
+
+// Reopen an interface with a redundant declaration and a useful one.
+interface Reopened {
+  x: number;
+}
+interface Reopened {
+  x: number;
+}
+interface Reopened {
+  y: string;
+}

--- a/test_files/interface/interface.tsickle.ts
+++ b/test_files/interface/interface.tsickle.ts
@@ -1,8 +1,10 @@
 
 /** @record */
 function Point() {}
+
 /** @type {number} */
 Point.prototype.x;
+
 /** @type {number} */
 Point.prototype.y;
 interface Point {
@@ -25,12 +27,14 @@ function TrickyInterface() {}
 /* TODO: handle strange member:
 [offset: number]: number;
 */
+
 /** @type {number} */
 TrickyInterface.prototype.foo;
 /* TODO: handle strange member:
 (x: number): __ yuck __
     number;
 */
+
 /** @type {(undefined|string)} */
 TrickyInterface.prototype.foobar;
 
@@ -52,4 +56,24 @@ interface TrickyInterface {
     number;
   // TODO: handle optional members.  Should have |undefined type.
   'foobar'?: 'true'|'false';
+}
+/** @record */
+function Reopened() {}
+
+/** @type {number} */
+Reopened.prototype.x;
+
+
+// Reopen an interface with a redundant declaration and a useful one.
+interface Reopened {
+  x: number;
+}
+interface Reopened {
+  x: number;
+}
+/** @type {string} */
+Reopened.prototype.y;
+
+interface Reopened {
+  y: string;
 }

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -42,15 +42,19 @@ class JSDocTest {
 }
 
 function JSDocTest_tsickle_Closure_declarations() {
+
 /**
  * @export
  * @type {string}
  */
 JSDocTest.prototype.exported;
+
 /** @type {string} */
 JSDocTest.prototype.badExport;
+
 /** @type {string} */
 JSDocTest.prototype.stringWithoutJSDoc;
+
 /** @type {number} */
 JSDocTest.prototype.typedThing;
 }

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -2,6 +2,7 @@
 export class Class {}
 /** @record */
 export function Interface() {}
+
 /** @type {number} */
 Interface.prototype.x;
 

--- a/test_files/jsdoc_types/module2.tsickle.ts
+++ b/test_files/jsdoc_types/module2.tsickle.ts
@@ -3,6 +3,7 @@ export class ClassOne {}
 export class ClassTwo {}
 /** @record */
 export function Interface() {}
+
 /** @type {number} */
 Interface.prototype.x;
 

--- a/test_files/jsdoc_types/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types/nevertyped.tsickle.ts
@@ -1,6 +1,7 @@
 
 /** @record */
 export function NeverTyped() {}
+
 /** @type {number} */
 NeverTyped.prototype.foo;
 /* This filename is specially marked in the tsickle test

--- a/test_files/methods/methods.tsickle.ts
+++ b/test_files/methods/methods.tsickle.ts
@@ -22,6 +22,7 @@ set f(n: number) { this._f = n - 1; }
 }
 
 function HasMethods_tsickle_Closure_declarations() {
+
 /** @type {number} */
 HasMethods.prototype._f;
 }

--- a/test_files/nullable/nullable.tsickle.ts
+++ b/test_files/nullable/nullable.tsickle.ts
@@ -7,12 +7,16 @@ class Primitives {
 }
 
 function Primitives_tsickle_Closure_declarations() {
+
 /** @type {(null|string)} */
 Primitives.prototype.nullable;
+
 /** @type {(undefined|number)} */
 Primitives.prototype.undefinable;
+
 /** @type {(undefined|null|string)} */
 Primitives.prototype.nullableUndefinable;
+
 /** @type {(undefined|string)} */
 Primitives.prototype.optional;
 }
@@ -27,14 +31,19 @@ class NonPrimitives {
 }
 
 function NonPrimitives_tsickle_Closure_declarations() {
+
 /** @type {!NonPrimitive} */
 NonPrimitives.prototype.nonNull;
+
 /** @type {(null|!NonPrimitive)} */
 NonPrimitives.prototype.nullable;
+
 /** @type {(undefined|!NonPrimitive)} */
 NonPrimitives.prototype.undefinable;
+
 /** @type {(undefined|null|!NonPrimitive)} */
 NonPrimitives.prototype.nullableUndefinable;
+
 /** @type {(undefined|!NonPrimitive)} */
 NonPrimitives.prototype.optional;
 }

--- a/test_files/parameter_properties/parameter_properties.tsickle.ts
+++ b/test_files/parameter_properties/parameter_properties.tsickle.ts
@@ -10,11 +10,13 @@ public bar2: string) {}
 }
 
 function ParamProps_tsickle_Closure_declarations() {
+
 /**
  * @export
  * @type {string}
  */
 ParamProps.prototype.bar;
+
 /** @type {string} */
 ParamProps.prototype.bar2;
 }

--- a/test_files/static/static.tsickle.ts
+++ b/test_files/static/static.tsickle.ts
@@ -6,8 +6,10 @@ private static baz: number = 3;
 }
 
 function Static_tsickle_Closure_declarations() {
+
 /** @type {number} */
 Static.bar;
+
 /** @type {number} */
 Static.baz;
 }

--- a/test_files/structural.untyped/structural.untyped.tsickle.ts
+++ b/test_files/structural.untyped/structural.untyped.tsickle.ts
@@ -8,6 +8,7 @@ method(): string { return this.field1; }
 }
 
 function StructuralTest_tsickle_Closure_declarations() {
+
 /** @type {?} */
 StructuralTest.prototype.field1;
 }

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -10,6 +10,7 @@ constructor(public x: number) {}
 }
 
 function SuperTestBaseOneArg_tsickle_Closure_declarations() {
+
 /** @type {number} */
 SuperTestBaseOneArg.prototype.x;
 }
@@ -24,6 +25,7 @@ constructor(public y: string) {
 }
 
 function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
+
 /** @type {string} */
 SuperTestDerivedParamProps.prototype.y;
 }
@@ -36,6 +38,7 @@ constructor() {
 }
 
 function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
+
 /** @type {string} */
 SuperTestDerivedInitializedProps.prototype.y;
 }
@@ -54,6 +57,7 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
 }
 /** @record */
 function SuperTestInterface() {}
+
 /** @type {number} */
 SuperTestInterface.prototype.foo;
 
@@ -66,6 +70,7 @@ class SuperTestDerivedInterface implements SuperTestInterface {
 }
 
 function SuperTestDerivedInterface_tsickle_Closure_declarations() {
+
 /** @type {number} */
 SuperTestDerivedInterface.prototype.foo;
 }
@@ -75,6 +80,7 @@ class SuperTestStaticProp extends SuperTestBaseOneArg {
 }
 
 function SuperTestStaticProp_tsickle_Closure_declarations() {
+
 /** @type {number} */
 SuperTestStaticProp.foo;
 }

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -5,6 +5,7 @@ export var /** @type {number} */ TypeAndValue = 3;
 export class Class { z: number }
 
 function Class_tsickle_Closure_declarations() {
+
 /** @type {number} */
 Class.prototype.z;
 }

--- a/test_files/underscore/underscore.tsickle.ts
+++ b/test_files/underscore/underscore.tsickle.ts
@@ -17,6 +17,7 @@ __method(__arg: string): string {
 }
 
 function __Class_tsickle_Closure_declarations() {
+
 /** @type {string} */
 __Class.prototype.__member;
 }


### PR DESCRIPTION
Interfaces can be reopened, but we should only emit the interface
(and each field) once.

TODO(me): perhaps we should emit the *type* of the interface once
and let TS do the unification for us.