### PR TITLE
Compose source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "merge2": "^1.0.2",
     "temp": "^0.8.1",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.0"
+    "typescript": "~2.0.0"
   },
   "scripts": {
     "prepublish": "gulp compile",

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,7 @@ function createSourceReplacingCompilerHost(
     let path: string = ts.sys.resolvePath(fileName);
     let sourceText = substituteSource.get(path);
     if (sourceText) {
-      return ts.createSourceFile(path, sourceText, languageVersion);
+      return ts.createSourceFile(fileName, sourceText, languageVersion);
     }
     return delegate.getSourceFile(path, languageVersion, onError);
   }
@@ -245,12 +245,10 @@ export function toClosureJS(
       for (const sourceFileName of (new SourceMapConsumer(tscSourceMapJson) as any).sources) {
         const tsickleSourceMapGenerator = tsickleSourceMaps.get(sourceFileName);
         if (!tsickleSourceMapGenerator) {
-          console.log('couldn\'t find a souce map for: ' + sourceFileName);
+          console.log(`couldn't find a source map for: ${sourceFileName}`);
           return null;
         }
         const tsickleRawSourceMap = tsickleSourceMapGenerator.toJSON();
-        tsickleRawSourceMap.sources[0] = sourceFileName;
-        tsickleRawSourceMap.file = sourceFileName;
 
         const tsickleSourceMap = new SourceMapConsumer(tsickleRawSourceMap);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,6 +163,8 @@ function createSourceReplacingCompilerHost(
 /**
  * Compiles TypeScript code into Closure-compiler-ready JS.
  * Doesn't write any files to disk; all JS content is returned in a map.
+ * Pass in a files param to programmatically specify input instead of
+ * looking for the files on disk.
  */
 export function toClosureJS(
     options: ts.CompilerOptions, fileNames: string[], settings: Settings,

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -29,6 +29,7 @@ export abstract class Rewriter {
   private indent: number = 0;
 
   constructor(protected file: ts.SourceFile) {
+    this.sourceMap = new SourceMapGenerator({file: file.fileName});
     this.sourceMap.addMapping({
       original: this.position,
       generated: this.position,

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -43,16 +43,16 @@ describe('source maps', () => {
   it('composes sources maps with multiple input files', function() {
     const sources = new Map<string, string>();
     sources.set('input1.ts', `
-      class X { field: number; }
-      let x : string = 'a string';
-      let y : string = 'another string';
-      let z : string = x + y;`);
+        class X { field: number; }
+        let x : string = 'a string';
+        let y : string = 'another string';
+        let z : string = x + y;`);
 
     sources.set('input2.ts', `
-      class A { field: number; }
-      let a : string = 'third string';
-      let b : string = 'fourth rate';
-      let c : string = a + b;`);
+        class A { field: number; }
+        let a : string = 'third string';
+        let b : string = 'fourth rate';
+        let c : string = a + b;`);
 
     // Run tsickle+TSC to convert inputs to Closure JS files.
     const {compiledJS, sourceMap} = compile(sources);
@@ -73,25 +73,27 @@ describe('source maps', () => {
   it('handles decorators correctly', function() {
     const sources = new Map<string, string>();
     sources.set('input.ts', `/** @Annotation */
-    function classAnnotation(t: any) { return t; }
+        function classAnnotation(t: any) { return t; }
 
-    @classAnnotation
-    class DecoratorTest {
-      public x(s: string): string { return s; }
-    }`);
+        @classAnnotation
+        class DecoratorTest {
+          public x(s: string): string { return s; }
+        }`);
 
     const {compiledJS, sourceMap} = compile(sources);
 
     const xPosition = getLineAndColumn(compiledJS, 'x');
 
     expect(sourceMap.originalPositionFor(xPosition).line).to.equal(6, 'method X position');
-
   });
 });
 
 function getLineAndColumn(source: string, token: string): {line: number, column: number} {
   const lines = source.split('\n');
   const line = lines.findIndex(l => l.indexOf(token) !== -1) + 1;
+  if (line === 0) {
+    throw new Error(`Couldn't find token '${token}' in source`);
+  }
   const column = lines[line - 1].indexOf(token) + 1;
   return {line, column};
 }

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assert, expect} from 'chai';
+import * as path from 'path';
+import {SourceMapConsumer} from 'source-map';
+import * as ts from 'typescript';
+
+import {Settings, toClosureJS} from '../src/main';
+import {annotate} from '../src/tsickle';
+import {toArray} from '../src/util';
+
+import {createProgram} from './test_support';
+
+describe('source maps', () => {
+  it('composes source maps with tsc', function() {
+    const diagnostics: ts.Diagnostic[] = [];
+
+    const sources = new Map<string, string>();
+    sources.set(ts.sys.resolvePath('input.ts'), `
+      class X { field: number; }
+      let x : string = 'a string';
+      let y : string = 'another string';
+      let z : string = x + y;`);
+
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const closure = toClosureJS(
+        {sourceMap: true} as ts.CompilerOptions, ['input.ts'], {isUntyped: false} as Settings,
+        diagnostics, sources);
+
+    if (!closure) {
+      assert.fail();
+      return;
+    }
+
+    const compiledJS = getFileWithName('input.js', closure.jsFiles);
+
+    if (!compiledJS) {
+      assert.fail();
+      return;
+    }
+
+    const lines = compiledJS.split('\n');
+    const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;
+    const stringXColumn = lines[stringXLine - 1].indexOf('a string') + 1;
+    const stringYLine = lines.findIndex(l => l.indexOf('another string') !== -1) + 1;
+    const stringYColumn = lines[stringYLine - 1].indexOf('another string') + 1;
+
+    const sourceMapJson: any = getFileWithName('input.js.map', closure.jsFiles);
+    const sourceMap = new SourceMapConsumer(sourceMapJson);
+
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).line)
+        .to.equal(3, 'first string definition');
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
+        .to.equal('input.ts', 'input file name');
+    expect(sourceMap.originalPositionFor({line: stringYLine, column: stringYColumn}).line)
+        .to.equal(4, 'second string definition');
+    expect(sourceMap.originalPositionFor({line: stringYLine, column: stringYColumn}).source)
+        .to.equal('input.ts', 'input file name');
+  });
+
+  it('composes sources maps with multiple input files', function() {
+    const diagnostics: ts.Diagnostic[] = [];
+
+    const sources = new Map<string, string>();
+    sources.set(ts.sys.resolvePath('input1.ts'), `
+      class X { field: number; }
+      let x : string = 'a string';
+      let y : string = 'another string';
+      let z : string = x + y;`);
+
+    sources.set(ts.sys.resolvePath('input2.ts'), `
+      class A { field: number; }
+      let a : string = 'third string';
+      let b : string = 'fourth rate';
+      let c : string = a + b;`);
+
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const closure = toClosureJS(
+        {sourceMap: true, outFile: 'output.js'} as ts.CompilerOptions, ['input1.ts', 'input2.ts'],
+        {isUntyped: false} as Settings, diagnostics, sources);
+
+    if (!closure) {
+      assert.fail();
+      return;
+    }
+
+    const compiledJS = getFileWithName('output.js', closure.jsFiles);
+
+    if (!compiledJS) {
+      assert.fail();
+      return;
+    }
+
+    const lines = compiledJS.split('\n');
+    const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;
+    const stringXColumn = lines[stringXLine - 1].indexOf('a string') + 1;
+    const stringBLine = lines.findIndex(l => l.indexOf('fourth rate') !== -1) + 1;
+    ;
+    const stringBColumn = lines[stringBLine - 1].indexOf('fourth rate') + 1;
+
+    const sourceMapJson: any = getFileWithName('output.js.map', closure.jsFiles);
+    const sourceMap = new SourceMapConsumer(sourceMapJson);
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).line)
+        .to.equal(3, 'first string definition');
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
+        .to.equal('input1.ts', 'first input file');
+    expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).line)
+        .to.equal(4, 'fouth string definition');
+    expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).source)
+        .to.equal('input2.ts', 'second input file');
+  });
+});
+
+
+function getFileWithName(filename: string, files: Map<string, string>): string|undefined {
+  for (let filepath of toArray(files.keys())) {
+    if (path.parse(filepath).base === filename) {
+      return files.get(filepath);
+    }
+  }
+}

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -12,10 +12,7 @@ import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import {Settings, toClosureJS} from '../src/main';
-import {annotate} from '../src/tsickle';
 import {toArray} from '../src/util';
-
-import {createProgram} from './test_support';
 
 describe('source maps', () => {
   it('composes source maps with tsc', function() {

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -6,12 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {expect} from 'chai';
+import {expect, assert} from 'chai';
 import {SourceMapConsumer} from 'source-map';
 
 import {annotate} from '../src/tsickle';
 
 import {createProgram} from './test_support';
+
+import {toClosureJS, Settings} from '../src/main';
+
+import * as ts from 'typescript';
+
+import {toArray} from '../src/util';
+
+import * as path from 'path';
 
 describe('source maps', () => {
   it('generates a source map', () => {
@@ -34,4 +42,50 @@ describe('source maps', () => {
     expect(consumer.originalPositionFor({line: secondClassLine, column: 20}).line)
         .to.equal(3, 'second class definition');
   });
+
+  it('composes source maps with tsc', function() {
+    this.timeout(3000);
+
+    const diagnostics: ts.Diagnostic[] = [];
+
+    const sources = new Map<string, string>();
+    sources.set(ts.sys.resolvePath('input.ts'), `
+      class X { field: number; }
+      let x : string = 'a string';
+      let y : string = 'another string';
+      let z : string = x + y;`);
+
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const closure = toClosureJS({sourceMap: true} as ts.CompilerOptions, ['input.ts'], {isUntyped: false} as Settings, diagnostics, sources);
+
+    if (!closure) {
+      assert.fail();
+      return;
+    }
+
+    const compiledJS = getFileWithName('input.js', closure.jsFiles);
+
+    if (!compiledJS) {
+      assert.fail();
+      return;
+    }
+
+    const lines = compiledJS.split('\n');
+    const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;
+    const stringXColumn = lines[stringXLine - 1].indexOf('a string') + 1;
+
+    const sourceMapJson : any = getFileWithName('input.js.map', closure.jsFiles);
+    const sourceMap = new SourceMapConsumer(sourceMapJson);
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).line)
+        .to.equal(3, 'first string definition');
+  });
 });
+
+
+function getFileWithName(filename: string, files: Map<string, string>): string | undefined {
+  for (let filepath of toArray(files.keys())) {
+    if (path.parse(filepath).base === filename) {
+      return files.get(filepath);
+    }
+  }
+}

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -6,14 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assert, expect} from 'chai';
-import * as path from 'path';
+import {expect} from 'chai';
 import {SourceMapConsumer} from 'source-map';
-import * as ts from 'typescript';
 
-import {Settings, toClosureJS} from '../src/main';
 import {annotate} from '../src/tsickle';
-import {toArray} from '../src/util';
 
 import {createProgram} from './test_support';
 


### PR DESCRIPTION
Currently, tsickle produces a source map for its transformations and tsc produces a source map for its transformations, but we don't produce a merged source map that maps the js to the original ts.  This PR adds support for merging the two source maps as well as e2e tests for the transformations.

Closes #116