### PR TITLE
blacklist ErrorConstructor for externs

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -57,8 +57,16 @@ export let closureExternsBlacklist: string[] = [
   'exports',
   'global',
   'module',
-  'WorkerGlobalScope',
+  // ErrorConstructor is the interface of the Error object itself.
+  // tsickle detects that this is part of the TypeScript standard library
+  // and assumes it's part of the Closure standard library, but this
+  // assumption is wrong for ErrorConstructor.  To properly handle this
+  // we'd somehow need to map methods defined on the ErrorConstructor
+  // interface into properties on Closure's Error object, but for now it's
+  // simpler to just blacklist it.
+  'ErrorConstructor',
   'Symbol',
+  'WorkerGlobalScope',
 ];
 
 export function formatDiagnostics(diags: ts.Diagnostic[]): string {

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -84,3 +84,8 @@ declare function destructures({a: number});
 declare enum ChartType {
     line, bar
 }
+
+// Should be dropped; redundant with Closure builtins.
+interface ErrorConstructor {
+  foo(): void;
+}

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -86,3 +86,8 @@ declare function destructures({a: number});
 declare enum ChartType {
     line, bar
 }
+
+// Should be dropped; redundant with Closure builtins.
+interface ErrorConstructor {
+  foo(): void;
+}


### PR DESCRIPTION
This is redundant with a type in the Closure standard library,
but our existing checks don't detect it.  Manually blacklist it
for now.

Works around issue #308.