### PR TITLE
initial ts2.1 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "merge2": "^1.0.2",
     "temp": "^0.8.1",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.0"
+    "typescript": "^2.1.0"
   },
   "scripts": {
     "prepublish": "gulp compile",

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -37,31 +37,13 @@ export function typeToDebugString(type: ts.Type): string {
   let debugString = `flags:0x${type.flags.toString(16)}`;
 
   const basicTypes: ts.TypeFlags[] = [
-    ts.TypeFlags.Any,
-    ts.TypeFlags.String,
-    ts.TypeFlags.Number,
-    ts.TypeFlags.Boolean,
-    ts.TypeFlags.Enum,
-    ts.TypeFlags.StringLiteral,
-    ts.TypeFlags.NumberLiteral,
-    ts.TypeFlags.BooleanLiteral,
-    ts.TypeFlags.EnumLiteral,
-    ts.TypeFlags.ESSymbol,
-    ts.TypeFlags.Void,
-    ts.TypeFlags.Undefined,
-    ts.TypeFlags.Null,
-    ts.TypeFlags.Never,
-    ts.TypeFlags.TypeParameter,
-    ts.TypeFlags.Class,
-    ts.TypeFlags.Interface,
-    ts.TypeFlags.Reference,
-    ts.TypeFlags.Tuple,
-    ts.TypeFlags.Union,
-    ts.TypeFlags.Intersection,
-    ts.TypeFlags.Anonymous,
-    ts.TypeFlags.Instantiated,
-    ts.TypeFlags.ThisType,
-    ts.TypeFlags.ObjectLiteralPatternWithComputedProperties,
+    ts.TypeFlags.Any,           ts.TypeFlags.String,         ts.TypeFlags.Number,
+    ts.TypeFlags.Boolean,       ts.TypeFlags.Enum,           ts.TypeFlags.StringLiteral,
+    ts.TypeFlags.NumberLiteral, ts.TypeFlags.BooleanLiteral, ts.TypeFlags.EnumLiteral,
+    ts.TypeFlags.ESSymbol,      ts.TypeFlags.Void,           ts.TypeFlags.Undefined,
+    ts.TypeFlags.Null,          ts.TypeFlags.Never,          ts.TypeFlags.TypeParameter,
+    ts.TypeFlags.Object,        ts.TypeFlags.Union,          ts.TypeFlags.Intersection,
+    ts.TypeFlags.Index,         ts.TypeFlags.IndexedAccess,
   ];
   for (let flag of basicTypes) {
     if ((type.flags & flag) !== 0) {
@@ -220,13 +202,13 @@ export class TypeTranslator {
 
     if (type.symbol && this.isBlackListed(type.symbol)) return '?';
 
-    if (type.flags & ts.TypeFlags.Class) {
+    if (/* TODO(ts2.1): type.flags & ts.TypeFlags.Class */ 1 === 1) {
       if (!type.symbol) {
         this.warn('class has no symbol');
         return '?';
       }
       return '!' + this.symbolToString(type.symbol);
-    } else if (type.flags & ts.TypeFlags.Interface) {
+    } else if (/* TODO(ts2.1): type.flags & ts.TypeFlags.Interface */ 1 === 1) {
       // Note: ts.InterfaceType has a typeParameters field, but that
       // specifies the parameters that the interface type *expects*
       // when it's used, and should not be transformed to the output.
@@ -248,13 +230,14 @@ export class TypeTranslator {
         }
       }
       return '!' + this.symbolToString(type.symbol);
-    } else if (type.flags & ts.TypeFlags.Reference) {
+    } else if (/* TODO(ts2.1): type.flags & ts.TypeFlags.Reference */ 1 === 1) {
       // A reference to another type, e.g. Array<number> refers to Array.
       // Emit the referenced type and any type arguments.
       let referenceType = type as ts.TypeReference;
 
       let typeStr = '';
-      let isTuple = (referenceType.flags & ts.TypeFlags.Tuple) > 0;
+      // TODO(ts2.1): let isTuple = (referenceType.flags & ts.TypeFlags.Tuple) > 0;
+      let isTuple = true;
       // For unknown reasons, tuple types can be reference types containing a
       // reference loop. see Destructuring3 in functions.ts.
       // TODO(rado): handle tuples in their own branch.
@@ -274,7 +257,7 @@ export class TypeTranslator {
         typeStr += isTuple ? `!Array` : `<${params.join(', ')}>`;
       }
       return typeStr;
-    } else if (type.flags & ts.TypeFlags.Anonymous) {
+    } else if (/* TODO(ts2.1): type.flags & ts.TypeFlags.Anonymous */ 1 === 1) {
       if (!type.symbol) {
         // This comes up when generating code for an arrow function as passed
         // to a generic function.  The passed-in type is tagged as anonymous

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -50,7 +50,7 @@ describe(
         let goodSourceFile = program.getSourceFile(testCaseFileName);
         expect(() => convertDecorators(program.getTypeChecker(), goodSourceFile)).to.not.throw();
         let badSourceFile =
-            ts.createSourceFile(testCaseFileName, sourceText, ts.ScriptTarget.ES6, true);
+            ts.createSourceFile(testCaseFileName, sourceText, ts.ScriptTarget.ES2015, true);
         expect(() => convertDecorators(program.getTypeChecker(), badSourceFile)).to.throw();
       });
 

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -17,7 +17,7 @@ import {toArray} from '../src/util';
 
 /** The TypeScript compiler options used by the test suite. */
 export const compilerOptions: ts.CompilerOptions = {
-  target: ts.ScriptTarget.ES6,
+  target: ts.ScriptTarget.ES2015,
   skipDefaultLibCheck: true,
   experimentalDecorators: true,
   emitDecoratorMetadata: true,
@@ -34,7 +34,7 @@ const {cachedLibPath, cachedLib} = (function() {
   let host = ts.createCompilerHost(compilerOptions);
   let fn = host.getDefaultLibFileName(compilerOptions);
   let p = ts.getDefaultLibFilePath(compilerOptions);
-  return {cachedLibPath: p, cachedLib: host.getSourceFile(fn, ts.ScriptTarget.ES6)};
+  return {cachedLibPath: p, cachedLib: host.getSourceFile(fn, ts.ScriptTarget.ES2015)};
 })();
 
 /** Creates a ts.Program from a set of input files. */


### PR DESCRIPTION
TypeScript 2.1 changed some APIs (which was easy enough to handle)
but it appears the representation of types is pretty different, so
I'm leaving that for a later change.

This change is enough to get tsickle to *compile* with TypeScript 2.1.
A bunch of type-related code is commented out (marked with "TODO(ts2.1)")
and many of the tests fail.

Initial work on #295.