### PR TITLE
Expose the source maps in the decorator-annotator code.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 import {Rewriter} from './rewriter';
@@ -279,7 +280,7 @@ class DecoratorRewriter extends Rewriter {
     super(sourceFile);
   }
 
-  process(): {output: string, diagnostics: ts.Diagnostic[]} {
+  process(): {output: string, diagnostics: ts.Diagnostic[], sourceMap: SourceMapGenerator} {
     this.visit(this.file);
     return this.getOutput();
   }
@@ -299,7 +300,7 @@ class DecoratorRewriter extends Rewriter {
 }
 
 export function convertDecorators(typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile):
-    {output: string, diagnostics: ts.Diagnostic[]} {
+    {output: string, diagnostics: ts.Diagnostic[], sourceMap: SourceMapGenerator} {
   assertTypeChecked(sourceFile);
   return new DecoratorRewriter(typeChecker, sourceFile).process();
 }

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -7,6 +7,7 @@
  */
 
 import {expect} from 'chai';
+import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import {ANNOTATION_SUPPORT_CODE, convertDecorators} from '../src/decorator-annotator';
@@ -33,11 +34,11 @@ describe(
     'decorator-annotator', () => {
       function translate(sourceText: string, allowErrors = false) {
         let program = testSupport.createProgram(sources(sourceText));
-        let {output, diagnostics} =
+        let {output, diagnostics, sourceMap} =
             convertDecorators(program.getTypeChecker(), program.getSourceFile(testCaseFileName));
         if (!allowErrors) expect(diagnostics).to.be.empty;
         verifyCompiles(output);
-        return {output, diagnostics};
+        return {output, diagnostics, sourceMap};
       }
 
       function expectUnchanged(sourceText: string) {
@@ -52,6 +53,21 @@ describe(
         let badSourceFile =
             ts.createSourceFile(testCaseFileName, sourceText, ts.ScriptTarget.ES6, true);
         expect(() => convertDecorators(program.getTypeChecker(), badSourceFile)).to.throw();
+      });
+
+      it('generates a source map', () => {
+        const {output, sourceMap} = translate(`
+/** @Annotation */ let Test1: Function;
+@Test1
+export class Foo {
+}
+let X = 'a string';`);
+        const rawMap = (sourceMap as any).toJSON();
+        const consumer = new SourceMapConsumer(rawMap);
+        const lines = output.split('\n');
+        const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;
+        expect(consumer.originalPositionFor({line: stringXLine, column: 10}).line)
+            .to.equal(6, 'string X definition');
       });
 
       describe('class decorator rewriter', () => {

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -62,7 +62,7 @@ describe(
 export class Foo {
 }
 let X = 'a string';`);
-        const rawMap = (sourceMap as any).toJSON();
+        const rawMap = sourceMap.toJSON();
         const consumer = new SourceMapConsumer(rawMap);
         const lines = output.split('\n');
         const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -21,7 +21,7 @@ describe('source maps', () => {
       class Y { field2: string; }`);
     const program = createProgram(sources);
     const annotated = annotate(program, program.getSourceFile('input.ts'));
-    const rawMap = (annotated.sourceMap as any).toJSON();
+    const rawMap = annotated.sourceMap.toJSON();
     const consumer = new SourceMapConsumer(rawMap);
     const lines = annotated.output.split('\n');
     // Uncomment to debug contents:


### PR DESCRIPTION
Rewriter generates source maps, but we weren't exposing that in DecoratorRewriter.  We need this exposed in order to support source maps going through decorator rewriting as well the type annotation commenting passes.