### PR TITLE
Use a private TS api to get full comment text.

### DIFF
--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -31,8 +31,8 @@ DecoratorTest.propDecorators = {
     'y': [{ type: annotationDecorator },],
 };
 __decorate([
-    decorator, 
-    __metadata('design:type', Number)
+    decorator,
+    __metadata("design:type", Number)
 ], DecoratorTest.prototype, "x", void 0);
 function DecoratorTest_tsickle_Closure_declarations() {
     /** @type {!Array<!DecoratorInvocation>} */
@@ -52,8 +52,8 @@ function DecoratorTest_tsickle_Closure_declarations() {
 let DecoratedClass = class DecoratedClass {
 };
 DecoratedClass = __decorate([
-    classDecorator, 
-    __metadata('design:paramtypes', [])
+    classDecorator,
+    __metadata("design:paramtypes", [])
 ], DecoratedClass);
 function DecoratedClass_tsickle_Closure_declarations() {
     /** @type {string} */


### PR DESCRIPTION
In TS 2.1 the comment text is stripped of jsdoc @ annotations.
To read the full JSDoc text we temporary use a private API.

Passes all tests with 'TEST_FILTER=decorator gulp watch'

Closes #313