### PR TITLE
ts2.1: rebaseline the remaining tests

### DIFF
--- a/test_files/enum/enum.tsickle.ts
+++ b/test_files/enum/enum.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/enum/enum.ts:2:7: unhandled type {type flags:0x2000 Never}
+Warning at test_files/enum/enum.ts:2:7: should not emit a 'never' type
 ====
 // Line with a missing semicolon should not break the following enum.
 const /** @type {!Array<?>} */ EnumTestMissingSemi = []

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -30,5 +30,4 @@ let /** @type {!FieldsTest} */ fieldsTest = new FieldsTest(3);
 // Ensure the type is understood by Closure.
 fieldsTest.field1 = 'hi';
 let /** @type {?} */ AnonymousClass = class {
-}
-;
+};

--- a/test_files/fields/fields.ts
+++ b/test_files/fields/fields.ts
@@ -21,4 +21,4 @@ fieldsTest.field1 = 'hi';
 
 let AnonymousClass = class {
   field: number;
-}
+};

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -40,4 +40,4 @@ fieldsTest.field1 = 'hi';
 
 let /** @type {?} */ AnonymousClass = class {
   field: number;
-}
+};

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -44,8 +44,8 @@ function Destructuring({ a, b }) { }
  */
 function Destructuring2([a, b], [[c]]) { }
 /**
- * @param {!Array<?, ?>} __0
- * @param {!Array<!Array<?>>} __1
+ * @param {!Array<?>} __0
+ * @param {!Array<?>} __1
  * @return {void}
  */
 function Destructuring3([a, b], [[c]]) { }

--- a/test_files/functions/functions.tsickle.ts
+++ b/test_files/functions/functions.tsickle.ts
@@ -1,8 +1,3 @@
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-Warning at test_files/functions/functions.ts:22:1: unhandled type {type flags:0x4000 TypeParameter}
-====
 
 /**
  * @param {number} a
@@ -53,8 +48,8 @@ function Destructuring({a, b}: {a: number, b: number}) {}
  */
 function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
 /**
- * @param {!Array<?, ?>} __0
- * @param {!Array<!Array<?>>} __1
+ * @param {!Array<?>} __0
+ * @param {!Array<?>} __1
  * @return {void}
  */
 function Destructuring3([a, b], [[c]]) {}

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -46,8 +46,7 @@ function x() { }
  * @see Nothing.
  */
 class RedundantJSDocShouldBeStripped {
-    constructor() {
-    }
+    constructor() { }
 }
 /**
  * This comment has code that needs to be escaped to pass Closure checking.

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,7 +1,7 @@
 goog.module('test_files.jsx.jsx');var module = module || {id: 'test_files/jsx/jsx.js'};let /** @type {!JSX.Element} */ simple = React.createElement("div", null);
 let /** @type {string} */ hello = 'hello';
-let /** @type {!JSX.Element} */ helloDiv = React.createElement("div", null, 
-    hello, 
-    "hello, world", 
+let /** @type {!JSX.Element} */ helloDiv = React.createElement("div", null,
+    hello,
+    "hello, world",
     React.createElement(Component, null));
 React.render(helloDiv, /** @type {!HTMLElement} */ ((document.body)));

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -11,8 +11,7 @@ class OptionalTest {
      * @param {string} a
      * @param {(undefined|string)=} b
      */
-    constructor(a, b) {
-    }
+    constructor(a, b) { }
     /**
      * @param {string=} c
      * @return {void}

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,6 +1,5 @@
 goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};class SuperTestBaseNoArg {
-    constructor() {
-    }
+    constructor() { }
 }
 class SuperTestBaseOneArg {
     /**


### PR DESCRIPTION
Check in new goldens for the remaining tests, as the remaining
changes are expected.

Affected tests:
- enum: changed internal warning message
- fields: added a missing semicolon
- functions: tuple emit has changed slightly
- jsdoc, optional, super: empty function emit has changed slightly
- jsx: whitespace changes

Finishes work in #295 to prepare for TS2.1.