### PR TITLE
Fix decorator downleveling in presence of 'export' statements.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -73,6 +73,13 @@ class ClassRewriter extends Rewriter {
         if (!commentNode.parent) return false;
         commentNode = commentNode.parent;
       }
+      // Go up one more level to VariableDeclarationStatement, where usually
+      // the comment lives. If the declaration has an 'export', the
+      // VDList.getFullText will not contain the comment.
+      if (commentNode.kind === ts.SyntaxKind.VariableDeclarationList) {
+        if (!commentNode.parent) return false;
+        commentNode = commentNode.parent;
+      }
       let range = ts.getLeadingCommentRanges(commentNode.getFullText(), 0);
       if (!range) return;
       for (let {pos, end} of range) {

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -131,6 +131,26 @@ static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|nu
 }`);
         });
 
+        it('transforms decorated classes with an exported annotation declaration', () => {
+          expect(translate(`
+/** @Annotation */ export let Test: Function;
+@Test
+class Foo {
+  field: string;
+}`).output).to.equal(`
+/** @Annotation */ export let Test: Function;
+
+class Foo {
+  field: string;
+static decorators: DecoratorInvocation[] = [
+{ type: Test },
+];
+/** @nocollapse */
+static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+];
+}`);
+        });
+
         it('accepts various complicated decorators', () => {
           expect(translate(`
 /** @Annotation */ let Test1: Function;


### PR DESCRIPTION
The AST corresponding to '/** foo */ export let x;' contains
VariableDeclarationStatement -> VariableDeclarationList ->
VariableDeclaration.

Without 'export' both VDList and VDStatement's full texts contain
the comment, but in presence of 'export' only VDStatement does.