### PR TITLE
add @implements tag on "implements" clauses

### DIFF
--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,0 +1,29 @@
+goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};class Super {
+    /**
+     * @return {?}
+     */
+    superFunc() { }
+}
+class Implements {
+    /**
+     * @return {?}
+     */
+    interfaceFunc() { }
+    /**
+     * @return {?}
+     */
+    superFunc() { }
+}
+class Extends extends Super {
+    /**
+     * @return {?}
+     */
+    interfaceFunc() { }
+}
+// Verify Closure accepts the various casts.
+let /** @type {?} */ interfaceVar;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+let /** @type {?} */ superVar;
+superVar = new Implements();
+superVar = new Extends();

--- a/test_files/class.untyped/class.ts
+++ b/test_files/class.untyped/class.ts
@@ -1,0 +1,26 @@
+interface Interface {
+  interfaceFunc(): void;
+}
+
+class Super {
+  superFunc(): void {}
+}
+
+class Implements implements Interface, Super {
+  interfaceFunc(): void {}
+  superFunc(): void {}
+}
+
+class Extends extends Super implements Interface {
+  interfaceFunc(): void {}
+}
+
+// Verify Closure accepts the various casts.
+let interfaceVar: Interface;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+
+let superVar: Super;
+superVar = new Implements();
+superVar = new Extends();
+

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -1,0 +1,35 @@
+interface Interface {
+  interfaceFunc(): void;
+}
+class Super {
+/**
+ * @return {?}
+ */
+superFunc(): void {}
+}
+class Implements implements Interface, Super {
+/**
+ * @return {?}
+ */
+interfaceFunc(): void {}
+/**
+ * @return {?}
+ */
+superFunc(): void {}
+}
+class Extends extends Super implements Interface {
+/**
+ * @return {?}
+ */
+interfaceFunc(): void {}
+}
+
+// Verify Closure accepts the various casts.
+let /** @type {?} */ interfaceVar: Interface;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+
+let /** @type {?} */ superVar: Super;
+superVar = new Implements();
+superVar = new Extends();
+

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,0 +1,40 @@
+goog.module('test_files.class.class');var module = module || {id: 'test_files/class/class.js'};/** @record */
+function Interface() { }
+/** @type {function(): void} */
+Interface.prototype.interfaceFunc;
+class Super {
+    /**
+     * @return {void}
+     */
+    superFunc() { }
+}
+/**
+ * @implements {Interface}
+ * @extends {Super}
+ */
+class Implements {
+    /**
+     * @return {void}
+     */
+    interfaceFunc() { }
+    /**
+     * @return {void}
+     */
+    superFunc() { }
+}
+/**
+ * @implements {Interface}
+ */
+class Extends extends Super {
+    /**
+     * @return {void}
+     */
+    interfaceFunc() { }
+}
+// Verify Closure accepts the various casts.
+let /** @type {!Interface} */ interfaceVar;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+let /** @type {!Super} */ superVar;
+superVar = new Implements();
+superVar = new Extends();

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -1,0 +1,26 @@
+interface Interface {
+  interfaceFunc(): void;
+}
+
+class Super {
+  superFunc(): void {}
+}
+
+class Implements implements Interface, Super {
+  interfaceFunc(): void {}
+  superFunc(): void {}
+}
+
+class Extends extends Super implements Interface {
+  interfaceFunc(): void {}
+}
+
+// Verify Closure accepts the various casts.
+let interfaceVar: Interface;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+
+let superVar: Super;
+superVar = new Implements();
+superVar = new Extends();
+

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,0 +1,47 @@
+
+/** @record */
+function Interface() {}
+/** @type {function(): void} */
+Interface.prototype.interfaceFunc;
+interface Interface {
+  interfaceFunc(): void;
+}
+class Super {
+/**
+ * @return {void}
+ */
+superFunc(): void {}
+}
+/**
+ * @implements {Interface}
+ * @extends {Super}
+ */
+class Implements implements Interface, Super {
+/**
+ * @return {void}
+ */
+interfaceFunc(): void {}
+/**
+ * @return {void}
+ */
+superFunc(): void {}
+}
+/**
+ * @implements {Interface}
+ */
+class Extends extends Super implements Interface {
+/**
+ * @return {void}
+ */
+interfaceFunc(): void {}
+}
+
+// Verify Closure accepts the various casts.
+let /** @type {!Interface} */ interfaceVar: Interface;
+interfaceVar = new Implements();
+interfaceVar = new Extends();
+
+let /** @type {!Super} */ superVar: Super;
+superVar = new Implements();
+superVar = new Extends();
+

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -49,6 +49,9 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
 function SuperTestInterface() { }
 /** @type {number} */
 SuperTestInterface.prototype.foo;
+/**
+ * @implements {SuperTestInterface}
+ */
 class SuperTestDerivedInterface {
 }
 function SuperTestDerivedInterface_tsickle_Closure_declarations() {

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -61,6 +61,9 @@ SuperTestInterface.prototype.foo;
 interface SuperTestInterface {
   foo: number;
 }
+/**
+ * @implements {SuperTestInterface}
+ */
 class SuperTestDerivedInterface implements SuperTestInterface {
   foo: number;
 }


### PR DESCRIPTION
This is made a bit subtle by the fact that Closure and TypeScript
disagree about how "implements" works around classes.  However,
with the logic implemented here a simple test that verifies
assignment compatibility passes.

Fixes #284.