### PR TITLE
don't emit @implements on non-types

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -740,7 +740,14 @@ class Annotator extends ClosureRewriter {
             // But it's fine to translate TS "implements Class" into Closure
             // "@extends {Class}" because this is just a type hint.
             let sym = this.program.getTypeChecker().getSymbolAtLocation(impl.expression);
-            if (sym.flags & ts.SymbolFlags.Class) tagName = 'extends';
+            if (sym.flags & ts.SymbolFlags.Class) {
+              tagName = 'extends';
+            } else if (sym.flags & ts.SymbolFlags.Value) {
+              // If the symbol was already in the value namespace, then it will
+              // not be a type in the Closure output (because Closure collapses
+              // the type and value namespaces).  Just ignore the implements.
+              continue;
+            }
 
             jsDoc.push({tagName, type: impl.getText()});
           }

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -27,3 +27,11 @@ interfaceVar = new Extends();
 let /** @type {?} */ superVar;
 superVar = new Implements();
 superVar = new Extends();
+const /** @type {?} */ Zone = (function (global) {
+    class Zone2 {
+    }
+    function Zone2_tsickle_Closure_declarations() {
+        /** @type {?} */
+        Zone2.prototype.zone;
+    }
+});

--- a/test_files/class.untyped/class.ts
+++ b/test_files/class.untyped/class.ts
@@ -24,3 +24,12 @@ let superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
 
+// Reproduce issue #333: type/value namespace collision.
+// Because Zone is both a type and a value, the interface will be dropped
+// when converting to Closure, so the "implements" should be ignored.
+interface Zone { zone: string; }
+const Zone = (function(global: any) {
+  class Zone2 implements Zone {
+    zone: string;
+  }
+});

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -33,3 +33,18 @@ let /** @type {?} */ superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
 
+// Reproduce issue #333: type/value namespace collision.
+// Because Zone is both a type and a value, the interface will be dropped
+// when converting to Closure, so the "implements" should be ignored.
+interface Zone { zone: string; }
+const /** @type {?} */ Zone = (function(global: any) {
+class Zone2 implements Zone {
+    zone: string;
+  }
+
+function Zone2_tsickle_Closure_declarations() {
+/** @type {?} */
+Zone2.prototype.zone;
+}
+
+});

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -38,3 +38,11 @@ interfaceVar = new Extends();
 let /** @type {!Super} */ superVar;
 superVar = new Implements();
 superVar = new Extends();
+const /** @type {function(?): void} */ Zone = (function (global) {
+    class Zone2 {
+    }
+    function Zone2_tsickle_Closure_declarations() {
+        /** @type {string} */
+        Zone2.prototype.zone;
+    }
+});

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -24,3 +24,12 @@ let superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
 
+// Reproduce issue #333: type/value namespace collision.
+// Because Zone is both a type and a value, the interface will be dropped
+// when converting to Closure, so the "implements" should be ignored.
+interface Zone { zone: string; }
+const Zone = (function(global: any) {
+  class Zone2 implements Zone {
+    zone: string;
+  }
+});

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -45,3 +45,18 @@ let /** @type {!Super} */ superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
 
+// Reproduce issue #333: type/value namespace collision.
+// Because Zone is both a type and a value, the interface will be dropped
+// when converting to Closure, so the "implements" should be ignored.
+interface Zone { zone: string; }
+const /** @type {function(?): void} */ Zone = (function(global: any) {
+class Zone2 implements Zone {
+    zone: string;
+  }
+
+function Zone2_tsickle_Closure_declarations() {
+/** @type {string} */
+Zone2.prototype.zone;
+}
+
+});


### PR DESCRIPTION
When a symbol is both a type and a value, we don't emit the
type in the Closure code.  This means we also can't add a
@implements tag to the type.

Fixes #333.