### PR TITLE
Fixes a bug in decorator downleveling.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -70,18 +70,18 @@ class ClassRewriter extends Rewriter {
       // Not handling PropertyAccess expressions here, because they are
       // filtered earlier.
       if (commentNode.kind === ts.SyntaxKind.VariableDeclaration) {
-        if (!commentNode.parent) return false;
+        if (!commentNode.parent) continue;
         commentNode = commentNode.parent;
       }
       // Go up one more level to VariableDeclarationStatement, where usually
       // the comment lives. If the declaration has an 'export', the
       // VDList.getFullText will not contain the comment.
       if (commentNode.kind === ts.SyntaxKind.VariableDeclarationList) {
-        if (!commentNode.parent) return false;
+        if (!commentNode.parent) continue;
         commentNode = commentNode.parent;
       }
       let range = ts.getLeadingCommentRanges(commentNode.getFullText(), 0);
-      if (!range) return;
+      if (!range) continue;
       for (let {pos, end} of range) {
         let jsDocText = commentNode.getFullText().substring(pos, end);
         if (jsDocText.includes('@Annotation')) return true;

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -5,6 +5,11 @@ function annotationDecorator(a: Object, b: string) {}
 
 function classDecorator(t: any) { return t; }
 
+type classAnnotation = {};
+// should not matter, but getDeclarations() returns this node too.
+// Comment comes after statement so that type alias does not have
+// a comment on its own.
+
 /** @Annotation */
 function classAnnotation(t: any) { return t; }
 

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -16,6 +16,8 @@ function annotationDecorator(a, b) { }
  * @return {?}
  */
 function classDecorator(t) { return t; }
+/** @typedef {!Object} */
+var classAnnotation;
 /**
  * \@Annotation
  * @param {?} t

--- a/test_files/decorator/decorator.ts
+++ b/test_files/decorator/decorator.ts
@@ -5,6 +5,11 @@ function annotationDecorator(a: Object, b: string) {}
 
 function classDecorator(t: any) { return t; }
 
+type classAnnotation = {};
+// should not matter, but getDeclarations() returns this node too.
+// Comment comes after statement so that type alias does not have
+// a comment on its own.
+
 /** @Annotation */
 function classAnnotation(t: any) { return t; }
 

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -17,6 +17,11 @@ function annotationDecorator(a: Object, b: string) {}
  * @return {?}
  */
 function classDecorator(t: any) { return t; }
+
+type classAnnotation = {};
+/** @typedef {!Object} */
+var classAnnotation;
+
 /**
  * \@Annotation
  * @param {?} t


### PR DESCRIPTION
It only affects decorator symbols that have multiple declarations.
Because in TS a symbol can exist in both value and type namespaces,
it is possible to have two or more declaration sites even for a
decorator value.