### PR TITLE
be careful around type aliases in @implements

### DIFF
--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -20,18 +20,38 @@ class Extends extends Super {
      */
     interfaceFunc() { }
 }
+class ImplementsTypeAlias {
+    /**
+     * @return {?}
+     */
+    interfaceFunc() { }
+    /**
+     * @return {?}
+     */
+    superFunc() { }
+}
 // Verify Closure accepts the various casts.
 let /** @type {?} */ interfaceVar;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 let /** @type {?} */ superVar;
 superVar = new Implements();
 superVar = new Extends();
-const /** @type {?} */ Zone = (function (global) {
-    class Zone2 {
-    }
-    function Zone2_tsickle_Closure_declarations() {
-        /** @type {?} */
-        Zone2.prototype.zone;
-    }
-});
+superVar = new ImplementsTypeAlias();
+/**
+ * @return {?}
+ */
+function Zone() { }
+class ZoneImplementsInterface {
+}
+function ZoneImplementsInterface_tsickle_Closure_declarations() {
+    /** @type {?} */
+    ZoneImplementsInterface.prototype.zone;
+}
+class ZoneImplementsAlias {
+}
+function ZoneImplementsAlias_tsickle_Closure_declarations() {
+    /** @type {?} */
+    ZoneImplementsAlias.prototype.zone;
+}

--- a/test_files/class.untyped/class.ts
+++ b/test_files/class.untyped/class.ts
@@ -6,6 +6,7 @@ class Super {
   superFunc(): void {}
 }
 
+
 class Implements implements Interface, Super {
   interfaceFunc(): void {}
   superFunc(): void {}
@@ -15,21 +16,34 @@ class Extends extends Super implements Interface {
   interfaceFunc(): void {}
 }
 
+// It's also legal to alias a type and then implement the alias.
+type TypeAlias = Interface;
+class ImplementsTypeAlias implements TypeAlias, Super {
+  interfaceFunc(): void {}
+  superFunc(): void {}
+}
+
 // Verify Closure accepts the various casts.
 let interfaceVar: Interface;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 
 let superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
+superVar = new ImplementsTypeAlias();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped
-// when converting to Closure, so the "implements" should be ignored.
+// when converting to Closure, so the "implements" should be ignored for
+// both the direct use and the use via a typedef.
 interface Zone { zone: string; }
-const Zone = (function(global: any) {
-  class Zone2 implements Zone {
-    zone: string;
-  }
-});
+function Zone() {}
+class ZoneImplementsInterface implements Zone {
+  zone: string;
+}
+type ZoneAlias = Zone;
+class ZoneImplementsAlias implements ZoneAlias {
+  zone: string;
+}

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -24,27 +24,54 @@ class Extends extends Super implements Interface {
 interfaceFunc(): void {}
 }
 
+// It's also legal to alias a type and then implement the alias.
+type TypeAlias = Interface;
+class ImplementsTypeAlias implements TypeAlias, Super {
+/**
+ * @return {?}
+ */
+interfaceFunc(): void {}
+/**
+ * @return {?}
+ */
+superFunc(): void {}
+}
+
 // Verify Closure accepts the various casts.
 let /** @type {?} */ interfaceVar: Interface;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 
 let /** @type {?} */ superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
+superVar = new ImplementsTypeAlias();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped
-// when converting to Closure, so the "implements" should be ignored.
+// when converting to Closure, so the "implements" should be ignored for
+// both the direct use and the use via a typedef.
 interface Zone { zone: string; }
-const /** @type {?} */ Zone = (function(global: any) {
-class Zone2 implements Zone {
-    zone: string;
-  }
-
-function Zone2_tsickle_Closure_declarations() {
-/** @type {?} */
-Zone2.prototype.zone;
+/**
+ * @return {?}
+ */
+function Zone() {}
+class ZoneImplementsInterface implements Zone {
+  zone: string;
 }
 
-});
+function ZoneImplementsInterface_tsickle_Closure_declarations() {
+/** @type {?} */
+ZoneImplementsInterface.prototype.zone;
+}
+
+type ZoneAlias = Zone;
+class ZoneImplementsAlias implements ZoneAlias {
+  zone: string;
+}
+
+function ZoneImplementsAlias_tsickle_Closure_declarations() {
+/** @type {?} */
+ZoneImplementsAlias.prototype.zone;
+}

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -31,18 +31,46 @@ class Extends extends Super {
      */
     interfaceFunc() { }
 }
+/** @typedef {!Interface} */
+var TypeAlias;
+/**
+ * @implements {TypeAlias}
+ * @extends {Super}
+ */
+class ImplementsTypeAlias {
+    /**
+     * @return {void}
+     */
+    interfaceFunc() { }
+    /**
+     * @return {void}
+     */
+    superFunc() { }
+}
 // Verify Closure accepts the various casts.
 let /** @type {!Interface} */ interfaceVar;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 let /** @type {!Super} */ superVar;
 superVar = new Implements();
 superVar = new Extends();
-const /** @type {function(?): void} */ Zone = (function (global) {
-    class Zone2 {
-    }
-    function Zone2_tsickle_Closure_declarations() {
-        /** @type {string} */
-        Zone2.prototype.zone;
-    }
-});
+superVar = new ImplementsTypeAlias();
+/**
+ * @return {void}
+ */
+function Zone() { }
+class ZoneImplementsInterface {
+}
+function ZoneImplementsInterface_tsickle_Closure_declarations() {
+    /** @type {string} */
+    ZoneImplementsInterface.prototype.zone;
+}
+/** @typedef {?} */
+var ZoneAlias;
+class ZoneImplementsAlias {
+}
+function ZoneImplementsAlias_tsickle_Closure_declarations() {
+    /** @type {string} */
+    ZoneImplementsAlias.prototype.zone;
+}

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -6,6 +6,7 @@ class Super {
   superFunc(): void {}
 }
 
+
 class Implements implements Interface, Super {
   interfaceFunc(): void {}
   superFunc(): void {}
@@ -15,21 +16,34 @@ class Extends extends Super implements Interface {
   interfaceFunc(): void {}
 }
 
+// It's also legal to alias a type and then implement the alias.
+type TypeAlias = Interface;
+class ImplementsTypeAlias implements TypeAlias, Super {
+  interfaceFunc(): void {}
+  superFunc(): void {}
+}
+
 // Verify Closure accepts the various casts.
 let interfaceVar: Interface;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 
 let superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
+superVar = new ImplementsTypeAlias();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped
-// when converting to Closure, so the "implements" should be ignored.
+// when converting to Closure, so the "implements" should be ignored for
+// both the direct use and the use via a typedef.
 interface Zone { zone: string; }
-const Zone = (function(global: any) {
-  class Zone2 implements Zone {
-    zone: string;
-  }
-});
+function Zone() {}
+class ZoneImplementsInterface implements Zone {
+  zone: string;
+}
+type ZoneAlias = Zone;
+class ZoneImplementsAlias implements ZoneAlias {
+  zone: string;
+}

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,3 +1,5 @@
+Warning at test_files/class/class.ts:46:1: type/symbol conflict for Zone, using {?} for now
+====
 
 /** @record */
 function Interface() {}
@@ -36,27 +38,64 @@ class Extends extends Super implements Interface {
 interfaceFunc(): void {}
 }
 
+// It's also legal to alias a type and then implement the alias.
+type TypeAlias = Interface;
+/** @typedef {!Interface} */
+var TypeAlias;
+
+/**
+ * @implements {TypeAlias}
+ * @extends {Super}
+ */
+class ImplementsTypeAlias implements TypeAlias, Super {
+/**
+ * @return {void}
+ */
+interfaceFunc(): void {}
+/**
+ * @return {void}
+ */
+superFunc(): void {}
+}
+
 // Verify Closure accepts the various casts.
 let /** @type {!Interface} */ interfaceVar: Interface;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
+interfaceVar = new ImplementsTypeAlias();
 
 let /** @type {!Super} */ superVar: Super;
 superVar = new Implements();
 superVar = new Extends();
+superVar = new ImplementsTypeAlias();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped
-// when converting to Closure, so the "implements" should be ignored.
+// when converting to Closure, so the "implements" should be ignored for
+// both the direct use and the use via a typedef.
 interface Zone { zone: string; }
-const /** @type {function(?): void} */ Zone = (function(global: any) {
-class Zone2 implements Zone {
-    zone: string;
-  }
-
-function Zone2_tsickle_Closure_declarations() {
-/** @type {string} */
-Zone2.prototype.zone;
+/**
+ * @return {void}
+ */
+function Zone() {}
+class ZoneImplementsInterface implements Zone {
+  zone: string;
 }
 
-});
+function ZoneImplementsInterface_tsickle_Closure_declarations() {
+/** @type {string} */
+ZoneImplementsInterface.prototype.zone;
+}
+
+type ZoneAlias = Zone;
+/** @typedef {?} */
+var ZoneAlias;
+
+class ZoneImplementsAlias implements ZoneAlias {
+  zone: string;
+}
+
+function ZoneImplementsAlias_tsickle_Closure_declarations() {
+/** @type {string} */
+ZoneImplementsAlias.prototype.zone;
+}


### PR DESCRIPTION
It's legal to @implements a type alias, but we need to be careful
to not @implements a type alias that maps back to a symbol that
we didn't emit a type for due to the symbol being both a type
and a value.  Yikes!

To ensure I got this right, I added both a test for:
- implementing an ordinary interface via an alias
- a more complex reproduction of the zone issue

Fixes #333 harder.