### PR TITLE
Support angular's tsc_wrapped in with the tsickle_compiler_host.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,7 @@ export function toClosureJS(
     es5Mode: false,
     tsickleTyped: !settings.isUntyped,
     prelude: '',
+    convertIndexImportShorthand: false,
   };
 
   const tsickleHost: tsickle.TsickleHost = {
@@ -168,7 +169,7 @@ export function toClosureJS(
   // Reparse and reload the program, inserting the tsickle output in
   // place of the original source.
   let host = new tsickle.TsickleCompilerHost(
-      hostDelegate, tsickleCompilerHostOptions, tsickleHost,
+      hostDelegate, options, tsickleCompilerHostOptions, tsickleHost,
       {oldProgram: program, pass: tsickle.Pass.CLOSURIZE});
   program = ts.createProgram(fileNames, options, host);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,12 +148,10 @@ export function toClosureJS(
     }
   }
 
-  const tsickleCompilerHostOptions: tsickle.TsickleCompilerHostOptions = {
+  const tsickleCompilerHostOptions: tsickle.Options = {
     googmodule: true,
     es5Mode: false,
-    tsickleTyped: !settings.isUntyped,
-    prelude: '',
-    convertIndexImportShorthand: false,
+    untyped: settings.isUntyped,
   };
 
   const tsickleHost: tsickle.TsickleHost = {

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -11,34 +11,14 @@ import * as ts from 'typescript';
 
 import * as jsdoc from './jsdoc';
 import {getIdentifierText, Rewriter, unescapeName} from './rewriter';
+import {Options} from './tsickle_compiler_host';
 import {assertTypeChecked, TypeTranslator} from './type-translator';
 import {toArray} from './util';
 
 export {convertDecorators} from './decorator-annotator';
 export {processES5} from './es5processor';
 export {FileMap, ModulesManifest} from './modules_manifest';
-export {Pass, TsickleCompilerHost, TsickleCompilerHostOptions, TsickleHost} from './tsickle_compiler_host';
-
-export interface Options {
-  /**
-   * If true, convert every type to the Closure {?} type, which means
-   * "don't check types".
-   */
-  untyped?: boolean;
-  /**
-   * If provided a function that logs an internal warning.
-   * These warnings are not actionable by an end user and should be hidden
-   * by default.
-   */
-  logWarning?: (warning: ts.Diagnostic) => void;
-  /** If provided, a set of paths whose types should always generate as {?}. */
-  typeBlackListPaths?: Set<string>;
-  /**
-   * Convert shorthand "/index" imports to full path (include the "/index").
-   * Annotation will be slower because every import must be resolved.
-   */
-  convertIndexImportShorthand?: boolean;
-}
+export {Options, Pass, TsickleCompilerHost, TsickleHost} from './tsickle_compiler_host';
 
 export interface Output {
   /** The TypeScript source with Closure annotations inserted. */

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -20,12 +20,28 @@ export enum Pass {
   CLOSURIZE
 }
 
-export interface TsickleCompilerHostOptions {
-  googmodule: boolean;
-  es5Mode: boolean;
-  tsickleTyped: boolean;
-  prelude: string;
-  convertIndexImportShorthand: boolean;
+export interface Options {
+  googmodule?: boolean;
+  es5Mode?: boolean;
+  prelude?: string;
+  /**
+   * If true, convert every type to the Closure {?} type, which means
+   * "don't check types".
+   */
+  untyped?: boolean;
+  /**
+   * If provided a function that logs an internal warning.
+   * These warnings are not actionable by an end user and should be hidden
+   * by default.
+   */
+  logWarning?: (warning: ts.Diagnostic) => void;
+  /** If provided, a set of paths whose types should always generate as {?}. */
+  typeBlackListPaths?: Set<string>;
+  /**
+   * Convert shorthand "/index" imports to full path (include the "/index").
+   * Annotation will be slower because every import must be resolved.
+   */
+  convertIndexImportShorthand?: boolean;
 }
 
 /**
@@ -84,7 +100,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
 
   constructor(
       private delegate: ts.CompilerHost, private tscOptions: ts.CompilerOptions,
-      private options: TsickleCompilerHostOptions, private environment: TsickleHost,
+      private options: Options, private environment: TsickleHost,
       private runConfiguration?: {oldProgram: ts.Program, pass: Pass}) {}
 
   /**
@@ -217,12 +233,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     // this means we don't process e.g. lib.d.ts.
     if (isDefinitions && this.environment.shouldSkipTsickleProcessing(fileName)) return sourceFile;
 
-    let {output, externs, diagnostics, sourceMap} = annotate(
-        program, sourceFile, {
-          untyped: !this.options.tsickleTyped,
-          convertIndexImportShorthand: this.options.convertIndexImportShorthand
-        },
-        this.delegate, this.tscOptions);
+    let {output, externs, diagnostics, sourceMap} =
+        annotate(program, sourceFile, this.options, this.delegate, this.tscOptions);
     if (externs) {
       this.externs[fileName] = externs;
     }

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -25,6 +25,7 @@ export interface TsickleCompilerHostOptions {
   es5Mode: boolean;
   tsickleTyped: boolean;
   prelude: string;
+  convertIndexImportShorthand: boolean;
 }
 
 /**
@@ -82,8 +83,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   private tsickleSourceMaps = new Map<string, SourceMapGenerator>();
 
   constructor(
-      private delegate: ts.CompilerHost, private options: TsickleCompilerHostOptions,
-      private environment: TsickleHost,
+      private delegate: ts.CompilerHost, private tscOptions: ts.CompilerOptions,
+      private options: TsickleCompilerHostOptions, private environment: TsickleHost,
       private runConfiguration?: {oldProgram: ts.Program, pass: Pass}) {}
 
   /**
@@ -216,8 +217,12 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     // this means we don't process e.g. lib.d.ts.
     if (isDefinitions && this.environment.shouldSkipTsickleProcessing(fileName)) return sourceFile;
 
-    let {output, externs, diagnostics, sourceMap} =
-        annotate(program, sourceFile, {untyped: !this.options.tsickleTyped});
+    let {output, externs, diagnostics, sourceMap} = annotate(
+        program, sourceFile, {
+          untyped: !this.options.tsickleTyped,
+          convertIndexImportShorthand: this.options.convertIndexImportShorthand
+        },
+        this.delegate, this.tscOptions);
     if (externs) {
       this.externs[fileName] = externs;
     }

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -139,6 +139,7 @@ function decoratorDownlevelCompiler(
     es5Mode: false,
     tsickleTyped: !settings.isUntyped,
     prelude: '',
+    convertIndexImportShorthand: false,
   };
 
   const tsickleHost: tsickle.TsickleHost = {
@@ -154,7 +155,7 @@ function decoratorDownlevelCompiler(
   // Reparse and reload the program, inserting the tsickle output in
   // place of the original source.
   let host = new tsickle.TsickleCompilerHost(
-      hostDelegate, tsickleCompilerHostOptions, tsickleHost,
+      hostDelegate, options, tsickleCompilerHostOptions, tsickleHost,
       {oldProgram: program, pass: tsickle.Pass.DECORATOR_DOWNLEVEL});
   program = ts.createProgram(fileNames, options, host);
 

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -134,12 +134,10 @@ function decoratorDownlevelCompiler(
     }
   }
 
-  const tsickleCompilerHostOptions: tsickle.TsickleCompilerHostOptions = {
+  const tsickleCompilerHostOptions: tsickle.Options = {
     googmodule: true,
     es5Mode: false,
-    tsickleTyped: !settings.isUntyped,
-    prelude: '',
-    convertIndexImportShorthand: false,
+    untyped: settings.isUntyped,
   };
 
   const tsickleHost: tsickle.TsickleHost = {

--- a/test/e2e_tsickle_compiler_host_test.ts
+++ b/test/e2e_tsickle_compiler_host_test.ts
@@ -9,9 +9,7 @@ import {createOutputRetainingCompilerHost, createSourceReplacingCompilerHost} fr
 const tsickleCompilerHostOptions = {
   googmodule: true,
   es5Mode: false,
-  tsickleTyped: false,
-  prelude: '',
-  convertIndexImportShorthand: false,
+  untyped: true,
 };
 
 const tsickleHost = {

--- a/test/e2e_tsickle_compiler_host_test.ts
+++ b/test/e2e_tsickle_compiler_host_test.ts
@@ -11,6 +11,7 @@ const tsickleCompilerHostOptions = {
   es5Mode: false,
   tsickleTyped: false,
   prelude: '',
+  convertIndexImportShorthand: false,
 };
 
 const tsickleHost = {
@@ -21,11 +22,13 @@ const tsickleHost = {
 };
 
 describe('tsickle compiler host', () => {
-  function makeProgram(fileName: string, source: string): [ts.Program, ts.CompilerHost] {
+  function makeProgram(
+      fileName: string, source: string): [ts.Program, ts.CompilerHost, ts.CompilerOptions] {
     // TsickleCompilerHost wants a ts.Program, which is the result of
     // parsing and typechecking the code before tsickle processing.
     // So we must create and run the entire stack of CompilerHost.
-    let compilerHostDelegate = ts.createCompilerHost({target: ts.ScriptTarget.ES5});
+    let options: ts.CompilerOptions = {target: ts.ScriptTarget.ES5};
+    let compilerHostDelegate = ts.createCompilerHost(options);
     const sources = new Map<string, string>();
     sources.set(ts.sys.resolvePath(fileName), source);
     let compilerHost = createSourceReplacingCompilerHost(sources, compilerHostDelegate);
@@ -33,13 +36,13 @@ describe('tsickle compiler host', () => {
     // To get types resolved, you must first call getPreEmitDiagnostics.
     let diags = formatDiagnostics(ts.getPreEmitDiagnostics(program));
     expect(diags).to.equal('');
-    return [program, compilerHost];
+    return [program, compilerHost, options];
   }
 
   it('applies tsickle transforms', () => {
-    const [program, compilerHost] = makeProgram('foo.ts', 'let x: number = 123;');
+    const [program, compilerHost, options] = makeProgram('foo.ts', 'let x: number = 123;');
     const host = new TsickleCompilerHost(
-        compilerHost, tsickleCompilerHostOptions, tsickleHost,
+        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
         {oldProgram: program, pass: Pass.CLOSURIZE});
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     // NOTE(evanm): currently tsickle just removes all types; we will
@@ -48,19 +51,19 @@ describe('tsickle compiler host', () => {
   });
 
   it('lowers decorators to annotations', () => {
-    const [program, compilerHost] =
+    const [program, compilerHost, options] =
         makeProgram('foo.ts', '/** @Annotation */ const A: Function = null; @A class B {}');
     const host = new TsickleCompilerHost(
-        compilerHost, tsickleCompilerHostOptions, tsickleHost,
+        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
         {oldProgram: program, pass: Pass.DECORATOR_DOWNLEVEL});
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.contain('static decorators');
   });
 
   it(`doesn't transform .d.ts files`, () => {
-    const [program, compilerHost] = makeProgram('foo.d.ts', 'declare let x: number;');
+    const [program, compilerHost, options] = makeProgram('foo.d.ts', 'declare let x: number;');
     const host = new TsickleCompilerHost(
-        compilerHost, tsickleCompilerHostOptions, tsickleHost,
+        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
         {oldProgram: program, pass: Pass.CLOSURIZE});
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.match(/^declare let x: number/);
@@ -68,9 +71,10 @@ describe('tsickle compiler host', () => {
 
   it(`does goog module rewriting`, () => {
     const jsFiles = new Map<string, string>();
-    const compilerHost = createOutputRetainingCompilerHost(
-        jsFiles, ts.createCompilerHost({target: ts.ScriptTarget.ES5}));
-    const host = new TsickleCompilerHost(compilerHost, tsickleCompilerHostOptions, tsickleHost);
+    const options = {target: ts.ScriptTarget.ES5};
+    const compilerHost = createOutputRetainingCompilerHost(jsFiles, ts.createCompilerHost(options));
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
 
     host.writeFile('foo.js', `console.log('hello');`, false);
     expect(jsFiles.get('foo.js'))


### PR DESCRIPTION
Add an option to TsickleCompilerHostOptions and supporting plumbing to convert index import shorthand, which the angular version of tsc_wrapped needs.