### PR TITLE
Add support for ts.SymbolFlags.ObjectLiteral

### DIFF
--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -339,7 +339,8 @@ export class TypeTranslator {
         return '?';
       }
 
-      if (type.symbol.flags === ts.SymbolFlags.TypeLiteral) {
+      if (type.symbol.flags === ts.SymbolFlags.TypeLiteral ||
+          type.symbol.flags === ts.SymbolFlags.ObjectLiteral) {
         return this.translateTypeLiteral(type);
       } else if (
           type.symbol.flags === ts.SymbolFlags.Function ||
@@ -358,7 +359,6 @@ export class TypeTranslator {
       Tuple
       Mapped
       Instantiated
-      ObjectLiteral
       EvolvingArray
       ObjectLiteralPatternWithComputedProperties
     */

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -74,3 +74,15 @@ function ZoneImplementsAlias_tsickle_Closure_declarations() {
     /** @type {string} */
     ZoneImplementsAlias.prototype.zone;
 }
+class HasObjectliteral {
+    constructor() {
+        this.foo = {
+            bar: 0,
+            baz: ''
+        };
+    }
+}
+function HasObjectliteral_tsickle_Closure_declarations() {
+    /** @type {{bar: number, baz: string}} */
+    HasObjectliteral.prototype.foo;
+}

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -47,3 +47,10 @@ type ZoneAlias = Zone;
 class ZoneImplementsAlias implements ZoneAlias {
   zone: string;
 }
+
+class HasObjectliteral {
+  public foo = {
+    bar: 0,
+    baz: ''
+  };
+}

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -99,3 +99,15 @@ function ZoneImplementsAlias_tsickle_Closure_declarations() {
 /** @type {string} */
 ZoneImplementsAlias.prototype.zone;
 }
+
+class HasObjectliteral {
+public foo = {
+    bar: 0,
+    baz: ''
+  };
+}
+
+function HasObjectliteral_tsickle_Closure_declarations() {
+/** @type {{bar: number, baz: string}} */
+HasObjectliteral.prototype.foo;
+}


### PR DESCRIPTION
This allows members of classes that are complex object literals to retain type safety. For example,

```
class Thing {
  public foo = {
    bar:4,
    baz:'asdf'
  };
}
```
emits
```
function Thing_tsickle_Closure_declarations() {
    /** @type {{bar:number,baz:string}} */
    Thing.prototype.foo;
}
```
rather than
```
function Thing_tsickle_Closure_declarations() {
    /** @type {?} */
    Thing.prototype.foo;
}
```