### PR TITLE
Handle source maps with relative paths specifying their sources.

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -171,7 +171,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     const tscSourceMapConsumer = this.sourceMapTextToConsumer(tscSourceMapText);
     const tscSourceMapGenerator = this.sourceMapConsumerToGenerator(tscSourceMapConsumer);
 
-    const fileDir = path.parse(filePath).dir;
+    const fileDir = path.dirname(filePath);
 
     if (this.tsickleSourceMaps.size > 0) {
       // TODO(lucassloan): remove when the .d.ts has the correct types

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -155,7 +155,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     return SourceMapGenerator.fromSourceMap(sourceMapConsumer);
   }
 
-  sourceMapGeneratorToConsumerWithFileName(sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
+  sourceMapGeneratorToConsumerWithFileName(
+      sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
     const rawSourceMap = sourceMapGenerator.toJSON();
     rawSourceMap.file = fileName;
     return new SourceMapConsumer(rawSourceMap);
@@ -175,21 +176,23 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     if (this.tsickleSourceMaps.size > 0) {
       // TODO(lucassloan): remove when the .d.ts has the correct types
       for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
-        const resolvedSourceFileName = this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));
+        const resolvedSourceFileName =
+            this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));
         const tsickleSourceMapGenerator = this.tsickleSourceMaps.get(resolvedSourceFileName)!;
-        const tsickleSourceMapConsumer =
-            this.sourceMapGeneratorToConsumerWithFileName(tsickleSourceMapGenerator, sourceFileName);
+        const tsickleSourceMapConsumer = this.sourceMapGeneratorToConsumerWithFileName(
+            tsickleSourceMapGenerator, sourceFileName);
         tscSourceMapGenerator.applySourceMap(tsickleSourceMapConsumer);
       }
     }
     if (this.decoratorDownlevelSourceMaps.size > 0) {
       // TODO(lucassloan): remove when the .d.ts has the correct types
       for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
-        const resolvedSourceFileName = this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));
+        const resolvedSourceFileName =
+            this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));
         const decoratorDownlevelSourceMapGenerator =
             this.decoratorDownlevelSourceMaps.get(resolvedSourceFileName)!;
-        const decoratorDownlevelSourceMapConsumer =
-            this.sourceMapGeneratorToConsumerWithFileName(decoratorDownlevelSourceMapGenerator, sourceFileName);
+        const decoratorDownlevelSourceMapConsumer = this.sourceMapGeneratorToConsumerWithFileName(
+            decoratorDownlevelSourceMapGenerator, sourceFileName);
         tscSourceMapGenerator.applySourceMap(decoratorDownlevelSourceMapConsumer);
       }
     }
@@ -216,7 +219,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   private downlevelDecorators(
       sourceFile: ts.SourceFile, program: ts.Program, fileName: string,
       languageVersion: ts.ScriptTarget): ts.SourceFile {
-    this.decoratorDownlevelSourceMaps.set(this.getCanonicalFileName(sourceFile.path), new SourceMapGenerator());
+    this.decoratorDownlevelSourceMaps.set(
+        this.getCanonicalFileName(sourceFile.path), new SourceMapGenerator());
     if (this.environment.shouldSkipTsickleProcessing(fileName)) return sourceFile;
     let fileContent = sourceFile.text;
     const converted = convertDecorators(program.getTypeChecker(), sourceFile);
@@ -228,14 +232,16 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       return sourceFile;
     }
     fileContent = converted.output + ANNOTATION_SUPPORT;
-    this.decoratorDownlevelSourceMaps.set(this.getCanonicalFileName(sourceFile.path), converted.sourceMap);
+    this.decoratorDownlevelSourceMaps.set(
+        this.getCanonicalFileName(sourceFile.path), converted.sourceMap);
     return ts.createSourceFile(fileName, fileContent, languageVersion, true);
   }
 
   private closurize(
       sourceFile: ts.SourceFile, program: ts.Program, fileName: string,
       languageVersion: ts.ScriptTarget): ts.SourceFile {
-    this.tsickleSourceMaps.set(this.getCanonicalFileName(sourceFile.path), new SourceMapGenerator());
+    this.tsickleSourceMaps.set(
+        this.getCanonicalFileName(sourceFile.path), new SourceMapGenerator());
     let isDefinitions = /\.d\.ts$/.test(fileName);
     // Don't tsickle-process any d.ts that isn't a compilation target;
     // this means we don't process e.g. lib.d.ts.

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -156,11 +156,11 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   }
 
   /**
-  * Tsc identifies source files by their relative path to the output file.  Since
-  * there's no easy way to identify these relative paths when tsickle generates its
-  * own source maps, we patch them with the file name from the tsc source maps
-  * before composing them.
-  */
+   * Tsc identifies source files by their relative path to the output file.  Since
+   * there's no easy way to identify these relative paths when tsickle generates its
+   * own source maps, we patch them with the file name from the tsc source maps
+   * before composing them.
+   */
   sourceMapGeneratorToConsumerWithFileName(
       sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
     const rawSourceMap = sourceMapGenerator.toJSON();
@@ -174,7 +174,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     return new SourceMapConsumer(sourceMapJson);
   }
 
-  getSourceMapKey(outputFilePath: string, sourceFileName:string): string {
+  getSourceMapKey(outputFilePath: string, sourceFileName: string): string {
     const fileDir = path.dirname(outputFilePath);
 
     return this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -158,6 +158,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   sourceMapGeneratorToConsumerWithFileName(
       sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
     const rawSourceMap = sourceMapGenerator.toJSON();
+    rawSourceMap.sources = [fileName];
     rawSourceMap.file = fileName;
     return new SourceMapConsumer(rawSourceMap);
   }
@@ -176,6 +177,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     if (this.tsickleSourceMaps.size > 0) {
       // TODO(lucassloan): remove when the .d.ts has the correct types
       for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
+        console.log(sourceFileName);
         const resolvedSourceFileName =
             this.getCanonicalFileName(path.resolve(fileDir, sourceFileName));
         const tsickleSourceMapGenerator = this.tsickleSourceMaps.get(resolvedSourceFileName)!;

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -68,7 +68,7 @@ describe('source maps', () => {
     expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
         .to.equal('input1.ts', 'first input file');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).line)
-        .to.equal(4, 'fouth string definition');
+        .to.equal(4, 'fourth string definition');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).source)
         .to.equal('input2.ts', 'second input file');
   });
@@ -98,7 +98,7 @@ describe('source maps', () => {
     expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
         .to.equal('a/b/input1.ts', 'first input file');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).line)
-        .to.equal(4, 'fouth string definition');
+        .to.equal(4, 'fourth string definition');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).source)
         .to.equal('a/c/input2.ts', 'second input file');
   });
@@ -131,7 +131,7 @@ describe('source maps', () => {
     expect(sourceMap.originalPositionFor({line: methodLine, column: methodColumn}).source)
         .to.equal('input1.ts', 'method input file');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).line)
-        .to.equal(4, 'fouth string definition');
+        .to.equal(4, 'fourth string definition');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).source)
         .to.equal('input2.ts', 'second input file');
   });

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -96,11 +96,11 @@ describe('source maps', () => {
     expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).line)
         .to.equal(3, 'first string definition');
     expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
-        .to.equal('a/b/input1.ts', 'first input file');
+        .to.equal('../b/input1.ts', 'first input file');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).line)
         .to.equal(4, 'fourth string definition');
     expect(sourceMap.originalPositionFor({line: stringBLine, column: stringBColumn}).source)
-        .to.equal('a/c/input2.ts', 'second input file');
+        .to.equal('../c/input2.ts', 'second input file');
   });
 
   it('works when not decorator downleveling some input', function() {


### PR DESCRIPTION
If the input and output files are in different directories, tsc specifies the source file as a relative path from the output file to the input file.  This wasn't exposed until I tried to incorporate the source map changes into Angular's tsc_wrapped.