### PR TITLE
Inline source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^2.1.0"
   },
   "devDependencies": {
+    "@types/base-64": "^0.1.0",
     "@types/chai": "^3.4.32",
     "@types/glob": "^5.0.29",
     "@types/google-closure-compiler": "0.0.18",
@@ -28,6 +29,7 @@
     "@types/node": "^6.0.38",
     "@types/source-map": "^0.1.27",
     "@types/source-map-support": "^0.2.27",
+    "base-64": "^0.1.0",
     "chai": "^3.5.0",
     "clang-format": "^1.0.45",
     "glob": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "typescript": "^2.1.0"
   },
   "devDependencies": {
-    "@types/base-64": "^0.1.0",
     "@types/chai": "^3.4.32",
     "@types/glob": "^5.0.29",
     "@types/google-closure-compiler": "0.0.18",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/node": "^6.0.38",
     "@types/source-map": "^0.1.27",
     "@types/source-map-support": "^0.2.27",
-    "base-64": "^0.1.0",
     "chai": "^3.5.0",
     "clang-format": "^1.0.45",
     "glob": "^7.0.0",

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -218,7 +218,9 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     const sourceMapJson = extractInlineSourceMap(tscOutputText);
     const composedSourceMap = this.combineSourceMaps(filePath, sourceMapJson);
     const encodedSourceMap = encode(composedSourceMap);
-    return tscOutputText.replace(new RegExp("//# sourceMappingURL=data:application/json;base64,(.*)"), `//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
+    return tscOutputText.replace(
+        new RegExp('//# sourceMappingURL=data:application/json;base64,(.*)'),
+        `//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
   }
 
   convertCommonJsToGoogModule(fileName: string, content: string): string {

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -1,4 +1,3 @@
-import {encode} from 'base-64';
 import * as path from 'path';
 import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
@@ -217,7 +216,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   combineInlineSourceMaps(filePath: string, compiledJsWithInlineSourceMap: string): string {
     const sourceMapJson = extractInlineSourceMap(compiledJsWithInlineSourceMap);
     const composedSourceMap = this.combineSourceMaps(filePath, sourceMapJson);
-    const encodedSourceMap = encode(composedSourceMap);
+    const encodedSourceMap = Buffer.from(composedSourceMap, 'utf8').toString('base64');
     return compiledJsWithInlineSourceMap.replace(
         new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'm'),
         `//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -214,12 +214,12 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     return tscSourceMapGenerator.toString();
   }
 
-  combineInlineSourceMaps(filePath: string, tscOutputText: string): string {
-    const sourceMapJson = extractInlineSourceMap(tscOutputText);
+  combineInlineSourceMaps(filePath: string, compiledJsWithInlineSourceMap: string): string {
+    const sourceMapJson = extractInlineSourceMap(compiledJsWithInlineSourceMap);
     const composedSourceMap = this.combineSourceMaps(filePath, sourceMapJson);
     const encodedSourceMap = encode(composedSourceMap);
-    return tscOutputText.replace(
-        new RegExp('//# sourceMappingURL=data:application/json;base64,(.*)'),
+    return compiledJsWithInlineSourceMap.replace(
+        new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'm'),
         `//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+import {decode} from 'base-64';
 import * as ts from 'typescript';
 
 /**
@@ -87,4 +88,11 @@ export function createOutputRetainingCompilerHost(
       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]): void {
     outputFiles.set(fileName, content);
   }
+}
+
+export function extractInlineSourceMap(source: string): string {
+    const regex = new RegExp("//# sourceMappingURL=data:application/json;base64,(.*)");
+    const result = regex.exec(source)!;
+    const base64EncodedMap = result[1];
+    return decode(base64EncodedMap);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,8 +91,8 @@ export function createOutputRetainingCompilerHost(
 }
 
 export function extractInlineSourceMap(source: string): string {
-    const regex = new RegExp("//# sourceMappingURL=data:application/json;base64,(.*)");
-    const result = regex.exec(source)!;
-    const base64EncodedMap = result[1];
-    return decode(base64EncodedMap);
+  const regex = new RegExp('//# sourceMappingURL=data:application/json;base64,(.*)');
+  const result = regex.exec(source)!;
+  const base64EncodedMap = result[1];
+  return decode(base64EncodedMap);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,3 @@
-import {decode} from 'base-64';
-import * as ts from 'typescript';
-
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -12,6 +9,9 @@ import * as ts from 'typescript';
 // toArray is a temporary function to help in the use of
 // ES6 maps and sets when running on node 4, which doesn't
 // support Iterators completely.
+
+import {decode} from 'base-64';
+import * as ts from 'typescript';
 
 export function toArray<T>(iterator: Iterator<T>): T[] {
   const array: T[] = [];
@@ -91,7 +91,7 @@ export function createOutputRetainingCompilerHost(
 }
 
 export function extractInlineSourceMap(source: string): string {
-  const regex = new RegExp('//# sourceMappingURL=data:application/json;base64,(.*)');
+  const regex = new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'm');
   const result = regex.exec(source)!;
   const base64EncodedMap = result[1];
   return decode(base64EncodedMap);

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,6 @@
 // ES6 maps and sets when running on node 4, which doesn't
 // support Iterators completely.
 
-import {decode} from 'base-64';
 import * as ts from 'typescript';
 
 export function toArray<T>(iterator: Iterator<T>): T[] {
@@ -94,5 +93,5 @@ export function extractInlineSourceMap(source: string): string {
   const regex = new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'm');
   const result = regex.exec(source)!;
   const base64EncodedMap = result[1];
-  return decode(base64EncodedMap);
+  return Buffer.from(base64EncodedMap, 'base64').toString('utf8');
 }

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {decode} from 'base-64';
 import {assert, expect} from 'chai';
 import * as path from 'path';
 import {SourceMapConsumer} from 'source-map';
@@ -16,7 +15,7 @@ import * as cliSupport from '../src/cli_support';
 import {Settings} from '../src/main';
 import * as tsickle from '../src/tsickle';
 import {toArray} from '../src/util';
-import {createOutputRetainingCompilerHost, createSourceReplacingCompilerHost} from '../src/util';
+import {createOutputRetainingCompilerHost, createSourceReplacingCompilerHost, extractInlineSourceMap} from '../src/util';
 
 describe('source maps', () => {
   it('composes source maps with tsc', function() {
@@ -292,7 +291,7 @@ function compile(
 
   let sourceMapJson: any;
   if (inlineSourceMap) {
-      sourceMapJson = getInlineSourceMap(compiledJS);
+      sourceMapJson = extractInlineSourceMap(compiledJS);
   }
   else {
     sourceMapJson = getFileWithName(outFile + '.map', closure.jsFiles);
@@ -300,14 +299,6 @@ function compile(
   const sourceMap = new SourceMapConsumer(sourceMapJson);
 
   return {compiledJS, sourceMap};
-}
-
-function getInlineSourceMap(source: string): string | null {
-    console.log(source);
-    const regex = new RegExp("//# sourceMappingURL=data:application/json;base64,(.*)");
-    const result = regex.exec(source)!;
-    const base64EncodedMap = result[1];
-    return decode(base64EncodedMap);
 }
 
 function getFileWithName(filename: string, files: Map<string, string>): string|undefined {

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -255,8 +255,8 @@ function tsickleCompiler(
 }
 
 function compile(
-    sources: Map<string, string>, outFile = 'output.js',
-    filesNotToProcess = new Set<string>(), inlineSourceMap = false): {compiledJS: string, sourceMap: SourceMapConsumer} {
+    sources: Map<string, string>, outFile = 'output.js', filesNotToProcess = new Set<string>(),
+    inlineSourceMap = false): {compiledJS: string, sourceMap: SourceMapConsumer} {
   const resolvedSources = new Map<string, string>();
   for (const fileName of toArray(sources.keys())) {
     resolvedSources.set(ts.sys.resolvePath(fileName), sources.get(fileName));
@@ -266,16 +266,21 @@ function compile(
 
   let compilerOptions: ts.CompilerOptions;
   if (inlineSourceMap) {
-      compilerOptions = {inlineSourceMap: inlineSourceMap, outFile: outFile, experimentalDecorators: true};
-  }
-  else {
-      compilerOptions = {sourceMap: true, outFile: outFile, experimentalDecorators: true};
+    compilerOptions = {
+      inlineSourceMap: inlineSourceMap,
+      outFile: outFile,
+      experimentalDecorators: true
+    };
+  } else {
+    compilerOptions = {sourceMap: true, outFile: outFile, experimentalDecorators: true};
   }
 
-  const closure = tsickleCompiler(compilerOptions, toArray(sources.keys()), {isUntyped: false} as Settings, diagnostics, resolvedSources, filesNotToProcess);
+  const closure = tsickleCompiler(
+      compilerOptions, toArray(sources.keys()), {isUntyped: false} as Settings, diagnostics,
+      resolvedSources, filesNotToProcess);
 
   if (!closure) {
-          console.error(tsickle.formatDiagnostics(diagnostics));
+    console.error(tsickle.formatDiagnostics(diagnostics));
     assert.fail();
     // TODO(lucassloan): remove when the .d.ts has the correct types
     return {compiledJS: '', sourceMap: new SourceMapConsumer('' as any)};
@@ -291,9 +296,8 @@ function compile(
 
   let sourceMapJson: any;
   if (inlineSourceMap) {
-      sourceMapJson = extractInlineSourceMap(compiledJS);
-  }
-  else {
+    sourceMapJson = extractInlineSourceMap(compiledJS);
+  } else {
     sourceMapJson = getFileWithName(outFile + '.map', closure.jsFiles);
   }
   const sourceMap = new SourceMapConsumer(sourceMapJson);

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -272,7 +272,11 @@ function compile(
       experimentalDecorators: true
     };
   } else {
-    compilerOptions = {sourceMap: true, outFile: outFile, experimentalDecorators: true};
+    compilerOptions = {
+      sourceMap: true,
+      outFile: outFile,
+      experimentalDecorators: true,
+    };
   }
 
   const closure = tsickleCompiler(

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {decode} from 'base-64';
 import {assert, expect} from 'chai';
 import * as path from 'path';
 import {SourceMapConsumer} from 'source-map';
@@ -160,6 +161,32 @@ describe('source maps', () => {
 
     expect(sourceMap.originalPositionFor(methodPosition).line).to.equal(6, 'method position');
   });
+
+  it('composes inline sources', function() {
+    const sources = new Map<string, string>();
+    sources.set('input.ts', `
+      class X { field: number; }
+      let x : string = 'a string';
+      let y : string = 'another string';
+      let z : string = x + y;`);
+
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const {compiledJS, sourceMap} = compile(sources, undefined, undefined, true);
+
+    const {line: stringXLine, column: stringXColumn} = getLineAndColumn(compiledJS, 'a string');
+    const {line: stringYLine, column: stringYColumn} =
+        getLineAndColumn(compiledJS, 'another string');
+
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).line)
+        .to.equal(3, 'first string definition');
+    expect(sourceMap.originalPositionFor({line: stringXLine, column: stringXColumn}).source)
+        .to.equal('input.ts', 'input file name');
+    expect(sourceMap.originalPositionFor({line: stringYLine, column: stringYColumn}).line)
+        .to.equal(4, 'second string definition');
+    expect(sourceMap.originalPositionFor({line: stringYLine, column: stringYColumn}).source)
+        .to.equal('input.ts', 'input file name');
+
+  });
 });
 
 function getLineAndColumn(source: string, token: string): {line: number, column: number} {
@@ -230,7 +257,7 @@ function tsickleCompiler(
 
 function compile(
     sources: Map<string, string>, outFile = 'output.js',
-    filesNotToProcess = new Set<string>()): {compiledJS: string, sourceMap: SourceMapConsumer} {
+    filesNotToProcess = new Set<string>(), inlineSourceMap = false): {compiledJS: string, sourceMap: SourceMapConsumer} {
   const resolvedSources = new Map<string, string>();
   for (const fileName of toArray(sources.keys())) {
     resolvedSources.set(ts.sys.resolvePath(fileName), sources.get(fileName));
@@ -238,12 +265,18 @@ function compile(
 
   const diagnostics: ts.Diagnostic[] = [];
 
-  const closure = tsickleCompiler(
-      {sourceMap: true, outFile: outFile, experimentalDecorators: true} as ts.CompilerOptions,
-      toArray(sources.keys()), {isUntyped: false} as Settings, diagnostics, resolvedSources,
-      filesNotToProcess);
+  let compilerOptions: ts.CompilerOptions;
+  if (inlineSourceMap) {
+      compilerOptions = {inlineSourceMap: inlineSourceMap, outFile: outFile, experimentalDecorators: true};
+  }
+  else {
+      compilerOptions = {sourceMap: true, outFile: outFile, experimentalDecorators: true};
+  }
+
+  const closure = tsickleCompiler(compilerOptions, toArray(sources.keys()), {isUntyped: false} as Settings, diagnostics, resolvedSources, filesNotToProcess);
 
   if (!closure) {
+          console.error(tsickle.formatDiagnostics(diagnostics));
     assert.fail();
     // TODO(lucassloan): remove when the .d.ts has the correct types
     return {compiledJS: '', sourceMap: new SourceMapConsumer('' as any)};
@@ -257,10 +290,24 @@ function compile(
     return {compiledJS: '', sourceMap: new SourceMapConsumer('' as any)};
   }
 
-  const sourceMapJson: any = getFileWithName(outFile + '.map', closure.jsFiles);
+  let sourceMapJson: any;
+  if (inlineSourceMap) {
+      sourceMapJson = getInlineSourceMap(compiledJS);
+  }
+  else {
+    sourceMapJson = getFileWithName(outFile + '.map', closure.jsFiles);
+  }
   const sourceMap = new SourceMapConsumer(sourceMapJson);
 
   return {compiledJS, sourceMap};
+}
+
+function getInlineSourceMap(source: string): string | null {
+    console.log(source);
+    const regex = new RegExp("//# sourceMappingURL=data:application/json;base64,(.*)");
+    const result = regex.exec(source)!;
+    const base64EncodedMap = result[1];
+    return decode(base64EncodedMap);
 }
 
 function getFileWithName(filename: string, files: Map<string, string>): string|undefined {


### PR DESCRIPTION
We currently handle source maps that are in separate files from the compiled js tsc outputs, but we don't handle source maps in a comment in the compiled js.  This PR handles extracting the source map from the comment, composing it, and adding a new comment with the composed map.