### PR TITLE
Support preexisisting inline source maps.

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -1,0 +1,83 @@
+import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
+
+/**
+ * Return a new RegExp object every time we want one because the
+ * RegExp object has internal state that we don't want to persist
+ * between different logical uses.
+ */
+function getInlineSourceMapRegex(): RegExp {
+  return new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'mg');
+}
+
+export function containsInlineSourceMap(source: string): boolean {
+  return getInlineSourceMapCount(source) > 0;
+}
+
+export function getInlineSourceMapCount(source: string): number {
+  const match = source.match(getInlineSourceMapRegex());
+  return match ? match.length : 0;
+}
+
+export function extractInlineSourceMap(source: string): string {
+  const inlineSourceMapRegex = getInlineSourceMapRegex();
+  let previousResult: RegExpExecArray|null = null;
+  let result: RegExpExecArray|null = null;
+  // We want to extract the last source map in the source file
+  // since that's probably the most recent one added.  We keep
+  // matching against the source until we don't get a result,
+  // then we use the previous result.
+  do {
+    previousResult = result;
+    result = inlineSourceMapRegex.exec(source);
+  } while (result !== null);
+  const base64EncodedMap = previousResult![1];
+  return Buffer.from(base64EncodedMap, 'base64').toString('utf8');
+}
+
+export function removeInlineSourceMap(source: string): string {
+  return source.replace(getInlineSourceMapRegex(), '');
+}
+
+/**
+ * Sets the source map inline in the file.  If there's an existing inline source
+ * map, it clobbers it.
+ */
+export function setInlineSourceMap(source: string, sourceMap: string): string {
+  const encodedSourceMap = Buffer.from(sourceMap, 'utf8').toString('base64');
+  if (containsInlineSourceMap(source)) {
+    return source.replace(
+        getInlineSourceMapRegex(),
+        `//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
+  } else {
+    return `${source}\n//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`;
+  }
+}
+
+export function sourceMapConsumerToGenerator(sourceMapConsumer: SourceMapConsumer):
+    SourceMapGenerator {
+  return SourceMapGenerator.fromSourceMap(sourceMapConsumer);
+}
+
+/**
+ * Tsc identifies source files by their relative path to the output file.  Since
+ * there's no easy way to identify these relative paths when tsickle generates its
+ * own source maps, we patch them with the file name from the tsc source maps
+ * before composing them.
+ */
+export function sourceMapGeneratorToConsumerWithFileName(
+    sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
+  const rawSourceMap = sourceMapGenerator.toJSON();
+  rawSourceMap.sources = [fileName];
+  rawSourceMap.file = fileName;
+  return new SourceMapConsumer(rawSourceMap);
+}
+
+export function sourceMapTextToConsumer(sourceMapText: string): SourceMapConsumer {
+  const sourceMapJson: any = sourceMapText;
+  return new SourceMapConsumer(sourceMapJson);
+}
+
+export function sourceMapTextToGenerator(sourceMapText: string): SourceMapGenerator {
+  const sourceMapJson: any = sourceMapText;
+  return SourceMapGenerator.fromSourceMap(sourceMapTextToConsumer(sourceMapJson));
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,10 +88,3 @@ export function createOutputRetainingCompilerHost(
     outputFiles.set(fileName, content);
   }
 }
-
-export function extractInlineSourceMap(source: string): string {
-  const regex = new RegExp('^//# sourceMappingURL=data:application/json;base64,(.*)$', 'm');
-  const result = regex.exec(source)!;
-  const base64EncodedMap = result[1];
-  return Buffer.from(base64EncodedMap, 'base64').toString('utf8');
-}

--- a/test/e2e_tsickle_compiler_host_test.ts
+++ b/test/e2e_tsickle_compiler_host_test.ts
@@ -51,9 +51,9 @@ describe('tsickle compiler host', () => {
 
   it('applies tsickle transforms', () => {
     const [program, compilerHost, options] = makeProgram('foo.ts', 'let x: number = 123;');
-    const host = new TsickleCompilerHost(
-        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
-        {oldProgram: program, pass: Pass.CLOSURIZE});
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
+    host.reconfigureForRun(program, Pass.CLOSURIZE);
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.contain('/** @type {?} */');
   });
@@ -61,9 +61,9 @@ describe('tsickle compiler host', () => {
   it('applies tsickle transforms with types', () => {
     const [program, compilerHost, options] = makeProgram('foo.ts', 'let x: number = 123;');
     tsickleCompilerHostOptions.untyped = false;
-    const host = new TsickleCompilerHost(
-        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
-        {oldProgram: program, pass: Pass.CLOSURIZE});
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
+    host.reconfigureForRun(program, Pass.CLOSURIZE);
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.contain('/** @type {number} */');
   });
@@ -76,9 +76,9 @@ describe('tsickle compiler host', () => {
     const [program, compilerHost, options] = makeMultiFileProgram(sources);
     tsickleCompilerHostOptions.typeBlackListPaths = new Set([ts.sys.resolvePath('banned.d.ts')]);
     tsickleCompilerHostOptions.untyped = false;
-    const host = new TsickleCompilerHost(
-        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
-        {oldProgram: program, pass: Pass.CLOSURIZE});
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
+    host.reconfigureForRun(program, Pass.CLOSURIZE);
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.contain('/** @type {?} */ b: Banned');
   });
@@ -86,18 +86,18 @@ describe('tsickle compiler host', () => {
   it('lowers decorators to annotations', () => {
     const [program, compilerHost, options] =
         makeProgram('foo.ts', '/** @Annotation */ const A: Function = null; @A class B {}');
-    const host = new TsickleCompilerHost(
-        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
-        {oldProgram: program, pass: Pass.DECORATOR_DOWNLEVEL});
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
+    host.reconfigureForRun(program, Pass.DECORATOR_DOWNLEVEL);
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.contain('static decorators');
   });
 
   it(`doesn't transform .d.ts files`, () => {
     const [program, compilerHost, options] = makeProgram('foo.d.ts', 'declare let x: number;');
-    const host = new TsickleCompilerHost(
-        compilerHost, options, tsickleCompilerHostOptions, tsickleHost,
-        {oldProgram: program, pass: Pass.CLOSURIZE});
+    const host =
+        new TsickleCompilerHost(compilerHost, options, tsickleCompilerHostOptions, tsickleHost);
+    host.reconfigureForRun(program, Pass.CLOSURIZE);
     const f = host.getSourceFile(program.getRootFileNames()[0], ts.ScriptTarget.ES5);
     expect(f.text).to.match(/^declare let x: number/);
   });

--- a/test/source_map_utils_test.ts
+++ b/test/source_map_utils_test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {expect} from 'chai';
+
+import * as sourceMapUtils from '../src/source_map_utils';
+
+const SOURCE_MAP_COMMENT = '//# sourceMappingURL=data:application/json;base64,';
+
+describe('source map utils', () => {
+  it('calculates the number of inline source maps', () => {
+    const one = `${SOURCE_MAP_COMMENT}foo`;
+    expect(sourceMapUtils.getInlineSourceMapCount(one)).to.equal(1);
+
+    const two = `${SOURCE_MAP_COMMENT}foo\n${SOURCE_MAP_COMMENT}bar`;
+    expect(sourceMapUtils.getInlineSourceMapCount(two)).to.equal(2);
+  });
+
+  it('extracts the last inline source map', () => {
+    const foo = `${SOURCE_MAP_COMMENT}${encode('foo')}`;
+    expect(sourceMapUtils.extractInlineSourceMap(foo)).to.equal('foo');
+
+    const foobar = `${SOURCE_MAP_COMMENT}${encode('foo')}\n${SOURCE_MAP_COMMENT}${encode('bar')}`;
+    expect(sourceMapUtils.extractInlineSourceMap(foobar)).to.equal('bar');
+
+    const foobarbaz = `${SOURCE_MAP_COMMENT}${encode('foo')}\n${SOURCE_MAP_COMMENT}${encode(
+        'bar')}\n${SOURCE_MAP_COMMENT}${encode('baz')}`;
+    expect(sourceMapUtils.extractInlineSourceMap(foobarbaz)).to.equal('baz');
+  });
+});
+
+function encode(s: string): string {
+  return Buffer.from(s, 'utf8').toString('base64');
+}


### PR DESCRIPTION
If tsickle is passed sources that include inline source maps (eg ts 'sources' produced by ngc), compose those source maps with the source maps produced by running tsickle.