### PR TITLE
Don't canonicalize the fileName in write file.

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -141,7 +141,6 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       fileName: string, content: string, writeByteOrderMark: boolean,
       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]): void {
     if (path.extname(fileName) !== '.map') {
-      fileName = this.delegate.getCanonicalFileName(fileName);
       if (this.options.googmodule && !isDtsFileName(fileName)) {
         content = this.convertCommonJsToGoogModule(fileName, content);
       }


### PR DESCRIPTION
We need to canonicalize for g3 support, but we should (and already do) leave that to the host delegate.

Fixes #365