### PR TITLE
enable more tsc strictness

### DIFF
--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -7,7 +7,6 @@
  */
 
 import {assert, expect} from 'chai';
-import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import {Settings, toClosureJS} from '../src/main';
@@ -24,8 +23,7 @@ describe('toClosureJS', () => {
     if (!closure) {
       diagnostics.forEach(v => console.log(JSON.stringify(v)));
       assert.fail();
-      // TODO(lucassloan): remove when the .d.ts has the correct types
-      return {compiledJS: '', sourceMap: new SourceMapConsumer('' as any)};
+      return;
     }
 
     expect(closure.externs).to.contain(`/** @const */

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -325,4 +325,5 @@ function getFileWithName(filename: string, files: Map<string, string>): string|u
       return files.get(filepath);
     }
   }
+  return undefined;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,15 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "declaration": true,
-    "noImplicitAny": true,
     "noEmitOnError": true,
     "target": "es5",
     "lib": ["es5", "es6", "es2015.collection", "es2015.iterable", "dom"],
     "jsx": "react",
     "types": ["node", "mocha"],
+
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
     "strictNullChecks": true
   },
   "files": [


### PR DESCRIPTION
Group the compiler strictness flags together and enable some more.
Fix a few minor bugs they turn up.

(I believe this would've caught the stray "this" seen in a recent CL.)