### PR TITLE
Fix source map key generation on windows.

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -165,7 +165,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   }
 
   getSourceMapKeyForSourceFile(sourceFile: ts.SourceFile): string {
-    return this.getCanonicalFileName(sourceFile.path);
+    return this.getCanonicalFileName(path.resolve(sourceFile.path));
   }
 
   stripAndStoreExistingSourceMap(sourceFile: ts.SourceFile): ts.SourceFile {


### PR DESCRIPTION
path.resolve() returns paths with '\\' on Windows, but typescript always uses '/' in paths regardless of platform.  If we use path.resolve in one of the sourceMapKey methods, we have to use it in the other.

Fixes #371 