### PR TITLE
Fix a bug where tsickle would try to extract a non-existent source map.

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -18,7 +18,7 @@ export function getInlineSourceMapCount(source: string): number {
   return match ? match.length : 0;
 }
 
-export function extractInlineSourceMap(source: string): string {
+export function extractInlineSourceMap(source: string): string|null {
   const inlineSourceMapRegex = getInlineSourceMapRegex();
   let previousResult: RegExpExecArray|null = null;
   let result: RegExpExecArray|null = null;
@@ -30,7 +30,8 @@ export function extractInlineSourceMap(source: string): string {
     previousResult = result;
     result = inlineSourceMapRegex.exec(source);
   } while (result !== null);
-  const base64EncodedMap = previousResult![1];
+  if (!previousResult) return null;
+  const base64EncodedMap = previousResult[1];
   return Buffer.from(base64EncodedMap, 'base64').toString('utf8');
 }
 

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -171,6 +171,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   stripAndStoreExistingSourceMap(sourceFile: ts.SourceFile): ts.SourceFile {
     if (sourceMapUtils.containsInlineSourceMap(sourceFile.text)) {
       const sourceMapJson = sourceMapUtils.extractInlineSourceMap(sourceFile.text);
+      if (!sourceMapJson) return sourceFile;
       const sourceMap = sourceMapUtils.sourceMapTextToGenerator(sourceMapJson);
 
       const stripedSourceText = sourceMapUtils.removeInlineSourceMap(sourceFile.text);
@@ -238,6 +239,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
 
   combineInlineSourceMaps(filePath: string, compiledJsWithInlineSourceMap: string): string {
     const sourceMapJson = sourceMapUtils.extractInlineSourceMap(compiledJsWithInlineSourceMap);
+    if (!sourceMapJson) return compiledJsWithInlineSourceMap;
     const composedSourceMap = this.combineSourceMaps(filePath, sourceMapJson);
     return sourceMapUtils.setInlineSourceMap(compiledJsWithInlineSourceMap, composedSourceMap);
   }


### PR DESCRIPTION
@LucasSloan it seems that our e2e source map tests are less e2e than we'd like. I ran into this when syncing to g3. Can you take a look at improving our test coverage here, maybe by converting e2e_source_map test to run the fill compiler host?