### PR TITLE
Emit non-value symbols (e.g. interfaces, types) as typedef aliases.

### DIFF
--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,9 +1,11 @@
 goog.module('test_files.declare_export.declare_export');var module = module || {id: 'test_files/declare_export/declare_export.js'};
-exports.ExportDeclaredIf = ExportDeclaredIf;
+/** @typedef {ExportDeclaredIf} */
+exports.ExportDeclaredIf;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;
 exports.ExportDeclaredClass = ExportDeclaredClass;
 ;
 exports.exportedDeclaredFn = exportedDeclaredFn;
 exports.multiExportedDeclaredVar1 = window.multiExportedDeclaredVar1;
 exports.multiExportedDeclaredVar2 = window.multiExportedDeclaredVar2;
-exports.X = X;
+/** @typedef {X} */
+exports.X;

--- a/test_files/declare_export/declare_export.tsickle.ts
+++ b/test_files/declare_export/declare_export.tsickle.ts
@@ -1,5 +1,6 @@
 export declare interface ExportDeclaredIf { x: number; }
-exports.ExportDeclaredIf = ExportDeclaredIf;
+/** @typedef {ExportDeclaredIf} */
+exports.ExportDeclaredIf;
 
 export declare const exportedDeclaredVar: number;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;
@@ -16,5 +17,6 @@ exports.multiExportedDeclaredVar1 = window.multiExportedDeclaredVar1;
 exports.multiExportedDeclaredVar2 = window.multiExportedDeclaredVar2;
 
 export declare type X = string;
-exports.X = X;
+/** @typedef {X} */
+exports.X;
 


### PR DESCRIPTION
This avoids erroring at runtime because the symbol accessed is not
defined.