### PR TITLE
fix: pretend that arguments following an optional one are also optional

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -230,12 +230,16 @@ class ClosureRewriter extends Rewriter {
     }
 
     // Merge the JSDoc tags for each overloaded parameter.
+    let foundOptional = false;
     for (let i = 0; i < maxArgsCount; i++) {
       let paramTag = jsdoc.merge(paramTags[i]);
       // If any overload marks this param optional, mark it optional in the
-      // merged output.
-      const optional = paramTags[i].find(t => t.optional === true) !== undefined;
+      // merged output. Also mark parameters following optional as optional,
+      // even if they are not, since Closure restricts this, see
+      // https://github.com/google/closure-compiler/issues/2314
+      const optional = paramTags[i].find(t => t.optional === true) !== undefined || foundOptional;
       if (optional || i >= minArgsCount) {
+        foundOptional = true;
         paramTag.type += '=';
       }
       // If any overload marks this param as a ..., mark it ... in the

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -23,7 +23,7 @@ function Test3(a, b) { }
  * @return {string}
  */
 function Test4(a) {
-    return "a";
+    return 'a';
 }
 /**
  * @this {string}
@@ -70,3 +70,10 @@ function TestSplat3(...a) { }
 TestSplat(1, 2);
 TestSplat2(1, 2);
 TestSplat3(1, 2);
+/**
+ * @param {number=} x
+ * @param {number=} y
+ * @return {void}
+ */
+function defaultBeforeRequired(x = 1, y) { }
+defaultBeforeRequired(undefined, 2);

--- a/test_files/functions/functions.ts
+++ b/test_files/functions/functions.ts
@@ -10,7 +10,7 @@ function Test3(a: number, b: number) {}
 // Test overloaded functions.
 function Test4(a: number): string;
 function Test4(a: any): string {
-  return "a";
+  return 'a';
 }
 
 // Test a "this" param and a rest param in the same function.
@@ -20,7 +20,7 @@ TestThisAndRest.call('foo', 'bar', 3);
 function Destructuring({a, b}: {a: number, b: number}) {}
 function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
 function Destructuring3([a, b], [[c]]) {}
-Destructuring({a:1, b:2});
+Destructuring({a: 1, b: 2});
 Destructuring2([1, 2], [['a']]);
 Destructuring3([1, 2], [['a']]);
 
@@ -30,3 +30,6 @@ function TestSplat3(...a) {}
 TestSplat(1, 2);
 TestSplat2(1, 2);
 TestSplat3(1, 2);
+
+function defaultBeforeRequired(x = 1, y: number) {}
+defaultBeforeRequired(undefined, 2);

--- a/test_files/functions/functions.tsickle.ts
+++ b/test_files/functions/functions.tsickle.ts
@@ -27,7 +27,7 @@ function Test4(a: number): string;
  * @return {string}
  */
 function Test4(a: any): string {
-  return "a";
+  return 'a';
 }
 /**
  * @this {string}
@@ -53,7 +53,7 @@ function Destructuring2([a, b]: number[], [[c]]: string[][]) {}
  * @return {void}
  */
 function Destructuring3([a, b], [[c]]) {}
-Destructuring({a:1, b:2});
+Destructuring({a: 1, b: 2});
 Destructuring2([1, 2], [['a']]);
 Destructuring3([1, 2], [['a']]);
 /**
@@ -74,3 +74,10 @@ function TestSplat3(...a) {}
 TestSplat(1, 2);
 TestSplat2(1, 2);
 TestSplat3(1, 2);
+/**
+ * @param {number=} x
+ * @param {number=} y
+ * @return {void}
+ */
+function defaultBeforeRequired(x = 1, y: number) {}
+defaultBeforeRequired(undefined, 2);


### PR DESCRIPTION
Closure restricts this semantics beyond what ES6 permits