### PR TITLE
emit externs for "declare namespace 'foo'"

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1021,25 +1021,29 @@ class ExternsWriter extends ClosureRewriter {
       case ts.SyntaxKind.ModuleDeclaration:
         let decl = <ts.ModuleDeclaration>node;
         switch (decl.name.kind) {
-          case ts.SyntaxKind.Identifier:
+          case ts.SyntaxKind.Identifier: {
             // E.g. "declare namespace foo {"
             let name = getIdentifierText(decl.name as ts.Identifier);
             if (name === undefined) break;
-            namespace = namespace.concat(name);
             if (this.isFirstDeclaration(decl)) {
               this.emit('/** @const */\n');
-              if (namespace.length > 1) {
-                this.emit(`${namespace.join('.')} = {};\n`);
-              } else {
-                this.emit(`var ${namespace} = {};\n`);
-              }
+              this.writeExternsVariable(name, namespace, '{}');
             }
-            if (decl.body) this.visit(decl.body, namespace);
-            break;
-          case ts.SyntaxKind.StringLiteral:
+            if (decl.body) this.visit(decl.body, namespace.concat(name));
+          } break;
+          case ts.SyntaxKind.StringLiteral: {
             // E.g. "declare module 'foo' {" (note the quotes).
-            // Skip it.
-            break;
+            // We still want to emit externs for this module, but
+            // Closure doesn't really provide a mechanism for
+            // module-scoped externs.  For now, ignore the enclosing
+            // namespace (because this is declaring a top-level module)
+            // and emit into a fake namespace.
+            namespace = ['tsickle_declare_module'];
+            let name = (decl.name as ts.StringLiteral).text;
+            this.emit('/** @const */\n');
+            this.writeExternsVariable(name, namespace, '{}');
+            if (decl.body) this.visit(decl.body, namespace.concat(name));
+          } break;
           default:
             this.errorUnimplementedKind(decl.name, 'externs generation of namespace');
         }

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -31,7 +31,9 @@ declare namespace DeclareTestModule {
   type TypeAlias = string | number;
 }
 
-// This module is quoted, so it shouldn't show up in externs.js.
+// This module is quoted, which declares an importable module.
+// We can't model this in externs beyond making sure it's declared
+// in *some* namespace;
 declare module "DeclareTestQuotedModule" {
   var foo: string;
 }

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -1,4 +1,4 @@
-Warning at test_files/declare/declare.d.ts:81:1: anonymous type has no symbol
+Warning at test_files/declare/declare.d.ts:83:1: anonymous type has no symbol
 ====
 declare namespace DeclareTestModule {
   namespace inner {
@@ -33,7 +33,9 @@ declare namespace DeclareTestModule {
   type TypeAlias = string | number;
 }
 
-// This module is quoted, so it shouldn't show up in externs.js.
+// This module is quoted, which declares an importable module.
+// We can't model this in externs beyond making sure it's declared
+// in *some* namespace;
 declare module "DeclareTestQuotedModule" {
   var foo: string;
 }

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -56,6 +56,10 @@ DeclareTestModule.StringEnum.foo;
 
 /** @typedef {(string|number)} */
 DeclareTestModule.TypeAlias;
+/** @const */
+tsickle_declare_module.DeclareTestQuotedModule = {};
+ /** @type {string} */
+tsickle_declare_module.DeclareTestQuotedModule.foo;
  /** @type {number} */
 var declareGlobalVar;
 


### PR DESCRIPTION
We must emit *some* externs for these modules so that their fields
aren't renamed, but there's not an obvious namespace to emit them
in.  So just put them in a weird unused namespace.