### PR TITLE
Revert "Fix a bug where tsickle would try to extract a non-existent source map. (#378)"

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -18,7 +18,7 @@ export function getInlineSourceMapCount(source: string): number {
   return match ? match.length : 0;
 }
 
-export function extractInlineSourceMap(source: string): string|null {
+export function extractInlineSourceMap(source: string): string {
   const inlineSourceMapRegex = getInlineSourceMapRegex();
   let previousResult: RegExpExecArray|null = null;
   let result: RegExpExecArray|null = null;
@@ -30,8 +30,7 @@ export function extractInlineSourceMap(source: string): string|null {
     previousResult = result;
     result = inlineSourceMapRegex.exec(source);
   } while (result !== null);
-  if (!previousResult) return null;
-  const base64EncodedMap = previousResult[1];
+  const base64EncodedMap = previousResult![1];
   return Buffer.from(base64EncodedMap, 'base64').toString('utf8');
 }
 

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -171,7 +171,6 @@ export class TsickleCompilerHost implements ts.CompilerHost {
   stripAndStoreExistingSourceMap(sourceFile: ts.SourceFile): ts.SourceFile {
     if (sourceMapUtils.containsInlineSourceMap(sourceFile.text)) {
       const sourceMapJson = sourceMapUtils.extractInlineSourceMap(sourceFile.text);
-      if (!sourceMapJson) return sourceFile;
       const sourceMap = sourceMapUtils.sourceMapTextToGenerator(sourceMapJson);
 
       const stripedSourceText = sourceMapUtils.removeInlineSourceMap(sourceFile.text);
@@ -239,7 +238,6 @@ export class TsickleCompilerHost implements ts.CompilerHost {
 
   combineInlineSourceMaps(filePath: string, compiledJsWithInlineSourceMap: string): string {
     const sourceMapJson = sourceMapUtils.extractInlineSourceMap(compiledJsWithInlineSourceMap);
-    if (!sourceMapJson) return compiledJsWithInlineSourceMap;
     const composedSourceMap = this.combineSourceMaps(filePath, sourceMapJson);
     return sourceMapUtils.setInlineSourceMap(compiledJsWithInlineSourceMap, composedSourceMap);
   }


### PR DESCRIPTION
This reverts commit 6f14360b39dbbbf6643fd7f321a204dfc3aae355.

The commit was a quick fix to work around inline source maps breaking, this reversion clears the way for a real fix to be tested.