### PR TITLE
Replace inline source maps before goog.module rewriting.

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -145,11 +145,11 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       fileName: string, content: string, writeByteOrderMark: boolean,
       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]): void {
     if (path.extname(fileName) !== '.map') {
-      if (this.options.googmodule && !isDtsFileName(fileName)) {
-        content = this.convertCommonJsToGoogModule(fileName, content);
-      }
       if (!isDtsFileName(fileName) && this.tscOptions.inlineSourceMap) {
         content = this.combineInlineSourceMaps(fileName, content);
+      }
+      if (this.options.googmodule && !isDtsFileName(fileName)) {
+        content = this.convertCommonJsToGoogModule(fileName, content);
       }
     } else {
       content = this.combineSourceMaps(fileName, content);

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,7 +52,7 @@ export function createSourceReplacingCompilerHost(
       onError?: (message: string) => void): ts.SourceFile {
     let path: string = ts.sys.resolvePath(fileName);
     let sourceText = substituteSource.get(path);
-    if (sourceText) {
+    if (sourceText !== undefined) {
       return ts.createSourceFile(fileName, sourceText, languageVersion);
     }
     return delegate.getSourceFile(path, languageVersion, onError);


### PR DESCRIPTION
Given empty input files and a directive to produce inline source maps, tsc produces output containing only an inline source map.  Since we don't create any new lines when rewriting imports, we have to replace the source map before it gets concatenated with a goog.module() statement.