### PR TITLE
fix emitted externs namespace

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1075,7 +1075,7 @@ class ExternsWriter extends ClosureRewriter {
       case ts.SyntaxKind.ModuleDeclaration:
         let decl = <ts.ModuleDeclaration>node;
         switch (decl.name.kind) {
-          case ts.SyntaxKind.Identifier: {
+          case ts.SyntaxKind.Identifier:
             // E.g. "declare namespace foo {"
             let name = getIdentifierText(decl.name as ts.Identifier);
             if (name === undefined) break;
@@ -1084,20 +1084,32 @@ class ExternsWriter extends ClosureRewriter {
               this.writeExternsVariable(name, namespace, '{}');
             }
             if (decl.body) this.visit(decl.body, namespace.concat(name));
-          } break;
-          case ts.SyntaxKind.StringLiteral: {
+            break;
+          case ts.SyntaxKind.StringLiteral:
             // E.g. "declare module 'foo' {" (note the quotes).
             // We still want to emit externs for this module, but
             // Closure doesn't really provide a mechanism for
             // module-scoped externs.  For now, ignore the enclosing
             // namespace (because this is declaring a top-level module)
             // and emit into a fake namespace.
-            namespace = ['tsickle_declare_module'];
-            let name = (decl.name as ts.StringLiteral).text;
+
+            // Declare the top-level "tsickle_declare_module".
             this.emit('/** @const */\n');
-            this.writeExternsVariable(name, namespace, '{}');
-            if (decl.body) this.visit(decl.body, namespace.concat(name));
-          } break;
+            this.writeExternsVariable('tsickle_declare_module', [], '{}');
+            namespace = ['tsickle_declare_module'];
+
+            // Declare the inner "tsickle_declare_module.foo".
+            let importName = (decl.name as ts.StringLiteral).text;
+            this.emit(`// Derived from: declare module "${importName}"\n`);
+            // We also don't care about the actual name of the module ("foo"
+            // in the above example), except that we want it to not conflict.
+            importName = importName.replace(/[^A-Za-z]/g, '_');
+            this.emit('/** @const */\n');
+            this.writeExternsVariable(importName, namespace, '{}');
+
+            // Declare the contents inside the "tsickle_declare_module.foo".
+            if (decl.body) this.visit(decl.body, namespace.concat(importName));
+            break;
           default:
             this.errorUnimplementedKind(decl.name, 'externs generation of namespace');
         }

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -34,7 +34,7 @@ declare namespace DeclareTestModule {
 // This module is quoted, which declares an importable module.
 // We can't model this in externs beyond making sure it's declared
 // in *some* namespace;
-declare module "DeclareTestQuotedModule" {
+declare module "DeclareTest-QuotedModule" {
   var foo: string;
 }
 

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -36,7 +36,7 @@ declare namespace DeclareTestModule {
 // This module is quoted, which declares an importable module.
 // We can't model this in externs beyond making sure it's declared
 // in *some* namespace;
-declare module "DeclareTestQuotedModule" {
+declare module "DeclareTest-QuotedModule" {
   var foo: string;
 }
 

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -57,9 +57,12 @@ DeclareTestModule.StringEnum.foo;
 /** @typedef {(string|number)} */
 DeclareTestModule.TypeAlias;
 /** @const */
-tsickle_declare_module.DeclareTestQuotedModule = {};
+var tsickle_declare_module = {};
+// Derived from: declare module "DeclareTest-QuotedModule"
+/** @const */
+tsickle_declare_module.DeclareTest_QuotedModule = {};
  /** @type {string} */
-tsickle_declare_module.DeclareTestQuotedModule.foo;
+tsickle_declare_module.DeclareTest_QuotedModule.foo;
  /** @type {number} */
 var declareGlobalVar;
 


### PR DESCRIPTION
f99e086 translates "declare module 'foo'" into externs declarations,
but it generates a bad variable name if the declared module has a
hyphen in it.  Fix this by whitelisting valid module characters.

Fixes issue #393.