### PR TITLE
Fix error when handling input with some files with preexisting source maps, and some without.

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import {SourceMapGenerator} from 'source-map';
+import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 import {convertDecorators} from './decorator-annotator';
@@ -224,11 +224,12 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       // TODO(lucassloan): remove when the .d.ts has the correct types
       for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
-        const preexistingSourceMapGenerator = this.preexistingSourceMaps.get(sourceMapKey)!;
-        const preexistingSourceMapConsumer =
-            sourceMapUtils.sourceMapGeneratorToConsumerWithFileName(
-                preexistingSourceMapGenerator, sourceFileName);
-        tscSourceMapGenerator.applySourceMap(preexistingSourceMapConsumer);
+        const preexistingSourceMapGenerator = this.preexistingSourceMaps.get(sourceMapKey);
+        if (preexistingSourceMapGenerator) {
+          const preexistingSourceMapConsumer =
+              new SourceMapConsumer(preexistingSourceMapGenerator.toJSON());
+          tscSourceMapGenerator.applySourceMap(preexistingSourceMapConsumer);
+        }
       }
     }
 


### PR DESCRIPTION
When composing source maps, we assumed that if any of the source files had a source map for a given transform, they all had them.  While this is correct for decorator downleveling and closurization, we don't have any guarantees for inline source maps in the source files, thus we need to guard against the source map not existing.