### PR TITLE
ensure parameter names are unique

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -231,9 +231,16 @@ class ClosureRewriter extends Rewriter {
     }
 
     // Merge the JSDoc tags for each overloaded parameter.
+    // Ensure each parameter has a unique name; the merging process can otherwise
+    // accidentally generate the same parameter name twice.
+    let paramNames = new Set();
     let foundOptional = false;
     for (let i = 0; i < maxArgsCount; i++) {
       let paramTag = jsdoc.merge(paramTags[i]);
+      if (paramNames.has(paramTag.parameterName)) {
+        paramTag.parameterName += i.toString();
+      }
+      paramNames.add(paramTag.parameterName);
       // If any overload marks this param as a ..., mark it ... in the
       // merged output.
       if (paramTags[i].find(t => t.restParam === true) !== undefined) {

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -70,6 +70,11 @@ declare module CodeMirror {
   }
 }
 
+// Test overloaded functions with confusing parameter names.
+declare function redirect(url: string): void;
+declare function redirect(status: number, url: string): void;
+declare function redirect(url: string, status: number): void;
+
 // An interface that is not tagged with "declare", but exists in a
 // d.ts file so it should show up in the externs anyway.
 interface BareInterface {

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -1,4 +1,4 @@
-Warning at test_files/declare/declare.d.ts:83:1: anonymous type has no symbol
+Warning at test_files/declare/declare.d.ts:88:1: anonymous type has no symbol
 ====
 declare namespace DeclareTestModule {
   namespace inner {
@@ -71,6 +71,11 @@ declare module CodeMirror {
     name: string;
   }
 }
+
+// Test overloaded functions with confusing parameter names.
+declare function redirect(url: string): void;
+declare function redirect(status: number, url: string): void;
+declare function redirect(url: string, status: number): void;
 
 // An interface that is not tagged with "declare", but exists in a
 // d.ts file so it should show up in the externs anyway.

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -98,6 +98,13 @@ CodeMirror.Editor = function() {};
  /** @type {string} */
 CodeMirror.Editor.prototype.name;
 
+/**
+ * @param {string|number} url_or_status
+ * @param {string|number=} url_or_status1
+ * @return {void}
+ */
+function redirect(url_or_status, url_or_status1) {}
+
 /** @record @struct */
 function BareInterface() {}
  /** @type {string} */


### PR DESCRIPTION
When unifying overloaded functions, we generate parameter names.
If the overloaded functions have particularly bad names, we can generate
a duplicate parameter name.  This actually came up in some real externs!

Work around this by ensuring generated names are unique.