### PR TITLE
handle overloaded functions with rest params

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -249,6 +249,11 @@ class ClosureRewriter extends Rewriter {
         paramTag.optional = true;
       }
       newDoc.push(paramTag);
+      if (paramTag.restParam) {
+        // Cannot have any parameters after a rest param.
+        // Just dump the remaining parameters.
+        break;
+      }
     }
 
     // Merge the JSDoc tags for each overloaded return.

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -75,6 +75,10 @@ declare function redirect(url: string): void;
 declare function redirect(status: number, url: string): void;
 declare function redirect(url: string, status: number): void;
 
+// Test an overload with a rest param occurring before an ordinary function.
+declare function TestOverload(a: number, ...b: any[]): string;
+declare function TestOverload(a: number, b: string, c: string): string;
+
 // An interface that is not tagged with "declare", but exists in a
 // d.ts file so it should show up in the externs anyway.
 interface BareInterface {

--- a/test_files/declare/declare.tsickle.d.ts
+++ b/test_files/declare/declare.tsickle.d.ts
@@ -1,4 +1,4 @@
-Warning at test_files/declare/declare.d.ts:88:1: anonymous type has no symbol
+Warning at test_files/declare/declare.d.ts:92:1: anonymous type has no symbol
 ====
 declare namespace DeclareTestModule {
   namespace inner {
@@ -76,6 +76,10 @@ declare module CodeMirror {
 declare function redirect(url: string): void;
 declare function redirect(status: number, url: string): void;
 declare function redirect(url: string, status: number): void;
+
+// Test an overload with a rest param occurring before an ordinary function.
+declare function TestOverload(a: number, ...b: any[]): string;
+declare function TestOverload(a: number, b: string, c: string): string;
 
 // An interface that is not tagged with "declare", but exists in a
 // d.ts file so it should show up in the externs anyway.

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -108,6 +108,13 @@ CodeMirror.Editor.prototype.name;
  */
 function redirect(url_or_status, url_or_status1) {}
 
+/**
+ * @param {number} a
+ * @param {...?|string} b
+ * @return {string}
+ */
+function TestOverload(a, b) {}
+
 /** @record @struct */
 function BareInterface() {}
  /** @type {string} */


### PR DESCRIPTION
If one of the overloads declares a rest parameter, then we must ignore
any later parameters from the other overloads.