### PR TITLE
fix: also escape JSDoc on top-level variables

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -630,6 +630,7 @@ class Annotator extends ClosureRewriter {
         this.emit('))');
         return true;
       case ts.SyntaxKind.PropertyDeclaration:
+      case ts.SyntaxKind.VariableStatement:
         const jsDoc = this.getJSDoc(node);
         if (jsDoc && jsDoc.length > 0 && node.getFirstToken()) {
           this.emit('\n');

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -70,3 +70,8 @@ class RedundantJSDocShouldBeStripped {
  * @return {void}
  */
 function JSDocWithBadTag() { }
+/**
+ * For example,
+ * \@madeUpTag
+ */
+const c = 'c';

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -65,3 +65,9 @@ class RedundantJSDocShouldBeStripped {
  *   function example2() {}
  */
 function JSDocWithBadTag() {}
+
+/**
+ * For example,
+ * @madeUpTag
+ */
+const c = 'c';

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -93,3 +93,8 @@ constructor() {}
  * @return {void}
  */
 function JSDocWithBadTag() {}
+/**
+ * For example,
+ * \@madeUpTag
+ */
+const c = 'c';


### PR DESCRIPTION
This now clears up all the whitelisted "Unknown JSDoc" warnings.