### PR TITLE
default to untyped mode in CLI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ export interface Settings {
   /** If provided, path to save externs to. */
   externsPath?: string;
 
-  /** If provided, convert every type to the Closure {?} type */
-  isUntyped: boolean;
+  /** If provided, attempt to provide types rather than {?}. */
+  isTyped?: boolean;
 
   /** If true, log internal debug warnings to the console. */
   verbose?: boolean;
@@ -37,7 +37,7 @@ example:
 
 tsickle flags are:
   --externs=PATH     save generated Closure externs.js to PATH
-  --untyped          convert every type in TypeScript to the Closure {?} type
+  --typed            [experimental] attempt to provide Closure types instead of {?}
 `);
 }
 
@@ -46,7 +46,7 @@ tsickle flags are:
  * the arguments to pass on to tsc.
  */
 function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: string[]} {
-  let settings: Settings = {isUntyped: false};
+  let settings: Settings = {};
   let parsedArgs = minimist(args);
   for (let flag of Object.keys(parsedArgs)) {
     switch (flag) {
@@ -58,8 +58,8 @@ function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: str
       case 'externs':
         settings.externsPath = parsedArgs[flag];
         break;
-      case 'untyped':
-        settings.isUntyped = true;
+      case 'typed':
+        settings.isTyped = true;
         break;
       case 'verbose':
         settings.verbose = true;
@@ -135,7 +135,7 @@ function getDefaultClosureJSOptions(fileNames: string[], settings: Settings): Cl
     tsickleCompilerHostOptions: {
       googmodule: true,
       es5Mode: false,
-      untyped: settings.isUntyped,
+      untyped: !settings.isTyped,
     },
     tsickleHost: {
       shouldSkipTsickleProcessing: (fileName) => fileNames.indexOf(fileName) === -1,

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -9,7 +9,7 @@
 import {assert, expect} from 'chai';
 import * as ts from 'typescript';
 
-import {Settings, toClosureJS} from '../src/main';
+import {toClosureJS} from '../src/main';
 
 describe('toClosureJS', () => {
   it('creates externs, adds type comments and rewrites imports', function() {
@@ -18,7 +18,7 @@ describe('toClosureJS', () => {
     const closure = toClosureJS(
         {sourceMap: true, experimentalDecorators: true} as ts.CompilerOptions,
         ['test_files/underscore/export_underscore.ts', 'test_files/underscore/underscore.ts'],
-        {isUntyped: false} as Settings, diagnostics);
+        {isTyped: true}, diagnostics);
 
     if (!closure) {
       diagnostics.forEach(v => console.log(JSON.stringify(v)));

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -13,7 +13,7 @@ import * as ts from 'typescript';
 
 import * as cliSupport from '../src/cli_support';
 import {ANNOTATION_SUPPORT_CODE, convertDecorators} from '../src/decorator-annotator';
-import {Settings, toClosureJS} from '../src/main';
+import {toClosureJS} from '../src/main';
 import {getInlineSourceMapCount, setInlineSourceMap,} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
 import {toArray} from '../src/util';
@@ -369,8 +369,7 @@ function compile(sources: Map<string, string>, partialOptions = {} as Partial<Co
     tsicklePasses: options.tsicklePasses,
   };
 
-  const closure = toClosureJS(
-      compilerOptions, fileNames, {isUntyped: false} as Settings, diagnostics, closureJSOPtions);
+  const closure = toClosureJS(compilerOptions, fileNames, {}, diagnostics, closureJSOPtions);
 
   if (!closure) {
     console.error(tsickle.formatDiagnostics(diagnostics));


### PR DESCRIPTION
We want to eliminate untyped mode, but until we do, the open source
tsickle behavior should match the behavior we're using in production.

Fixes #394.