### PR TITLE
Ban more redundant Closure tags.

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -113,14 +113,35 @@ const JSDOC_TAGS_WHITELIST = [
 ];
 
 /**
- * A list of JSDoc @tags that are never allowed in TypeScript source.
- * These are Closure tags that can be expressed in the TypeScript surface
- * syntax.
+ * A list of JSDoc @tags that are never allowed in TypeScript source. These are Closure tags that
+ * can be expressed in the TypeScript surface syntax. As tsickle's emit will mangle type names,
+ * these will cause Closure Compiler issues and should not be used.
  */
-const JSDOC_TAGS_BLACKLIST = ['constructor', 'extends', 'implements', 'private', 'public', 'type'];
+const JSDOC_TAGS_BLACKLIST = [
+  'constructor',
+  'enum',
+  'extends',
+  'implements',
+  'interface',
+  'lends',
+  'private',
+  'public',
+  'record',
+  'template',
+  'this',
+  'type',
+  'typedef',
+];
 
-/** A list of JSDoc @tags that might include a {type} after them. */
-const JSDOC_TAGS_WITH_TYPES = ['export', 'param', 'return'];
+/**
+ * A list of JSDoc @tags that might include a {type} after them. Only banned when a type is passed.
+ */
+const JSDOC_TAGS_WITH_TYPES = [
+  'const',
+  'export',
+  'param',
+  'return',
+];
 
 /**
  * parse parses JSDoc out of a comment string.
@@ -150,7 +171,12 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
         warnings.push(`@${tagName} annotations are redundant with TypeScript equivalents`);
         continue;  // Drop the tag so Closure won't process it.
       } else if (arrayIncludes(JSDOC_TAGS_WITH_TYPES, tagName) && text[0] === '{') {
-        warnings.push('type annotations (using {...}) are redundant with TypeScript types');
+        warnings.push(
+            `the type annotation on @${tagName} is redundant with its TypeScript type, ` +
+            `remove the {...} part`);
+        continue;
+      } else if (tagName === 'dict') {
+        warnings.push('use index signatures (`[k: string]: type`) instead of @dict');
         continue;
       }
 

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -42,7 +42,9 @@ describe('jsdoc.parse', () => {
 */`;
     expect(jsdoc.parse(source)).to.deep.equal({
       tags: [],
-      warnings: ['type annotations (using {...}) are redundant with TypeScript types']
+      warnings: [
+        'the type annotation on @param is redundant with its TypeScript type, remove the {...} part'
+      ]
     });
   });
   it('warns on @type annotations', () => {

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -22,6 +22,12 @@ function jsDocTestBadDoc(foo) { }
  * \@madeUpTag This tag will be escaped, because Closure disallows it.
  */
 class JSDocTest {
+    constructor() {
+        /** @enum {string} */
+        this.badEnumThing = { A: 'a' };
+        /** @const {string} */
+        this.badConstThing = 'a';
+    }
 }
 /**
  * \@internal
@@ -44,7 +50,32 @@ function JSDocTest_tsickle_Closure_declarations() {
     JSDocTest.prototype.stringWithoutJSDoc;
     /** @type {number} */
     JSDocTest.prototype.typedThing;
+    /** @type {?} */
+    JSDocTest.prototype.badEnumThing;
+    /** @type {string} */
+    JSDocTest.prototype.badConstThing;
+    /** @type {string} */
+    JSDocTest.prototype.badTypeDef;
 }
+class BadTemplated {
+}
+class BadDict {
+}
+class BadLends {
+}
+/**
+ * @throws {Error} JSCompiler treats this as pure documentation, no need to ban it.
+ * @return {void}
+ */
+function fnThrows() { }
+/**
+ * @return {void}
+ */
+function badThis() { }
+/**
+ * @return {void}
+ */
+function BadInterface() { }
 /**
  * \@madeUptag This tag will be escaped, because Closure disallows it.
  * @see This tag will be kept, because Closure allows it.

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -36,7 +36,34 @@ class JSDocTest {
 
   /** @type {badType} */
   typedThing: number;
+
+  /** @enum {string} */
+  badEnumThing = {A: 'a'};
+
+  /** @const {string} */
+  badConstThing = 'a';
+
+  /** @typedef {string} */
+  badTypeDef: string;
 }
+
+/** @template T */
+class BadTemplated {}
+
+/** @dict */
+class BadDict {}
+
+/** @lends {BadDict} */
+class BadLends {}
+
+/** @throws {Error} JSCompiler treats this as pure documentation, no need to ban it. */
+function fnThrows() {}
+
+/** @this {string} */
+function badThis() {}
+
+/** @interface @record */
+function BadInterface() {}
 
 /**
  * @madeUptag This tag will be escaped, because Closure disallows it.

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -1,11 +1,23 @@
-Warning at test_files/jsdoc/jsdoc.ts:16:1: type annotations (using {...}) are redundant with TypeScript types
-Warning at test_files/jsdoc/jsdoc.ts:32:3: type annotations (using {...}) are redundant with TypeScript types
+Warning at test_files/jsdoc/jsdoc.ts:16:1: the type annotation on @param is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:32:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
 Warning at test_files/jsdoc/jsdoc.ts:37:3: @type annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:32:3: type annotations (using {...}) are redundant with TypeScript types
+Warning at test_files/jsdoc/jsdoc.ts:40:3: @enum annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:43:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:46:3: @typedef annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:32:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
 Warning at test_files/jsdoc/jsdoc.ts:37:3: @type annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:47:1: @extends annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:40:3: @enum annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:43:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:46:3: @typedef annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:50:1: @template annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:53:1: use index signatures (`[k: string]: type`) instead of @dict
+Warning at test_files/jsdoc/jsdoc.ts:56:1: @lends annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:62:1: @this annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:65:1: @interface annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:74:1: @extends annotations are redundant with TypeScript equivalents
 @implements annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:54:3: @constructor annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:81:3: @constructor annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:41:3: unhandled anonymous type
 ====
 
 /**
@@ -48,6 +60,15 @@ exported: string;
 
   /** @type {badType} */
   typedThing: number;
+
+  /** @enum {string} */
+  badEnumThing = {A: 'a'};
+
+  /** @const {string} */
+  badConstThing = 'a';
+
+  /** @typedef {string} */
+  badTypeDef: string;
 }
 
 function JSDocTest_tsickle_Closure_declarations() {
@@ -67,8 +88,30 @@ JSDocTest.prototype.badExport;
 JSDocTest.prototype.stringWithoutJSDoc;
 /** @type {number} */
 JSDocTest.prototype.typedThing;
+/** @type {?} */
+JSDocTest.prototype.badEnumThing;
+/** @type {string} */
+JSDocTest.prototype.badConstThing;
+/** @type {string} */
+JSDocTest.prototype.badTypeDef;
 }
 
+class BadTemplated {}
+class BadDict {}
+class BadLends {}
+/**
+ * @throws {Error} JSCompiler treats this as pure documentation, no need to ban it.
+ * @return {void}
+ */
+function fnThrows() {}
+/**
+ * @return {void}
+ */
+function badThis() {}
+/**
+ * @return {void}
+ */
+function BadInterface() {}
 /**
  * \@madeUptag This tag will be escaped, because Closure disallows it.
  * @see This tag will be kept, because Closure allows it.


### PR DESCRIPTION
@enum, @typedef, @const etc.
    
Also improves the error message to be a bit more actionable.

This is based on going through https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler.