### PR TITLE
add abstract classes to the "class" test

### DIFF
--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -6,7 +6,7 @@ class Class {
     /**
      * @return {void}
      */
-    superFunc() { }
+    classFunc() { }
 }
 /**
  * @abstract
@@ -22,24 +22,43 @@ class AbstractClass {
      */
     nonAbstractFunc() { }
 }
+/** @record */
+function InterfaceExtendsInterface() { }
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsInterface.prototype.interfaceFunc2;
+/** @record */
+function InterfaceExtendsClass() { }
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsClass.prototype.interfaceFunc2;
+/** @record */
+function InterfaceExtendsAbstractClass() { }
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
 /**
  * @implements {Interface}
- * @extends {Class}
  */
-class Implements {
+class ClassImplementsInterface {
     /**
      * @return {void}
      */
     interfaceFunc() { }
+}
+/**
+ * @extends {Class}
+ */
+class ClassImplementsClass {
     /**
      * @return {void}
      */
-    superFunc() { }
+    classFunc() { }
 }
 /**
  * @extends {AbstractClass}
  */
-class ImplementsAbstract {
+class ClassImplementsAbstractClass {
     /**
      * @return {void}
      */
@@ -49,16 +68,13 @@ class ImplementsAbstract {
      */
     nonAbstractFunc() { }
 }
-/**
- * @implements {Interface}
- */
-class Extends extends Class {
+class ClassExtendsClass extends Class {
     /**
      * @return {void}
      */
-    interfaceFunc() { }
+    classFunc() { }
 }
-class ExtendsAbstract extends AbstractClass {
+class ClassExtendsAbstractClass extends AbstractClass {
     /**
      * @return {void}
      */
@@ -78,17 +94,27 @@ class ImplementsTypeAlias {
     /**
      * @return {void}
      */
-    superFunc() { }
+    classFunc() { }
 }
-// Verify Closure accepts the various casts.
+// Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar;
-interfaceVar = new Implements();
-interfaceVar = new Extends();
+let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = (null);
+interfaceVar = interfaceExtendsInterface;
+interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
-let /** @type {!Class} */ superVar;
-superVar = new Implements();
-superVar = new Extends();
-superVar = new ImplementsTypeAlias();
+// Verify Closure accepts the various subtypes of Class.
+let /** @type {!Class} */ classVar;
+let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass = (null);
+classVar = interfaceExtendsClass;
+classVar = new ClassImplementsClass();
+classVar = new ClassExtendsClass();
+classVar = new ImplementsTypeAlias();
+// Verify Closure accepts the various subtypes of AbstractClass.
+let /** @type {!AbstractClass} */ abstractClassVar;
+let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass = (null);
+abstractClassVar = interfaceExtendsAbstractClass;
+abstractClassVar = new ClassImplementsAbstractClass();
+abstractClassVar = new ClassExtendsAbstractClass();
 /**
  * @return {void}
  */

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -2,7 +2,7 @@ goog.module('test_files.class.class');var module = module || {id: 'test_files/cl
 function Interface() { }
 /** @type {function(): void} */
 Interface.prototype.interfaceFunc;
-class Super {
+class Class {
     /**
      * @return {void}
      */
@@ -24,8 +24,7 @@ class AbstractClass {
 }
 /**
  * @implements {Interface}
- * @extends {Super}
- * @extends {AbstractClass}
+ * @extends {Class}
  */
 class Implements {
     /**
@@ -36,6 +35,11 @@ class Implements {
      * @return {void}
      */
     superFunc() { }
+}
+/**
+ * @extends {AbstractClass}
+ */
+class ImplementsAbstract {
     /**
      * @return {void}
      */
@@ -48,7 +52,7 @@ class Implements {
 /**
  * @implements {Interface}
  */
-class Extends extends Super {
+class Extends extends Class {
     /**
      * @return {void}
      */
@@ -64,7 +68,7 @@ class ExtendsAbstract extends AbstractClass {
 var TypeAlias;
 /**
  * @implements {TypeAlias}
- * @extends {Super}
+ * @extends {Class}
  */
 class ImplementsTypeAlias {
     /**
@@ -81,7 +85,7 @@ let /** @type {!Interface} */ interfaceVar;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
 interfaceVar = new ImplementsTypeAlias();
-let /** @type {!Super} */ superVar;
+let /** @type {!Class} */ superVar;
 superVar = new Implements();
 superVar = new Extends();
 superVar = new ImplementsTypeAlias();

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -115,6 +115,54 @@ class ClassExtendsAbstractClass extends AbstractClass {
      */
     abstractFunc() { }
 }
+/**
+ * @abstract
+ * @implements {Interface}
+ */
+class AbstractClassImplementsInterface {
+    /**
+     * @return {void}
+     */
+    interfaceFunc() { }
+}
+/**
+ * @abstract
+ * @extends {Class}
+ */
+class AbstractClassImplementsClass {
+    /**
+     * @return {void}
+     */
+    classFunc() { }
+}
+/**
+ * @abstract
+ * @extends {AbstractClass}
+ */
+class AbstractClassImplementsAbstractClass {
+    /**
+     * @return {void}
+     */
+    abstractFunc() { }
+    /**
+     * @return {void}
+     */
+    nonAbstractFunc() { }
+}
+/**
+ * @abstract
+ */
+class AbstractClassExtendsClass extends Class {
+    /**
+     * @return {void}
+     */
+    classFunc() { }
+}
+/**
+ * @abstract
+ */
+class AbstractClassExtendsAbstractClass extends AbstractClass {
+}
 /** @typedef {!Interface} */
 var TypeAlias;
 /**

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -24,51 +24,20 @@ class AbstractClass {
      */
     nonAbstractFunc() { }
 }
-/** @record */
+/**
+ * @record
+ * @extends {Interface}
+ */
 function InterfaceExtendsInterface() { }
-// TODO: derived interfaces.
 /** @type {function(): void} */
 InterfaceExtendsInterface.prototype.interfaceFunc2;
-/** @record */
-function InterfaceExtendsClass() { }
-// TODO: derived interfaces.
-/** @type {function(): void} */
-InterfaceExtendsClass.prototype.interfaceFunc2;
-/** @record */
-function InterfaceExtendsAbstractClass() { }
-// TODO: derived interfaces.
-/** @type {function(): void} */
-InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
-// Create values of each of the above interface types for use in later testing.
+// Note: interfaces can only extend interfaces, so there's no
+// InterfaceExtendsClass etc.
 let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = {
     /**
      * @return {void}
      */
     interfaceFunc() { },
-    /**
-     * @return {void}
-     */
-    interfaceFunc2() { }
-};
-let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass = {
-    /**
-     * @return {void}
-     */
-    classFunc() { },
-    /**
-     * @return {void}
-     */
-    interfaceFunc2() { }
-};
-let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass = {
-    /**
-     * @return {void}
-     */
-    abstractFunc() { },
-    /**
-     * @return {void}
-     */
-    nonAbstractFunc() { },
     /**
      * @return {void}
      */
@@ -188,13 +157,11 @@ interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 // Verify Closure accepts the various subtypes of Class.
 let /** @type {!Class} */ classVar;
-// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 // Verify Closure accepts the various subtypes of AbstractClass.
 let /** @type {!AbstractClass} */ abstractClassVar;
-// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 /**

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -9,8 +9,23 @@ class Super {
     superFunc() { }
 }
 /**
+ * @abstract
+ */
+class AbstractClass {
+    /**
+     * @abstract
+     * @return {void}
+     */
+    abstractFunc() { }
+    /**
+     * @return {void}
+     */
+    nonAbstractFunc() { }
+}
+/**
  * @implements {Interface}
  * @extends {Super}
+ * @extends {AbstractClass}
  */
 class Implements {
     /**
@@ -21,6 +36,14 @@ class Implements {
      * @return {void}
      */
     superFunc() { }
+    /**
+     * @return {void}
+     */
+    abstractFunc() { }
+    /**
+     * @return {void}
+     */
+    nonAbstractFunc() { }
 }
 /**
  * @implements {Interface}
@@ -30,6 +53,12 @@ class Extends extends Super {
      * @return {void}
      */
     interfaceFunc() { }
+}
+class ExtendsAbstract extends AbstractClass {
+    /**
+     * @return {void}
+     */
+    abstractFunc() { }
 }
 /** @typedef {!Interface} */
 var TypeAlias;

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -37,6 +37,41 @@ function InterfaceExtendsAbstractClass() { }
 // TODO: derived interfaces.
 /** @type {function(): void} */
 InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
+// Create values of each of the above interface types for use in later testing.
+let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = {
+    /**
+     * @return {void}
+     */
+    interfaceFunc() { },
+    /**
+     * @return {void}
+     */
+    interfaceFunc2() { }
+};
+let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass = {
+    /**
+     * @return {void}
+     */
+    classFunc() { },
+    /**
+     * @return {void}
+     */
+    interfaceFunc2() { }
+};
+let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass = {
+    /**
+     * @return {void}
+     */
+    abstractFunc() { },
+    /**
+     * @return {void}
+     */
+    nonAbstractFunc() { },
+    /**
+     * @return {void}
+     */
+    interfaceFunc2() { }
+};
 /**
  * @implements {Interface}
  */
@@ -98,21 +133,18 @@ class ImplementsTypeAlias {
 }
 // Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar;
-let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = (null);
-interfaceVar = interfaceExtendsInterface;
+// TODO(evanm): interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 // Verify Closure accepts the various subtypes of Class.
 let /** @type {!Class} */ classVar;
-let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass = (null);
-classVar = interfaceExtendsClass;
+// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 // Verify Closure accepts the various subtypes of AbstractClass.
 let /** @type {!AbstractClass} */ abstractClassVar;
-let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass = (null);
-abstractClassVar = interfaceExtendsAbstractClass;
+// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 /**

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -152,7 +152,7 @@ class ImplementsTypeAlias {
 }
 // Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar;
-// TODO(evanm): interfaceVar = interfaceExtendsInterface;
+interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 // Verify Closure accepts the various subtypes of Class.

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -32,12 +32,15 @@ abstract class AbstractClass {
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
+let interfaceExtendsInterfaceValue = {} as InterfaceExtendsInterface;
 interface InterfaceExtendsClass extends Class {
   interfaceFunc2(): void;
 }
+let interfaceExtendsClassValue: InterfaceExtendsClass = {} as InterfaceExtendsClass;
 interface InterfaceExtendsAbstractClass extends AbstractClass {
   interfaceFunc2(): void;
 }
+let interfaceExtendsAbstractClassValue: InterfaceExtendsAbstractClass = {} as any;
 
 // 3) class implements.
 class ClassImplementsInterface implements Interface {
@@ -74,18 +77,22 @@ class ImplementsTypeAlias implements TypeAlias, Class {
 
 // Verify Closure accepts the various subtypes of Interface.
 let interfaceVar: Interface;
-let interfaceExtendsInterface: InterfaceExtendsInterface;
-interfaceVar = interfaceExtendsInterface;
+interfaceVar = interfaceExtendsInterfaceValue;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of Class.
 let classVar: Class;
-let interfaceExtendsClass: InterfaceExtendsClass;
-classVar = interfaceExtendsClass;
+classVar = interfaceExtendsClassValue;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
+
+// Verify Closure accepts the various subtypes of AbstractClass.
+let abstractClassVar: AbstractClass;
+abstractClassVar = interfaceExtendsAbstractClass;
+abstractClassVar = new ClassImplementsAbstractClass();
+abstractClassVar = new ClassExtendsAbstractClass();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -34,24 +34,10 @@ abstract class AbstractClass {
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
-interface InterfaceExtendsClass extends Class {
-  interfaceFunc2(): void;
-}
-interface InterfaceExtendsAbstractClass extends AbstractClass {
-  interfaceFunc2(): void;
-}
-// Create values of each of the above interface types for use in later testing.
+// Note: interfaces can only extend interfaces, so there's no
+// InterfaceExtendsClass etc.
 let interfaceExtendsInterface: InterfaceExtendsInterface = {
   interfaceFunc() {},
-  interfaceFunc2() {}
-};
-let interfaceExtendsClass: InterfaceExtendsClass = {
-  classFunc() {},
-  interfaceFunc2() {}
-};
-let interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = {
-  abstractFunc() {},
-  nonAbstractFunc() {},
   interfaceFunc2() {}
 };
 
@@ -118,14 +104,12 @@ interfaceVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of Class.
 let classVar: Class;
-// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of AbstractClass.
 let abstractClassVar: AbstractClass;
-// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -24,11 +24,13 @@ abstract class AbstractClass {
 // 2) interface extends
 // 3) class implements
 // 4) class extends
+// 5) abstract class implements
+// 6) abstract class extends
 
-// 1) interface implements.
-// No examples; this is not legal TypeScript.
+// Permutation 1: interface implements.
+// "interface implements" is not legal TypeScript, so no examples necessary.
 
-// 2) interface extends.
+// Permutation 2: interface extends.
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
@@ -53,7 +55,7 @@ let interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = {
   interfaceFunc2() {}
 };
 
-// 3) class implements.
+// Permutation 3: class implements.
 class ClassImplementsInterface implements Interface {
   interfaceFunc(): void {}
 }
@@ -67,14 +69,38 @@ class ClassImplementsAbstractClass implements AbstractClass {
   nonAbstractFunc(): void {}
 }
 
-// 4) class extends.
+// Permutation 4: class extends.
 // Note: cannot "extends" an interface.
-//    class ClassExtendsInterface extends Interface {
+// So this is illegal: class ClassExtendsInterface extends Interface {
 class ClassExtendsClass extends Class {
   classFunc(): void {}
 }
 class ClassExtendsAbstractClass extends AbstractClass {
   abstractFunc(): void {}
+}
+
+// Permutation 5: abstract class implements.
+abstract class AbstractClassImplementsInterface implements Interface {
+  interfaceFunc(): void {}
+}
+abstract class AbstractClassImplementsClass implements Class {
+  classFunc(): void {}
+}
+abstract class AbstractClassImplementsAbstractClass implements AbstractClass {
+  // Note: because this class *implements* AbstractClass, it must also implement
+  // abstractFunc and nonAbstractFunc despite that already having an implementation.
+  abstractFunc(): void {}
+  nonAbstractFunc(): void {}
+}
+
+// Permutation 6: abstract class extends.
+// Note: cannot "extends" an interface.
+// So this is illegal: class AbstractClassExtendsInterface extends Interface {
+abstract class AbstractClassExtendsClass extends Class {
+  classFunc(): void {}
+}
+abstract class AbstractClassExtendsAbstractClass extends AbstractClass {
+  // Note: can leave out abstractFunc() because this class is still abstract.
 }
 
 // It's also legal to alias a type and then implement the alias.

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -32,15 +32,26 @@ abstract class AbstractClass {
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
-let interfaceExtendsInterfaceValue = {} as InterfaceExtendsInterface;
 interface InterfaceExtendsClass extends Class {
   interfaceFunc2(): void;
 }
-let interfaceExtendsClassValue: InterfaceExtendsClass = {} as InterfaceExtendsClass;
 interface InterfaceExtendsAbstractClass extends AbstractClass {
   interfaceFunc2(): void;
 }
-let interfaceExtendsAbstractClassValue: InterfaceExtendsAbstractClass = {} as any;
+// Create values of each of the above interface types for use in later testing.
+let interfaceExtendsInterface: InterfaceExtendsInterface = {
+  interfaceFunc() {},
+  interfaceFunc2() {}
+};
+let interfaceExtendsClass: InterfaceExtendsClass = {
+  classFunc() {},
+  interfaceFunc2() {}
+};
+let interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = {
+  abstractFunc() {},
+  nonAbstractFunc() {},
+  interfaceFunc2() {}
+};
 
 // 3) class implements.
 class ClassImplementsInterface implements Interface {
@@ -66,8 +77,6 @@ class ClassExtendsAbstractClass extends AbstractClass {
   abstractFunc(): void {}
 }
 
-
-
 // It's also legal to alias a type and then implement the alias.
 type TypeAlias = Interface;
 class ImplementsTypeAlias implements TypeAlias, Class {
@@ -77,20 +86,20 @@ class ImplementsTypeAlias implements TypeAlias, Class {
 
 // Verify Closure accepts the various subtypes of Interface.
 let interfaceVar: Interface;
-interfaceVar = interfaceExtendsInterfaceValue;
+// TODO(evanm): interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of Class.
 let classVar: Class;
-classVar = interfaceExtendsClassValue;
+// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of AbstractClass.
 let abstractClassVar: AbstractClass;
-abstractClassVar = interfaceExtendsAbstractClass;
+// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -98,7 +98,7 @@ class ImplementsTypeAlias implements TypeAlias, Class {
 
 // Verify Closure accepts the various subtypes of Interface.
 let interfaceVar: Interface;
-// TODO(evanm): interfaceVar = interfaceExtendsInterface;
+interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -1,36 +1,52 @@
+// This test exercises the various ways classes and interfaces can interact.
+// There are three types of classy things:
+//   interface, class, abstract class
+// And there are two keywords for relating them:
+//   extends, implements
+// You can legally use them in any configuration the cross product implies;
+// for example, you can "implements" a class though it's more rare than the
+// other options.
+
+// Three declarations, one for each type of thing.
 interface Interface {
   interfaceFunc(): void;
 }
-
-class Super {
+class Class {
   superFunc(): void {}
 }
-
 abstract class AbstractClass {
   abstract abstractFunc(): void;
   nonAbstractFunc(): void { }
 }
 
-class Implements implements Interface, Super, AbstractClass {
+// This tests "implements" against an interface and the class.
+class Implements implements Interface, Class {
   interfaceFunc(): void {}
   superFunc(): void {}
+}
+
+// This tests "implements" against an abstract class.
+// Note: in Closure you cannot currently "implements" two classes, see #410.
+class ImplementsAbstract implements AbstractClass {
   abstractFunc(): void {}
   // Note: because this class *implements* AbstractClass, it must also implement
   // nonAbstractFunc despite that already having an implementation.
   nonAbstractFunc(): void {}
 }
 
-class Extends extends Super implements Interface {
+// This tests "extends" against the class.
+class Extends extends Class implements Interface {
   interfaceFunc(): void {}
 }
 
+// This tests "extends" against the abstract class.
 class ExtendsAbstract extends AbstractClass {
   abstractFunc(): void {}
 }
 
 // It's also legal to alias a type and then implement the alias.
 type TypeAlias = Interface;
-class ImplementsTypeAlias implements TypeAlias, Super {
+class ImplementsTypeAlias implements TypeAlias, Class {
   interfaceFunc(): void {}
   superFunc(): void {}
 }
@@ -41,7 +57,7 @@ interfaceVar = new Implements();
 interfaceVar = new Extends();
 interfaceVar = new ImplementsTypeAlias();
 
-let superVar: Super;
+let superVar: Class;
 superVar = new Implements();
 superVar = new Extends();
 superVar = new ImplementsTypeAlias();

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -3,7 +3,7 @@
 //   interface, class, abstract class
 // And there are two keywords for relating them:
 //   extends, implements
-// You can legally use them in any configuration the cross product implies;
+// You can legally use them in almost any configuration the cross product implies;
 // for example, you can "implements" a class though it's more rare than the
 // other options.
 
@@ -12,55 +12,80 @@ interface Interface {
   interfaceFunc(): void;
 }
 class Class {
-  superFunc(): void {}
+  classFunc(): void {}
 }
 abstract class AbstractClass {
   abstract abstractFunc(): void;
   nonAbstractFunc(): void { }
 }
 
-// This tests "implements" against an interface and the class.
-class Implements implements Interface, Class {
-  interfaceFunc(): void {}
-  superFunc(): void {}
+// Write out all permutations:
+// 1) interface implements
+// 2) interface extends
+// 3) class implements
+// 4) class extends
+
+// 1) interface implements.
+// No examples; this is not legal TypeScript.
+
+// 2) interface extends.
+interface InterfaceExtendsInterface extends Interface {
+  interfaceFunc2(): void;
+}
+interface InterfaceExtendsClass extends Class {
+  interfaceFunc2(): void;
+}
+interface InterfaceExtendsAbstractClass extends AbstractClass {
+  interfaceFunc2(): void;
 }
 
-// This tests "implements" against an abstract class.
-// Note: in Closure you cannot currently "implements" two classes, see #410.
-class ImplementsAbstract implements AbstractClass {
+// 3) class implements.
+class ClassImplementsInterface implements Interface {
+  interfaceFunc(): void {}
+}
+class ClassImplementsClass implements Class {
+  classFunc(): void {}
+}
+class ClassImplementsAbstractClass implements AbstractClass {
   abstractFunc(): void {}
   // Note: because this class *implements* AbstractClass, it must also implement
   // nonAbstractFunc despite that already having an implementation.
   nonAbstractFunc(): void {}
 }
 
-// This tests "extends" against the class.
-class Extends extends Class implements Interface {
-  interfaceFunc(): void {}
+// 4) class extends.
+// Note: cannot "extends" an interface.
+//    class ClassExtendsInterface extends Interface {
+class ClassExtendsClass extends Class {
+  classFunc(): void {}
 }
-
-// This tests "extends" against the abstract class.
-class ExtendsAbstract extends AbstractClass {
+class ClassExtendsAbstractClass extends AbstractClass {
   abstractFunc(): void {}
 }
+
+
 
 // It's also legal to alias a type and then implement the alias.
 type TypeAlias = Interface;
 class ImplementsTypeAlias implements TypeAlias, Class {
   interfaceFunc(): void {}
-  superFunc(): void {}
+  classFunc(): void {}
 }
 
-// Verify Closure accepts the various casts.
+// Verify Closure accepts the various subtypes of Interface.
 let interfaceVar: Interface;
-interfaceVar = new Implements();
-interfaceVar = new Extends();
+let interfaceExtendsInterface: InterfaceExtendsInterface;
+interfaceVar = interfaceExtendsInterface;
+interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 
-let superVar: Class;
-superVar = new Implements();
-superVar = new Extends();
-superVar = new ImplementsTypeAlias();
+// Verify Closure accepts the various subtypes of Class.
+let classVar: Class;
+let interfaceExtendsClass: InterfaceExtendsClass;
+classVar = interfaceExtendsClass;
+classVar = new ClassImplementsClass();
+classVar = new ClassExtendsClass();
+classVar = new ImplementsTypeAlias();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped

--- a/test_files/class/class.ts
+++ b/test_files/class/class.ts
@@ -6,14 +6,26 @@ class Super {
   superFunc(): void {}
 }
 
+abstract class AbstractClass {
+  abstract abstractFunc(): void;
+  nonAbstractFunc(): void { }
+}
 
-class Implements implements Interface, Super {
+class Implements implements Interface, Super, AbstractClass {
   interfaceFunc(): void {}
   superFunc(): void {}
+  abstractFunc(): void {}
+  // Note: because this class *implements* AbstractClass, it must also implement
+  // nonAbstractFunc despite that already having an implementation.
+  nonAbstractFunc(): void {}
 }
 
 class Extends extends Super implements Interface {
   interfaceFunc(): void {}
+}
+
+class ExtendsAbstract extends AbstractClass {
+  abstractFunc(): void {}
 }
 
 // It's also legal to alias a type and then implement the alias.

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,14 +1,24 @@
-Warning at test_files/class/class.ts:58:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:74:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /** @record */
 function Interface() {}
 /** @type {function(): void} */
 Interface.prototype.interfaceFunc;
+// This test exercises the various ways classes and interfaces can interact.
+// There are three types of classy things:
+//   interface, class, abstract class
+// And there are two keywords for relating them:
+//   extends, implements
+// You can legally use them in any configuration the cross product implies;
+// for example, you can "implements" a class though it's more rare than the
+// other options.
+
+// Three declarations, one for each type of thing.
 interface Interface {
   interfaceFunc(): void;
 }
-class Super {
+class Class {
 /**
  * @return {void}
  */
@@ -30,10 +40,9 @@ nonAbstractFunc(): void { }
 }
 /**
  * @implements {Interface}
- * @extends {Super}
- * @extends {AbstractClass}
+ * @extends {Class}
  */
-class Implements implements Interface, Super, AbstractClass {
+class Implements implements Interface, Class {
 /**
  * @return {void}
  */
@@ -42,6 +51,11 @@ interfaceFunc(): void {}
  * @return {void}
  */
 superFunc(): void {}
+}
+/**
+ * @extends {AbstractClass}
+ */
+class ImplementsAbstract implements AbstractClass {
 /**
  * @return {void}
  */
@@ -54,7 +68,7 @@ nonAbstractFunc(): void {}
 /**
  * @implements {Interface}
  */
-class Extends extends Super implements Interface {
+class Extends extends Class implements Interface {
 /**
  * @return {void}
  */
@@ -74,9 +88,9 @@ var TypeAlias;
 
 /**
  * @implements {TypeAlias}
- * @extends {Super}
+ * @extends {Class}
  */
-class ImplementsTypeAlias implements TypeAlias, Super {
+class ImplementsTypeAlias implements TypeAlias, Class {
 /**
  * @return {void}
  */
@@ -93,7 +107,7 @@ interfaceVar = new Implements();
 interfaceVar = new Extends();
 interfaceVar = new ImplementsTypeAlias();
 
-let /** @type {!Super} */ superVar: Super;
+let /** @type {!Class} */ superVar: Class;
 superVar = new Implements();
 superVar = new Extends();
 superVar = new ImplementsTypeAlias();

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/class/class.ts:106:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:115:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /** @record */
@@ -76,6 +76,41 @@ InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
 interface InterfaceExtendsAbstractClass extends AbstractClass {
   interfaceFunc2(): void;
 }
+// Create values of each of the above interface types for use in later testing.
+let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface: InterfaceExtendsInterface = {
+/**
+ * @return {void}
+ */
+interfaceFunc() {},
+/**
+ * @return {void}
+ */
+interfaceFunc2() {}
+};
+let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass: InterfaceExtendsClass = {
+/**
+ * @return {void}
+ */
+classFunc() {},
+/**
+ * @return {void}
+ */
+interfaceFunc2() {}
+};
+let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = {
+/**
+ * @return {void}
+ */
+abstractFunc() {},
+/**
+ * @return {void}
+ */
+nonAbstractFunc() {},
+/**
+ * @return {void}
+ */
+interfaceFunc2() {}
+};
 /**
  * @implements {Interface}
  */
@@ -120,8 +155,6 @@ class ClassExtendsAbstractClass extends AbstractClass {
 abstractFunc(): void {}
 }
 
-
-
 // It's also legal to alias a type and then implement the alias.
 type TypeAlias = Interface;
 /** @typedef {!Interface} */
@@ -144,23 +177,20 @@ classFunc(): void {}
 
 // Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar: Interface;
-let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface: InterfaceExtendsInterface = /** @type {?} */(( null as any));
-interfaceVar = interfaceExtendsInterface;
+// TODO(evanm): interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of Class.
 let /** @type {!Class} */ classVar: Class;
-let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass: InterfaceExtendsClass = /** @type {?} */(( null as any));
-classVar = interfaceExtendsClass;
+// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of AbstractClass.
 let /** @type {!AbstractClass} */ abstractClassVar: AbstractClass;
-let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = /** @type {?} */(( null as any));
-abstractClassVar = interfaceExtendsAbstractClass;
+// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/class/class.ts:115:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:141:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /** @record */
@@ -50,11 +50,13 @@ InterfaceExtendsInterface.prototype.interfaceFunc2;
 // 2) interface extends
 // 3) class implements
 // 4) class extends
+// 5) abstract class implements
+// 6) abstract class extends
 
-// 1) interface implements.
-// No examples; this is not legal TypeScript.
+// Permutation 1: interface implements.
+// "interface implements" is not legal TypeScript, so no examples necessary.
 
-// 2) interface extends.
+// Permutation 2: interface extends.
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
@@ -153,6 +155,55 @@ class ClassExtendsAbstractClass extends AbstractClass {
  * @return {void}
  */
 abstractFunc(): void {}
+}
+/**
+ * @abstract
+ * @implements {Interface}
+ */
+abstract class AbstractClassImplementsInterface implements Interface {
+/**
+ * @return {void}
+ */
+interfaceFunc(): void {}
+}
+/**
+ * @abstract
+ * @extends {Class}
+ */
+abstract class AbstractClassImplementsClass implements Class {
+/**
+ * @return {void}
+ */
+classFunc(): void {}
+}
+/**
+ * @abstract
+ * @extends {AbstractClass}
+ */
+abstract class AbstractClassImplementsAbstractClass implements AbstractClass {
+/**
+ * @return {void}
+ */
+abstractFunc(): void {}
+/**
+ * @return {void}
+ */
+nonAbstractFunc(): void {}
+}
+/**
+ * @abstract
+ */
+abstract class AbstractClassExtendsClass extends Class {
+/**
+ * @return {void}
+ */
+classFunc(): void {}
+}
+/**
+ * @abstract
+ */
+abstract class AbstractClassExtendsAbstractClass extends AbstractClass {
+  // Note: can leave out abstractFunc() because this class is still abstract.
 }
 
 // It's also legal to alias a type and then implement the alias.

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/class/class.ts:74:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:106:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /** @record */
@@ -10,7 +10,7 @@ Interface.prototype.interfaceFunc;
 //   interface, class, abstract class
 // And there are two keywords for relating them:
 //   extends, implements
-// You can legally use them in any configuration the cross product implies;
+// You can legally use them in almost any configuration the cross product implies;
 // for example, you can "implements" a class though it's more rare than the
 // other options.
 
@@ -22,7 +22,7 @@ class Class {
 /**
  * @return {void}
  */
-superFunc(): void {}
+classFunc(): void {}
 }
 /**
  * @abstract
@@ -38,24 +38,66 @@ abstractFunc() {}
  */
 nonAbstractFunc(): void { }
 }
+/** @record */
+function InterfaceExtendsInterface() {}
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsInterface.prototype.interfaceFunc2;
+
+
+// Write out all permutations:
+// 1) interface implements
+// 2) interface extends
+// 3) class implements
+// 4) class extends
+
+// 1) interface implements.
+// No examples; this is not legal TypeScript.
+
+// 2) interface extends.
+interface InterfaceExtendsInterface extends Interface {
+  interfaceFunc2(): void;
+}
+/** @record */
+function InterfaceExtendsClass() {}
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsClass.prototype.interfaceFunc2;
+
+interface InterfaceExtendsClass extends Class {
+  interfaceFunc2(): void;
+}
+/** @record */
+function InterfaceExtendsAbstractClass() {}
+// TODO: derived interfaces.
+/** @type {function(): void} */
+InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
+
+interface InterfaceExtendsAbstractClass extends AbstractClass {
+  interfaceFunc2(): void;
+}
 /**
  * @implements {Interface}
- * @extends {Class}
  */
-class Implements implements Interface, Class {
+class ClassImplementsInterface implements Interface {
 /**
  * @return {void}
  */
 interfaceFunc(): void {}
+}
+/**
+ * @extends {Class}
+ */
+class ClassImplementsClass implements Class {
 /**
  * @return {void}
  */
-superFunc(): void {}
+classFunc(): void {}
 }
 /**
  * @extends {AbstractClass}
  */
-class ImplementsAbstract implements AbstractClass {
+class ClassImplementsAbstractClass implements AbstractClass {
 /**
  * @return {void}
  */
@@ -65,21 +107,20 @@ abstractFunc(): void {}
  */
 nonAbstractFunc(): void {}
 }
-/**
- * @implements {Interface}
- */
-class Extends extends Class implements Interface {
+class ClassExtendsClass extends Class {
 /**
  * @return {void}
  */
-interfaceFunc(): void {}
+classFunc(): void {}
 }
-class ExtendsAbstract extends AbstractClass {
+class ClassExtendsAbstractClass extends AbstractClass {
 /**
  * @return {void}
  */
 abstractFunc(): void {}
 }
+
+
 
 // It's also legal to alias a type and then implement the alias.
 type TypeAlias = Interface;
@@ -98,19 +139,30 @@ interfaceFunc(): void {}
 /**
  * @return {void}
  */
-superFunc(): void {}
+classFunc(): void {}
 }
 
-// Verify Closure accepts the various casts.
+// Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar: Interface;
-interfaceVar = new Implements();
-interfaceVar = new Extends();
+let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface: InterfaceExtendsInterface = /** @type {?} */(( null as any));
+interfaceVar = interfaceExtendsInterface;
+interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 
-let /** @type {!Class} */ superVar: Class;
-superVar = new Implements();
-superVar = new Extends();
-superVar = new ImplementsTypeAlias();
+// Verify Closure accepts the various subtypes of Class.
+let /** @type {!Class} */ classVar: Class;
+let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass: InterfaceExtendsClass = /** @type {?} */(( null as any));
+classVar = interfaceExtendsClass;
+classVar = new ClassImplementsClass();
+classVar = new ClassExtendsClass();
+classVar = new ImplementsTypeAlias();
+
+// Verify Closure accepts the various subtypes of AbstractClass.
+let /** @type {!AbstractClass} */ abstractClassVar: AbstractClass;
+let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = /** @type {?} */(( null as any));
+abstractClassVar = interfaceExtendsAbstractClass;
+abstractClassVar = new ClassImplementsAbstractClass();
+abstractClassVar = new ClassExtendsAbstractClass();
 
 // Reproduce issue #333: type/value namespace collision.
 // Because Zone is both a type and a value, the interface will be dropped

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -191,7 +191,7 @@ classFunc(): void {}
 
 // Verify Closure accepts the various subtypes of Interface.
 let /** @type {!Interface} */ interfaceVar: Interface;
-// TODO(evanm): interfaceVar = interfaceExtendsInterface;
+interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
 

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/class/class.ts:46:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:58:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /** @record */
@@ -15,10 +15,25 @@ class Super {
 superFunc(): void {}
 }
 /**
+ * @abstract
+ */
+abstract class AbstractClass {
+/**
+ * @abstract
+ * @return {void}
+ */
+abstractFunc() {}
+/**
+ * @return {void}
+ */
+nonAbstractFunc(): void { }
+}
+/**
  * @implements {Interface}
  * @extends {Super}
+ * @extends {AbstractClass}
  */
-class Implements implements Interface, Super {
+class Implements implements Interface, Super, AbstractClass {
 /**
  * @return {void}
  */
@@ -27,6 +42,14 @@ interfaceFunc(): void {}
  * @return {void}
  */
 superFunc(): void {}
+/**
+ * @return {void}
+ */
+abstractFunc(): void {}
+/**
+ * @return {void}
+ */
+nonAbstractFunc(): void {}
 }
 /**
  * @implements {Interface}
@@ -36,6 +59,12 @@ class Extends extends Super implements Interface {
  * @return {void}
  */
 interfaceFunc(): void {}
+}
+class ExtendsAbstract extends AbstractClass {
+/**
+ * @return {void}
+ */
+abstractFunc(): void {}
 }
 
 // It's also legal to alias a type and then implement the alias.

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -1,4 +1,4 @@
-Warning at test_files/class/class.ts:141:1: type/symbol conflict for Zone, using {?} for now
+Warning at test_files/class/class.ts:125:1: type/symbol conflict for Zone, using {?} for now
 ====
 
 /**
@@ -40,9 +40,11 @@ abstractFunc() {}
  */
 nonAbstractFunc(): void { }
 }
-/** @record */
+/**
+ * @record
+ * @extends {Interface}
+ */
 function InterfaceExtendsInterface() {}
-// TODO: derived interfaces.
 /** @type {function(): void} */
 InterfaceExtendsInterface.prototype.interfaceFunc2;
 
@@ -62,54 +64,13 @@ InterfaceExtendsInterface.prototype.interfaceFunc2;
 interface InterfaceExtendsInterface extends Interface {
   interfaceFunc2(): void;
 }
-/** @record */
-function InterfaceExtendsClass() {}
-// TODO: derived interfaces.
-/** @type {function(): void} */
-InterfaceExtendsClass.prototype.interfaceFunc2;
-
-interface InterfaceExtendsClass extends Class {
-  interfaceFunc2(): void;
-}
-/** @record */
-function InterfaceExtendsAbstractClass() {}
-// TODO: derived interfaces.
-/** @type {function(): void} */
-InterfaceExtendsAbstractClass.prototype.interfaceFunc2;
-
-interface InterfaceExtendsAbstractClass extends AbstractClass {
-  interfaceFunc2(): void;
-}
-// Create values of each of the above interface types for use in later testing.
+// Note: interfaces can only extend interfaces, so there's no
+// InterfaceExtendsClass etc.
 let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface: InterfaceExtendsInterface = {
 /**
  * @return {void}
  */
 interfaceFunc() {},
-/**
- * @return {void}
- */
-interfaceFunc2() {}
-};
-let /** @type {!InterfaceExtendsClass} */ interfaceExtendsClass: InterfaceExtendsClass = {
-/**
- * @return {void}
- */
-classFunc() {},
-/**
- * @return {void}
- */
-interfaceFunc2() {}
-};
-let /** @type {!InterfaceExtendsAbstractClass} */ interfaceExtendsAbstractClass: InterfaceExtendsAbstractClass = {
-/**
- * @return {void}
- */
-abstractFunc() {},
-/**
- * @return {void}
- */
-nonAbstractFunc() {},
 /**
  * @return {void}
  */
@@ -236,14 +197,12 @@ interfaceVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of Class.
 let /** @type {!Class} */ classVar: Class;
-// TODO(evanm): classVar = interfaceExtendsClass;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
 
 // Verify Closure accepts the various subtypes of AbstractClass.
 let /** @type {!AbstractClass} */ abstractClassVar: AbstractClass;
-// TODO(evanm): abstractClassVar = interfaceExtendsAbstractClass;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 


### PR DESCRIPTION
In preparation for #410, add some more test cases and comments to the "class" test.

No functionality change, just comments and renames.