### PR TITLE
Strip Clutz' look of disapproval namespace (ಠ_ಠ.clutz)

### DIFF
--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -187,6 +187,12 @@ export class TypeTranslator {
       reportInaccessibleThisError: doNothing,
     };
     builder.buildSymbolDisplay(sym, writer, this.node);
+    // Clutz (https://github.com/angular/clutz) emits global type symbols hidden in a special
+    // ಠ_ಠ.clutz namespace. While most code seen by Tsickle will only ever see local aliases, Clutz
+    // symbols can be written by users directly in code, and they can appear by dereferencing
+    // TypeAliases. The code below simply strips the prefix, the remaining type name then matches
+    // Closure's type.
+    if (str.startsWith('ಠ_ಠ.clutz.')) str = str.substring('ಠ_ಠ.clutz.'.length);
     return str;
   }
 

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -41,6 +41,8 @@ describe('golden file tests', () => {
   it('generates correct Closure code', (done: (err?: Error) => void) => {
     let tests = goldenTests();
     let goldenJs = ([] as string[]).concat(...tests.map(t => t.jsPaths));
+    goldenJs.push('test_files/clutz.no_externs/some_name_space.js');
+    goldenJs.push('test_files/clutz.no_externs/some_other.js');
     goldenJs.push('test_files/import_from_goog/closure_Module.js');
     goldenJs.push('test_files/import_from_goog/closure_OtherModule.js');
     let externs = tests.map(t => t.externsPath).filter(fs.existsSync);

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -144,7 +144,7 @@ testFn('golden tests', () => {
               readFile: ts.sys.readFile,
             },
             testSupport.compilerOptions);
-        if (externs) {
+        if (externs && !test.name.endsWith('.no_externs')) {
           if (!allExterns) allExterns = tsickle.EXTERNS_HEADER;
           allExterns += externs;
         }

--- a/test_files/clutz.no_externs/clutz_typings.d.ts
+++ b/test_files/clutz.no_externs/clutz_typings.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz.some.name.space {
+  class ClutzedClass { field: ಠ_ಠ.clutz.some.other.TypeAlias; }
+  function clutzedFn(param: ಠ_ಠ.clutz.some.other.TypeAlias);
+}
+
+declare module 'goog:some.name.space' {
+  import alias = ಠ_ಠ.clutz.some.name.space;
+  export = alias;
+}
+
+declare namespace ಠ_ಠ.clutz.some.other {
+  type TypeAlias = ClutzedInterface;
+  interface ClutzedInterface { field: string; }
+}
+
+declare module 'goog:some.other' {
+  import alias = ಠ_ಠ.clutz.some.other;
+  export = alias;
+}

--- a/test_files/clutz.no_externs/clutz_typings.tsickle.d.ts
+++ b/test_files/clutz.no_externs/clutz_typings.tsickle.d.ts
@@ -1,0 +1,19 @@
+declare namespace ಠ_ಠ.clutz.some.name.space {
+  class ClutzedClass { field: ಠ_ಠ.clutz.some.other.TypeAlias; }
+  function clutzedFn(param: ಠ_ಠ.clutz.some.other.TypeAlias);
+}
+
+declare module 'goog:some.name.space' {
+  import alias = ಠ_ಠ.clutz.some.name.space;
+  export = alias;
+}
+
+declare namespace ಠ_ಠ.clutz.some.other {
+  type TypeAlias = ClutzedInterface;
+  interface ClutzedInterface { field: string; }
+}
+
+declare module 'goog:some.other' {
+  import alias = ಠ_ಠ.clutz.some.other;
+  export = alias;
+}

--- a/test_files/clutz.no_externs/some_name_space.js
+++ b/test_files/clutz.no_externs/some_name_space.js
@@ -1,0 +1,9 @@
+goog.module('some.name.space');
+
+const other = goog.require('some.other');
+
+exports.ClutzedClass = class {
+  constructor() { /** @type {!other.TypeAlias} */ this.field; }
+};
+/** @param {!other.TypeAlias} param a param. */
+exports.clutzedFn = function(param) {};

--- a/test_files/clutz.no_externs/some_other.js
+++ b/test_files/clutz.no_externs/some_other.js
@@ -1,0 +1,11 @@
+goog.module('some.other');
+
+/** @record */
+const ClutzedInterface = function() {};
+/** @type {string} */
+ClutzedInterface.prototype.field;
+
+exports.ClutzedInterface = ClutzedInterface;
+
+/** @typedef {ClutzedInterface} */
+exports.TypeAlias;

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,0 +1,9 @@
+goog.module('test_files.clutz.no_externs.strip_clutz_type');var module = module || {id: 'test_files/clutz.no_externs/strip_clutz_type.js'};
+var goog_some_name_space_1 = goog.require('some.name.space');
+const tsickle_forward_declare_1 = goog.forwardDeclare('some.name.space');
+const tsickle_forward_declare_2 = goog.forwardDeclare('some.other');
+goog.require('some.other'); // force type-only module to be loaded
+let /** @type {!tsickle_forward_declare_1.ClutzedClass} */ clutzedClass = new goog_some_name_space_1.ClutzedClass();
+console.log(clutzedClass);
+let /** @type {!some.other.ClutzedInterface} */ typeAliased = clutzedClass.field;
+goog_some_name_space_1.clutzedFn(typeAliased);

--- a/test_files/clutz.no_externs/strip_clutz_type.ts
+++ b/test_files/clutz.no_externs/strip_clutz_type.ts
@@ -1,0 +1,7 @@
+import {ClutzedClass, clutzedFn} from 'goog:some.name.space';
+import {TypeAlias} from 'goog:some.other';
+
+let clutzedClass: ClutzedClass = new ClutzedClass();
+console.log(clutzedClass);
+let typeAliased: TypeAlias = clutzedClass.field;
+clutzedFn(typeAliased);

--- a/test_files/clutz.no_externs/strip_clutz_type.tsickle.ts
+++ b/test_files/clutz.no_externs/strip_clutz_type.tsickle.ts
@@ -1,0 +1,10 @@
+import {ClutzedClass, clutzedFn} from 'goog:some.name.space';
+const tsickle_forward_declare_1 = goog.forwardDeclare('some.name.space');
+import {TypeAlias} from 'goog:some.other';
+const tsickle_forward_declare_2 = goog.forwardDeclare('some.other');
+goog.require('some.other'); // force type-only module to be loaded
+
+let /** @type {!tsickle_forward_declare_1.ClutzedClass} */ clutzedClass: ClutzedClass = new ClutzedClass();
+console.log(clutzedClass);
+let /** @type {!some.other.ClutzedInterface} */ typeAliased: TypeAlias = clutzedClass.field;
+clutzedFn(typeAliased);


### PR DESCRIPTION
Most code seen by Tsickle will only ever see local aliases, Clutz
symbols can be written by users directly in code, and they can appear by
dereferencing TypeAliases. The code below simply strips the prefix, the
remaining type name then matches Closure's type.