### PR TITLE
Support input source maps that say their file name is different from what tsc was told.

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -64,11 +64,16 @@ export function sourceMapConsumerToGenerator(sourceMapConsumer: SourceMapConsume
  * own source maps, we patch them with the file name from the tsc source maps
  * before composing them.
  */
-export function sourceMapGeneratorToConsumerWithFileName(
-    sourceMapGenerator: SourceMapGenerator, fileName: string): SourceMapConsumer {
+export function sourceMapGeneratorToConsumer(
+    sourceMapGenerator: SourceMapGenerator, fileName?: string,
+    sourceName?: string): SourceMapConsumer {
   const rawSourceMap = sourceMapGenerator.toJSON();
-  rawSourceMap.sources = [fileName];
-  rawSourceMap.file = fileName;
+  if (sourceName) {
+    rawSourceMap.sources = [sourceName];
+  }
+  if (fileName) {
+    rawSourceMap.file = fileName;
+  }
   return new SourceMapConsumer(rawSourceMap);
 }
 

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
+import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 import {convertDecorators} from './decorator-annotator';
@@ -236,8 +236,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const tsickleSourceMapGenerator = this.tsickleSourceMaps.get(sourceMapKey)!;
-        const tsickleSourceMapConsumer = sourceMapUtils.sourceMapGeneratorToConsumerWithFileName(
-            tsickleSourceMapGenerator, sourceFileName);
+        const tsickleSourceMapConsumer = sourceMapUtils.sourceMapGeneratorToConsumer(
+            tsickleSourceMapGenerator, sourceFileName, sourceFileName);
         tscSourceMapGenerator.applySourceMap(tsickleSourceMapConsumer);
       }
     }
@@ -247,9 +247,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const decoratorDownlevelSourceMapGenerator =
             this.decoratorDownlevelSourceMaps.get(sourceMapKey)!;
-        const decoratorDownlevelSourceMapConsumer =
-            sourceMapUtils.sourceMapGeneratorToConsumerWithFileName(
-                decoratorDownlevelSourceMapGenerator, sourceFileName);
+        const decoratorDownlevelSourceMapConsumer = sourceMapUtils.sourceMapGeneratorToConsumer(
+            decoratorDownlevelSourceMapGenerator, sourceFileName, sourceFileName);
         tscSourceMapGenerator.applySourceMap(decoratorDownlevelSourceMapConsumer);
       }
     }
@@ -259,8 +258,8 @@ export class TsickleCompilerHost implements ts.CompilerHost {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const preexistingSourceMapGenerator = this.preexistingSourceMaps.get(sourceMapKey);
         if (preexistingSourceMapGenerator) {
-          const preexistingSourceMapConsumer =
-              new SourceMapConsumer(preexistingSourceMapGenerator.toJSON());
+          const preexistingSourceMapConsumer = sourceMapUtils.sourceMapGeneratorToConsumer(
+              preexistingSourceMapGenerator, sourceFileName);
           tscSourceMapGenerator.applySourceMap(preexistingSourceMapConsumer);
         }
       }

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -242,6 +242,22 @@ describe('source maps', () => {
     expect(sourceMap.originalPositionFor({line, column}).line).to.equal(6, 'method position');
   });
 
+  it('handles input source maps with different file names than supplied to tsc', function() {
+    const sources = new Map<string, string>();
+    const inputSourceMap =
+        `{"version":3,"sources":["original.ts"],"names":[],"mappings":"AAAA,MAAM,EAAE,EAAE,CAAC","file":"foo/bar/intermediate.ts","sourceRoot":""}`;
+    const encodedSourceMap = Buffer.from(inputSourceMap, 'utf8').toString('base64');
+    sources.set('intermediate.ts', `const x = 3;
+//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
+
+    const {compiledJS, sourceMap} = compile(sources);
+
+    const {line, column} = getLineAndColumn(compiledJS, 'x');
+    expect(sourceMap.originalPositionFor({line, column}).line).to.equal(1, 'x definition');
+    expect(sourceMap.originalPositionFor({line, column}).source)
+        .to.equal('original.ts', 'input file name');
+  });
+
   it(`doesn't blow up putting an inline source map in an empty file`, function() {
     const sources = new Map<string, string>();
     sources.set('input.ts', ``);


### PR DESCRIPTION
Motivating example is that ngc produces fully specified source map file names, but we compile them by their bare names.  (e.g. /foo/bar/baz.ngfactory.ts vs. baz.ngfactory.ts).