### PR TITLE
fix jsdoc parsing on Windows

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -148,6 +148,8 @@ const JSDOC_TAGS_WITH_TYPES = [
  * Returns null if comment is not JSDoc.
  */
 export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null {
+  // Make sure we have proper line endings before parsing on Windows.
+  comment = comment.replace(/\r\n/g, '\n');
   // TODO(evanm): this is a pile of hacky regexes for now, because we
   // would rather use the better TypeScript implementation of JSDoc
   // parsing.  https://github.com/Microsoft/TypeScript/issues/7393


### PR DESCRIPTION
Fixes #440