### PR TITLE
drop an unneeded test

### DIFF
--- a/test_files/export_default/default.js
+++ b/test_files/export_default/default.js
@@ -1,8 +1,0 @@
-goog.module('test_files.export_default.default');var module = module || {id: 'test_files/export_default/default.js'};
-class Foo {
-    /**
-     * @return {number}
-     */
-    static bar() { return 3; }
-}
-exports.default = Foo;

--- a/test_files/export_default/default.ts
+++ b/test_files/export_default/default.ts
@@ -1,4 +1,0 @@
-// The resulting module should have no __esModule attribute defined.
-export default class Foo {
-  static bar() { return 3; }
-}

--- a/test_files/export_default/default.tsickle.ts
+++ b/test_files/export_default/default.tsickle.ts
@@ -1,7 +1,0 @@
-
-export default class Foo {
-/**
- * @return {number}
- */
-static bar() { return 3; }
-}


### PR DESCRIPTION
I just added this test, but in the review Alex pointed out that it wasn't too useful
because it is redundant with some other tests.  I agreed with him but then failed
to remove it before submitting.