### PR TITLE
Do not emit duplicate @deprecated tags.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1132,7 +1132,7 @@ class Annotator extends ClosureRewriter {
     tags.push({tagName: 'type', type: this.typeToClosure(p)});
     // Avoid printing annotations that can conflict with @type
     // This avoids Closure's error "type annotation incompatible with other annotations"
-    this.emit(jsdoc.toString(tags, ['param', 'return']));
+    this.emit(jsdoc.toString(tags, new Set(['param', 'return'])));
     namespace = namespace.concat([name]);
     this.emit(`${namespace.join('.')};\n`);
   }

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -17,7 +17,7 @@ describe('jsdoc.parse', () => {
   });
   it('grabs plain text from jsdoc', () => {
     let source = '/** jsdoc comment */';
-    expect(jsdoc.parse(source)).to.deep.equal({tags: [{text: 'jsdoc comment'}]});
+    expect(jsdoc.parse(source)).to.deep.equal({tags: [{tagName: '', text: 'jsdoc comment'}]});
   });
   it('gathers @tags from jsdoc', () => {
     let source = `/**
@@ -59,5 +59,18 @@ describe('jsdoc.parse', () => {
     expect(jsdoc.parse(source)).to.deep.equal({
       tags: [{tagName: 'suppress', text: '{checkTypes} I hate types'}]
     });
+  });
+});
+
+describe('jsdoc.toString', () => {
+  it('filters duplicated @deprecated tags', () => {
+    expect(jsdoc.toString([
+      {tagName: 'deprecated'}, {tagName: 'param', parameterName: 'hello', text: 'world'},
+      {tagName: 'deprecated'}
+    ])).to.equal(`/**
+ * @deprecated
+ * @param hello world
+ */
+`);
   });
 });


### PR DESCRIPTION
Also consistently use sets for the include operations.

Fixes #449.