### PR TITLE
Fix index imports take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build
 
 # Dependency directory
-./node_modules
+/node_modules
 
 # WebStorm/IntelliJ directory
 .idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tsickle - TypeScript to Closure Translator [![Build Status](https://travis-ci.org/angular/tsickle.svg?branch=master)](https://travis-ci.org/angular/tsickle)
+# Tsickle - TypeScript to Closure Translator [![Linux build](https://travis-ci.org/angular/tsickle.svg?branch=master)](https://travis-ci.org/angular/tsickle) [![Windows build](https://ci.appveyor.com/api/projects/status/puxdblmlqbofqqt1/branch/master?svg=true)](https://ci.appveyor.com/project/alexeagle/tsickle/branch/master)
 
 Tsickle converts TypeScript code into a form acceptable to the [Closure
 Compiler].  This allows using TypeScript to transpile your sources, and then

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -860,12 +860,12 @@ class Annotator extends ClosureRewriter {
       if (resolved && resolved.resolvedModule) {
         const requestedModule = moduleId.replace(extension, '');
         const resolvedModule = resolved.resolvedModule.resolvedFileName.replace(extension, '');
-        if (requestedModule.substr(requestedModule.lastIndexOf('/')) !==
-            resolvedModule.substr(resolvedModule.lastIndexOf('/'))) {
-          const relative = './' + path.relative(path.dirname(this.file.fileName), resolvedModule);
-          // moduleResolution=node support: if importing from under
-          // node_modules, omit the leading part of the path.
-          moduleId = relative.replace(/^(\.+\/)+node_modules\//, '');
+        if (resolvedModule.indexOf('node_modules') === -1 &&
+            requestedModule.substr(requestedModule.lastIndexOf('/')) !==
+                resolvedModule.substr(resolvedModule.lastIndexOf('/'))) {
+          moduleId = './' +
+              path.relative(path.dirname(this.file.fileName), resolvedModule)
+                  .replace(path.sep, '/');
         }
       }
     }

--- a/test_files/index_import/node_modules/foo/package.json
+++ b/test_files/index_import/node_modules/foo/package.json
@@ -1,3 +1,3 @@
 {
-  "main": "subdir/foo.js"
+  "main": "subdir/index.js"
 }

--- a/test_files/index_import/user.tsickle.ts
+++ b/test_files/index_import/user.tsickle.ts
@@ -12,4 +12,4 @@ import {a as a3} from './has_index/index.js';
 const tsickle_forward_declare_5 = goog.forwardDeclare('test_files.index_import.has_index.index');
 import {b} from './lib';
 const tsickle_forward_declare_6 = goog.forwardDeclare('test_files.index_import.lib');
-import * as foo from 'foo/subdir/foo';
+import * as foo from 'foo';


### PR DESCRIPTION
index imports should not apply to node_modules

See notes at https://github.com/angular/tsickle/pull/462#issuecomment-295433380
Closure understands package.json, and third-party libraries may have a different shape
when TypeScript resolves modules (.d.ts layout is different from .js layout)