### PR TITLE
add license headers to newer files

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
  * @fileoverview Extern definitions for types missing in the Closure externs,
  * but used in TypeScript platform `.d.ts`.
  * @externs

--- a/src/modules_manifest.ts
+++ b/src/modules_manifest.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export interface FileMap<T> { [fileName: string]: T; }
 
 /** A class that maintains the module dependency graph of output JS files. */

--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
 
 /**

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as path from 'path';
 import {SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';


### PR DESCRIPTION
These sources files were added without a @license header.  Fix that.