### PR TITLE
Upgrade to TypeScript 2.3.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "source-map-support": "^0.4.2"
   },
   "peerDependencies": {
-    "typescript": "2.3.0"
+    "typescript": "2.3.1"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",
@@ -43,7 +43,7 @@
     "mocha": "^3.2.0",
     "temp": "^0.8.1",
     "tslint": "^3.15.1",
-    "typescript": "2.3.0"
+    "typescript": "2.3.1"
   },
   "scripts": {
     "prepublish": "gulp compile",

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -439,7 +439,7 @@ export class TypeTranslator {
           indexable = true;
           break;
         default:
-          let member = type.symbol.members.get(field);
+          let member = type.symbol.members.get(field)!;
           // optional members are handled by the type including |undefined in a union type.
           let memberType =
               this.translate(this.typeChecker.getTypeOfSymbolAtLocation(member, this.node));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,9 +1867,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.0.tgz#2e63e09284392bc8158a2444c33e2093795c0418"
+typescript@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.1.tgz#e3361fb395c6c3f9c69faeeabc9503f8bdecaea1"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
The underlying implementation of getTypeOfSymbolAtLocation hasn't
changed, but a slightly different call chain causes the compiler to
reject `undefined` arguments.