### PR TITLE
split the externs comment

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -4,7 +4,9 @@
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
- *
+ */
+
+/**
  * @fileoverview Extern definitions for types missing in the Closure externs,
  * but used in TypeScript platform `.d.ts`.
  * @externs


### PR DESCRIPTION
The comment as written was not being parsed as externs.