### PR TITLE
Fix goog.module path on Windows for cases where the incoming fileName…

### DIFF
--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -186,6 +186,12 @@ export class TsickleCompilerHost implements ts.CompilerHost {
         content = this.combineInlineSourceMaps(fileName, content);
       }
       if (this.options.googmodule && !isDtsFileName(fileName)) {
+        // Remove currentDirectory part from filename if it is absolute
+        if (path.isAbsolute(fileName)) {
+          // Normalize Windows backslash to URL forwardslash
+          const currDir = this.getCurrentDirectory().replace(/\\/g, '/');
+          fileName = fileName.replace(currDir + '/', '');
+        }
         content = this.convertCommonJsToGoogModule(fileName, content);
       }
     } else {


### PR DESCRIPTION
… of the module is absolute

cc @evmar 

Should there be a test for this? This worked inside golden tests but not in command line.