### PR TITLE
always emit interfaces, even in untyped mode

### DIFF
--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,4 +1,10 @@
-goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};class Super {
+goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};/**
+ * @record
+ */
+function Interface() { }
+/** @type {?} */
+Interface.prototype.interfaceFunc;
+class Super {
     /**
      * @return {?}
      */

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -1,3 +1,10 @@
+
+/**
+ * @record
+ */
+function Interface() {}
+/** @type {?} */
+Interface.prototype.interfaceFunc;
 interface Interface {
   interfaceFunc(): void;
 }

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -2,3 +2,10 @@ goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id
 class Class {
 }
 exports.Class = Class;
+/**
+ * @record
+ */
+function Interface() { }
+exports.Interface = Interface;
+/** @type {?} */
+Interface.prototype.x;

--- a/test_files/jsdoc_types.untyped/module1.ts
+++ b/test_files/jsdoc_types.untyped/module1.ts
@@ -1,2 +1,5 @@
 export class Class {}
-export interface Interface { x: number }
+export interface Interface {
+  x: number;
+  "quoted-bad-name": string;
+}

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -1,3 +1,10 @@
 
 export class Class {}
+/**
+ * @record
+ */
+export function Interface() {}
+/** @type {?} */
+Interface.prototype.x;
+
 export interface Interface { x: number }

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -6,5 +6,11 @@ export class Class {}
 export function Interface() {}
 /** @type {?} */
 Interface.prototype.x;
+/* TODO: handle strange member:
+"quoted-bad-name": string;
+*/
 
-export interface Interface { x: number }
+export interface Interface {
+  x: number;
+  "quoted-bad-name": string;
+}

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -5,6 +5,13 @@ exports.ClassOne = ClassOne;
 class ClassTwo {
 }
 exports.ClassTwo = ClassTwo;
+/**
+ * @record
+ */
+function Interface() { }
+exports.Interface = Interface;
+/** @type {?} */
+Interface.prototype.x;
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;

--- a/test_files/jsdoc_types.untyped/module2.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module2.tsickle.ts
@@ -1,6 +1,13 @@
 
 export class ClassOne {}
 export class ClassTwo {}
+/**
+ * @record
+ */
+export function Interface() {}
+/** @type {?} */
+Interface.prototype.x;
+
 export interface Interface { x: number }
 export class ClassWithParams<T> {}
 

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,3 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/* This filename is specially marked in the tsickle test
- * suite runner so that its types are always {?}.*/
-
+goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};
+/**
+ * @record
+ */
+function NeverTyped() { }
+exports.NeverTyped = NeverTyped;
+/** @type {?} */
+NeverTyped.prototype.foo;

--- a/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
@@ -1,3 +1,10 @@
+
+/**
+ * @record
+ */
+export function NeverTyped() {}
+/** @type {?} */
+NeverTyped.prototype.foo;
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 

--- a/test_files/jsdoc_types/module1.ts
+++ b/test_files/jsdoc_types/module1.ts
@@ -1,2 +1,5 @@
 export class Class {}
-export interface Interface { x: number }
+export interface Interface {
+  x: number;
+  "quoted-bad-name": string;
+}

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -6,5 +6,11 @@ export class Class {}
 export function Interface() {}
 /** @type {number} */
 Interface.prototype.x;
+/* TODO: handle strange member:
+"quoted-bad-name": string;
+*/
 
-export interface Interface { x: number }
+export interface Interface {
+  x: number;
+  "quoted-bad-name": string;
+}


### PR DESCRIPTION
This changes inches us closer to fully typed mode, by making us
always emit a type definition even in untyped mode.

We accomplish this by moving around a few if statements.  The
resulting interfaces don't have heritance clauses (that broke
in google3) and the fields don't have types, but it means that
at least a type that is declared in TypeScript is visible (albeit
slightly mangled) to Closure code.