### PR TITLE
Simplify types in decorator downlevel.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -14,13 +14,6 @@ import {Rewriter} from './rewriter';
 import {assertTypeChecked, TypeTranslator} from './type-translator';
 import {toArray} from './util';
 
-export const ANNOTATION_SUPPORT_CODE = `
-interface DecoratorInvocation {
-  type: Function;
-  args?: any[];
-}
-`;
-
 // ClassRewriter rewrites a single "class Foo {...}" declaration.
 // It's its own object because we collect decorators on the class and the ctor
 // separately for each class we encounter.
@@ -204,8 +197,9 @@ class ClassRewriter extends Rewriter {
    * emitMetadata emits the various gathered metadata, as static fields.
    */
   private emitMetadata() {
+    const decoratorInvocations = '{type: Function, args?: any[]}[]';
     if (this.decorators) {
-      this.emit(`static decorators: DecoratorInvocation[] = [\n`);
+      this.emit(`static decorators: ${decoratorInvocations} = [\n`);
       for (let annotation of this.decorators) {
         this.emitDecorator(annotation);
         this.emit(',\n');
@@ -218,7 +212,8 @@ class ClassRewriter extends Rewriter {
       // ctorParameters may contain forward references in the type: field, so wrap in a function
       // closure
       this.emit(
-          `static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [\n`);
+          `static ctorParameters: () => ({type: any, decorators?: ` + decoratorInvocations +
+          `}|null)[] = () => [\n`);
       for (let param of this.ctorParameters || []) {
         if (!param) {
           this.emit('null,\n');
@@ -240,7 +235,7 @@ class ClassRewriter extends Rewriter {
     }
 
     if (this.propDecorators) {
-      this.emit('static propDecorators: {[key: string]: DecoratorInvocation[]} = {\n');
+      this.emit(`static propDecorators: {[key: string]: ` + decoratorInvocations + `} = {\n`);
       for (let name of toArray(this.propDecorators.keys())) {
         this.emit(`'${name}': [`);
 

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -82,14 +82,6 @@ export interface TsickleHost {
   fileNameToModuleId(fileName: string): string;
 }
 
-const ANNOTATION_SUPPORT = `
-interface DecoratorInvocation {
-  type: Function;
-  args?: any[];
-}
-`;
-
-
 /**
  * TsickleCompilerHost does tsickle processing of input files, including
  * closure type annotation processing, decorator downleveling and
@@ -314,7 +306,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       // No changes; reuse the existing parse.
       return sourceFile;
     }
-    fileContent = converted.output + ANNOTATION_SUPPORT;
+    fileContent = converted.output;
     this.decoratorDownlevelSourceMaps.set(
         this.getSourceMapKeyForSourceFile(sourceFile), converted.sourceMap);
     return ts.createSourceFile(fileName, fileContent, languageVersion, true);

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -10,7 +10,7 @@ import {expect} from 'chai';
 import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
-import {ANNOTATION_SUPPORT_CODE, convertDecorators} from '../src/decorator-annotator';
+import {convertDecorators} from '../src/decorator-annotator';
 import * as tsickle from '../src/tsickle';
 
 import * as testSupport from './test_support';
@@ -27,7 +27,7 @@ function sources(sourceText: string): Map<string, string> {
 
 function verifyCompiles(sourceText: string) {
   // This throws an exception on error.
-  testSupport.createProgram(sources(ANNOTATION_SUPPORT_CODE + sourceText));
+  testSupport.createProgram(sources(sourceText));
 }
 
 describe(
@@ -101,12 +101,12 @@ let param: any;
 
 class Foo {
   field: string;
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test1 },
 { type: Test2, args: [param, ] },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -122,11 +122,11 @@ class Foo {
 
 class Foo {
   field: string;
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -142,11 +142,11 @@ class Foo {
 
 class Foo {
   field: string;
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -174,14 +174,14 @@ let param: any;
 
 
 class Foo {
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test1, args: [{name: 'percentPipe'}, class ZZZ {}, ] },
 { type: Test2 },
 { type: Test3 },
 { type: Test4, args: [param, ] },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -195,11 +195,11 @@ export class Foo {
 /** @Annotation */ let Test1: Function;
 
 export class Foo {
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test1 },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -222,19 +222,19 @@ export class Foo {
 export class Foo {
   foo() {
     \n    class Bar {
-    static decorators: DecoratorInvocation[] = [
+    static decorators: {type: Function, args?: any[]}[] = [
 { type: Test2 },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }
   }
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test1 },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
 }`);
         });
@@ -266,7 +266,7 @@ class Foo {
   constructor( bar: AbstractService,  num: AnEnum) {
   }
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: AbstractService, decorators: [{ type: Inject }, ]},
 {type: AnEnum, decorators: [{ type: Inject, args: ['enum', ] }, ]},
 ];
@@ -288,11 +288,11 @@ import {BarService} from 'bar';
 class Foo {
   constructor(bar: BarService, num: number) {
   }
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: Test1 },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: BarService, },
 null,
 ];
@@ -315,7 +315,7 @@ class Foo {
   constructor( x: bar.BarService, {a, b}, defArg = 3, optional?: bar.BarService) {
   }
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: bar.BarService, decorators: [{ type: Inject, args: [param, ] }, ]},
 null,
 null,
@@ -336,7 +336,7 @@ let APP_ID: any;
 class ViewUtils {
   constructor( private _appId: string) {}
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: undefined, decorators: [{ type: Inject, args: [APP_ID, ] }, ]},
 ];
 }`);
@@ -354,7 +354,7 @@ class Foo {
   constructor( typed: Promise<string>) {
   }
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: Promise, decorators: [{ type: Inject }, ]},
 ];
 }`);
@@ -374,7 +374,7 @@ interface Iface {}
 class Foo {
   constructor( aClass: Class,  aIface: Iface) {}
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: Class, decorators: [{ type: Inject }, ]},
 {type: undefined, decorators: [{ type: Inject }, ]},
 ];
@@ -400,7 +400,7 @@ class Foo {
 /** @Annotation */ let Test1: Function;
 class Foo {
   \n  bar() {}
-static propDecorators: {[key: string]: DecoratorInvocation[]} = {
+static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 'bar': [{ type: Test1, args: ['somename', ] },],
 };
 }`);
@@ -422,7 +422,7 @@ class ClassWithDecorators {
   b;
 
   \n  set c(value) {}
-static propDecorators: {[key: string]: DecoratorInvocation[]} = {
+static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 'a': [{ type: PropDecorator, args: ["p1", ] },{ type: PropDecorator, args: ["p2", ] },],
 'c': [{ type: PropDecorator, args: ["p3", ] },],
 };
@@ -455,7 +455,7 @@ class Foo {
 class Foo {
   missingSemi = () => {}
    other: number;
-static propDecorators: {[key: string]: DecoratorInvocation[]} = {
+static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 'other': [{ type: PropDecorator },],
 };
 }`);

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -12,7 +12,7 @@ import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import * as cliSupport from '../src/cli_support';
-import {ANNOTATION_SUPPORT_CODE, convertDecorators} from '../src/decorator-annotator';
+import {convertDecorators} from '../src/decorator-annotator';
 import {toClosureJS} from '../src/main';
 import {getInlineSourceMapCount, setInlineSourceMap,} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
@@ -310,7 +310,6 @@ function decoratorDownlevelAndAddInlineSourceMaps(sources: Map<string, string>):
   for (const fileName of toArray(sources.keys())) {
     let {output, sourceMap: preexistingSourceMap} =
         convertDecorators(program.getTypeChecker(), program.getSourceFile(fileName));
-    output = output + ANNOTATION_SUPPORT_CODE;
     transformedSources.set(fileName, setInlineSourceMap(output, preexistingSourceMap.toString()));
   }
   return transformedSources;

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -11,7 +11,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {ANNOTATION_SUPPORT_CODE} from '../src/decorator-annotator';
 import * as tsickle from '../src/tsickle';
 import {toArray} from '../src/util';
 
@@ -113,7 +112,6 @@ testFn('golden tests', () => {
             tsickle.convertDecorators(program.getTypeChecker(), program.getSourceFile(tsPath));
         expect(diagnostics).to.be.empty;
         if (output !== tsSources.get(tsPath)) {
-          output += ANNOTATION_SUPPORT_CODE;
           let decoratedPath = tsPath.replace(/.ts(x)?$/, '.decorated.ts$1');
           expect(decoratedPath).to.not.equal(tsPath);
           compareAgainstGolden(output, decoratedPath);

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -20,13 +20,13 @@ class DecoratorTest {
 
   
   private y: number;
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: classAnnotation },
 ];
 /** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
-static propDecorators: {[key: string]: DecoratorInvocation[]} = {
+static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 'y': [{ type: annotationDecorator },],
 };
 }
@@ -34,9 +34,4 @@ static propDecorators: {[key: string]: DecoratorInvocation[]} = {
 @classDecorator
 class DecoratedClass {
   z: string;
-}
-
-interface DecoratorInvocation {
-  type: Function;
-  args?: any[];
 }

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -39,14 +39,14 @@ __decorate([
     __metadata("design:type", Number)
 ], DecoratorTest.prototype, "x", void 0);
 function DecoratorTest_tsickle_Closure_declarations() {
-    /** @type {!Array<!DecoratorInvocation>} */
+    /** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
     DecoratorTest.decorators;
     /**
      * @nocollapse
-     * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<!DecoratorInvocation>)})>}
+     * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
      */
     DecoratorTest.ctorParameters;
-    /** @type {!Object<string,!Array<!DecoratorInvocation>>} */
+    /** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
     DecoratorTest.propDecorators;
     /** @type {number} */
     DecoratorTest.prototype.x;
@@ -62,11 +62,3 @@ function DecoratedClass_tsickle_Closure_declarations() {
     /** @type {string} */
     DecoratedClass.prototype.z;
 }
-/**
- * @record
- */
-function DecoratorInvocation() { }
-/** @type {!Function} */
-DecoratorInvocation.prototype.type;
-/** @type {(undefined|!Array<?>)} */
-DecoratorInvocation.prototype.args;

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -29,28 +29,28 @@ class DecoratorTest {
   @decorator
 private x: number;
 private y: number;
-static decorators: DecoratorInvocation[] = [
+static decorators: {type: Function, args?: any[]}[] = [
 { type: classAnnotation },
 ];
 /**
  * @nocollapse
  */
-static ctorParameters: () => ({type: any, decorators?: DecoratorInvocation[]}|null)[] = () => [
+static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 ];
-static propDecorators: {[key: string]: DecoratorInvocation[]} = {
+static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 'y': [{ type: annotationDecorator },],
 };
 }
 
 function DecoratorTest_tsickle_Closure_declarations() {
-/** @type {!Array<!DecoratorInvocation>} */
+/** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
 DecoratorTest.decorators;
 /**
  * @nocollapse
- * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<!DecoratorInvocation>)})>}
+ * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
  */
 DecoratorTest.ctorParameters;
-/** @type {!Object<string,!Array<!DecoratorInvocation>>} */
+/** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
 DecoratorTest.propDecorators;
 /** @type {number} */
 DecoratorTest.prototype.x;
@@ -68,17 +68,3 @@ function DecoratedClass_tsickle_Closure_declarations() {
 DecoratedClass.prototype.z;
 }
 
-/**
- * @record
- */
-function DecoratorInvocation() {}
-/** @type {!Function} */
-DecoratorInvocation.prototype.type;
-/** @type {(undefined|!Array<?>)} */
-DecoratorInvocation.prototype.args;
-
-
-interface DecoratorInvocation {
-  type: Function;
-  args?: any[];
-}


### PR DESCRIPTION
This is needed to allow declarations:true on the resulting TS code, because the DecoratorInvocation type
was part of the public API but not exported.