### PR TITLE
More `@fileoverview` comments.

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -13,22 +13,32 @@
  * to their API will be easier.  See e.g. ts.JSDocTag and ts.JSDocComment.
  */
 export interface Tag {
-  // tagName is e.g. "param" in an @param declaration.  It is the empty string
-  // for the plain text documentation that occurs before any @foo lines.
+  /**
+   * tagName is e.g. "param" in an @param declaration.  It is the empty string
+   * for the plain text documentation that occurs before any @foo lines.
+   */
   tagName: string;
-  // parameterName is the the name of the function parameter, e.g. "foo"
-  // in
-  //   @param foo The foo param.
+  /**
+   * parameterName is the the name of the function parameter, e.g. "foo"
+   * in `\@param foo The foo param`
+   */
   parameterName?: string;
+  /**
+   * The type of a JSDoc \@param, \@type etc tag, rendered in curly braces.
+   * Can also hold the type of an \@suppress.
+   */
   type?: string;
-  // optional is true for optional function parameters.
+  /** optional is true for optional function parameters. */
   optional?: boolean;
-  // restParam is true for "...x: foo[]" function parameters.
+  /** restParam is true for "...x: foo[]" function parameters. */
   restParam?: boolean;
-  // destructuring is true for destructuring bind parameters, which require
-  // non-null arguments on the Closure side.  Can likely remove this
-  // once TypeScript nullable types are available.
+  /**
+   * destructuring is true for destructuring bind parameters, which require
+   * non-null arguments on the Closure side.  Can likely remove this
+   * once TypeScript nullable types are available.
+   */
   destructuring?: boolean;
+  /** Any remaining text on the tag, e.g. the description. */
   text?: string;
 }
 
@@ -37,72 +47,47 @@ export interface Tag {
  * The public Closure docs don't list all the tags it allows; this list comes
  * from the compiler source itself.
  * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/parsing/Annotation.java
+ * https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/parsing/ParserConfig.properties
  */
 const JSDOC_TAGS_WHITELIST = new Set([
-  'ngInject',
-  'abstract',
-  'argument',
-  'author',
-  'consistentIdGenerator',
-  'const',
-  'constant',
-  'constructor',
-  'copyright',
-  'define',
-  'deprecated',
-  'desc',
-  'dict',
-  'disposes',
-  'enum',
-  'export',
-  'expose',
-  'extends',
-  'externs',
-  'fileoverview',
-  'final',
-  'hidden',
-  'idGenerator',
-  'implements',
-  'implicitCast',
-  'inheritDoc',
-  'interface',
-  'record',
-  'jaggerInject',
-  'jaggerModule',
-  'jaggerProvidePromise',
-  'jaggerProvide',
-  'lends',
-  'license',
-  'meaning',
-  'modifies',
-  'noalias',
-  'nocollapse',
-  'nocompile',
-  'nosideeffects',
-  'override',
-  'owner',
-  'package',
-  'param',
-  'polymerBehavior',
-  'preserve',
-  'preserveTry',
-  'private',
-  'protected',
-  'public',
-  'return',
-  'returns',
-  'see',
-  'stableIdGenerator',
-  'struct',
-  'suppress',
-  'template',
-  'this',
-  'throws',
-  'type',
-  'typedef',
-  'unrestricted',
-  'version',
-  'wizaction',
+  'abstract',      'argument',
+  'author',        'consistentIdGenerator',
+  'const',         'constant',
+  'constructor',   'copyright',
+  'define',        'deprecated',
+  'desc',          'dict',
+  'disposes',      'enum',
+  'export',        'expose',
+  'extends',       'externs',
+  'fileoverview',  'final',
+  'hassoydelcall', 'hassoydeltemplate',
+  'hidden',        'id',
+  'idGenerator',   'ignore',
+  'implements',    'implicitCast',
+  'inheritDoc',    'interface',
+  'jaggerInject',  'jaggerModule',
+  'jaggerProvide', 'jaggerProvidePromise',
+  'lends',         'license',
+  'link',          'meaning',
+  'modifies',      'modName',
+  'mods',          'ngInject',
+  'noalias',       'nocollapse',
+  'nocompile',     'nosideeffects',
+  'override',      'owner',
+  'package',       'param',
+  'pintomodule',   'polymerBehavior',
+  'preserve',      'preserveTry',
+  'private',       'protected',
+  'public',        'record',
+  'requirecss',    'requires',
+  'return',        'returns',
+  'see',           'stableIdGenerator',
+  'struct',        'suppress',
+  'template',      'this',
+  'throws',        'type',
+  'typedef',       'unrestricted',
+  'version',       'wizaction',
+  'wizmodule',
 ]);
 
 /**
@@ -111,23 +96,15 @@ const JSDOC_TAGS_WHITELIST = new Set([
  * these will cause Closure Compiler issues and should not be used.
  */
 const JSDOC_TAGS_BLACKLIST = new Set([
-  'constructor',
-  'enum',
-  'extends',
-  'implements',
-  'interface',
-  'lends',
-  'private',
-  'public',
-  'record',
-  'template',
-  'this',
-  'type',
-  'typedef',
+  'augments', 'class',     'constructs', 'constructor', 'enhance',    'enhanceable',
+  'enum',     'extends',   'field',      'function',    'implements', 'interface',
+  'lends',    'namespace', 'private',    'public',      'record',     'static',
+  'template', 'this',      'type',       'typedef',
 ]);
 
 /**
  * A list of JSDoc @tags that might include a {type} after them. Only banned when a type is passed.
+ * Note that this does not include tags that carry a non-type system type, e.g. \@suppress.
  */
 const JSDOC_TAGS_WITH_TYPES = new Set([
   'const',
@@ -166,6 +143,7 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
         // A synonym for 'return'.
         tagName = 'return';
       }
+      let type: string|undefined;
       if (JSDOC_TAGS_BLACKLIST.has(tagName)) {
         warnings.push(`@${tagName} annotations are redundant with TypeScript equivalents`);
         continue;  // Drop the tag so Closure won't process it.
@@ -174,6 +152,13 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
             `the type annotation on @${tagName} is redundant with its TypeScript type, ` +
             `remove the {...} part`);
         continue;
+      } else if (tagName === 'suppress') {
+        const suppressMatch = text.match(/^\{(.*)\}(.*)$/);
+        if (!suppressMatch) {
+          warnings.push(`malformed @suppress tag: "${text}"`);
+        } else {
+          [, type, text] = suppressMatch;
+        }
       } else if (tagName === 'dict') {
         warnings.push('use index signatures (`[k: string]: type`) instead of @dict');
         continue;
@@ -189,6 +174,7 @@ export function parse(comment: string): {tags: Tag[], warnings?: string[]}|null 
       let tag: Tag = {tagName};
       if (parameterName) tag.parameterName = parameterName;
       if (text) tag.text = text;
+      if (type) tag.type = type;
       tags.push(tag);
     } else {
       // Text without a preceding @tag on it is either the plain text

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -57,7 +57,12 @@ describe('jsdoc.parse', () => {
   it('allows @suppress annotations', () => {
     let source = `/** @suppress {checkTypes} I hate types */`;
     expect(jsdoc.parse(source)).to.deep.equal({
-      tags: [{tagName: 'suppress', text: '{checkTypes} I hate types'}]
+      tags: [{tagName: 'suppress', type: 'checkTypes', text: ' I hate types'}]
+    });
+    let malformed = `/** @suppress malformed */`;
+    expect(jsdoc.parse(malformed)).to.deep.equal({
+      tags: [{tagName: 'suppress', text: 'malformed'}],
+      warnings: ['malformed @suppress tag: "malformed"'],
     });
   });
 });

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,6 +1,6 @@
 goog.module('test_files.abstract.abstract');var module = module || {id: 'test_files/abstract/abstract.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @abstract

--- a/test_files/abstract/abstract.tsickle.ts
+++ b/test_files/abstract/abstract.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,5 +1,5 @@
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');var module = module || {id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 var /** @type {?} */ fn3 = (a) => 12;

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.tsickle.ts
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var /** @type {?} */ fn3 = (a: number): number => 12;

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,6 +1,6 @@
 goog.module('test_files.arrow_fn.arrow_fn');var module = module || {id: 'test_files/arrow_fn/arrow_fn.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 var /** @type {function(number): number} */ fn3 = (a) => 12;
 var /** @type {function(?): ?} */ fn4 = (a) => a + 12;

--- a/test_files/arrow_fn/arrow_fn.tsickle.ts
+++ b/test_files/arrow_fn/arrow_fn.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var /** @type {function(number): number} */ fn3 = (a: number): number => 12;

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,6 +1,6 @@
 goog.module('test_files.basic.untyped.basic.untyped');var module = module || {id: 'test_files/basic.untyped/basic.untyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {?} arg1

--- a/test_files/basic.untyped/basic.untyped.tsickle.ts
+++ b/test_files/basic.untyped/basic.untyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,6 +1,6 @@
 goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @record

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,6 +1,6 @@
 goog.module('test_files.class.class');var module = module || {id: 'test_files/class/class.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @record

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -2,7 +2,7 @@ Warning at test_files/class/class.ts:125:1: type/symbol conflict for Zone, using
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,6 +1,6 @@
 goog.module('test_files.clutz.no_externs.strip_clutz_type');var module = module || {id: 'test_files/clutz.no_externs/strip_clutz_type.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var goog_some_name_space_1 = goog.require('some.name.space');

--- a/test_files/clutz.no_externs/strip_clutz_type.tsickle.ts
+++ b/test_files/clutz.no_externs/strip_clutz_type.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import {ClutzedClass, clutzedFn} from 'goog:some.name.space';

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,6 +1,6 @@
 goog.module('test_files.coerce.coerce');var module = module || {id: 'test_files/coerce/coerce.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {string} arg

--- a/test_files/coerce/coerce.tsickle.ts
+++ b/test_files/coerce/coerce.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,6 +1,6 @@
 goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class Comments {
 }

--- a/test_files/comments/comments.tsickle.ts
+++ b/test_files/comments/comments.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,6 +1,6 @@
 goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 let /** @type {function(new: (!Document)): ?} */ x = Document;
 class X {

--- a/test_files/ctors/ctors.tsickle.ts
+++ b/test_files/ctors/ctors.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 let /** @type {function(new: (!Document)): ?} */ x = Document;

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,4 +1,4 @@
 goog.module('test_files.declare_class_ns.declare_class_ns');var module = module || {id: 'test_files/declare_class_ns/declare_class_ns.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */

--- a/test_files/declare_class_ns/declare_class_ns.tsickle.ts
+++ b/test_files/declare_class_ns/declare_class_ns.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 declare class ClassAndNamespace {

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,4 +1,4 @@
 goog.module('test_files.declare_class_overloads.declare_class_overloads');var module = module || {id: 'test_files/declare_class_overloads/declare_class_overloads.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */

--- a/test_files/declare_class_overloads/declare_class_overloads.tsickle.ts
+++ b/test_files/declare_class_overloads/declare_class_overloads.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // A class with an overloaded constructor where constructor args are optional.

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,6 +1,6 @@
 goog.module('test_files.declare_export.untyped.declare_export');var module = module || {id: 'test_files/declare_export.untyped/declare_export.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 ;

--- a/test_files/declare_export.untyped/declare_export.tsickle.ts
+++ b/test_files/declare_export.untyped/declare_export.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export declare interface ExportDeclaredIf { x: number; }

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,6 +1,6 @@
 goog.module('test_files.declare_export.declare_export');var module = module || {id: 'test_files/declare_export/declare_export.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /** @typedef {ExportDeclaredIf} */

--- a/test_files/declare_export/declare_export.tsickle.ts
+++ b/test_files/declare_export/declare_export.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export declare interface ExportDeclaredIf { x: number; }

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,6 +1,6 @@
 goog.module('test_files.decorator.decorator');var module = module || {id: 'test_files/decorator/decorator.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {!Object} a

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,6 +1,6 @@
 goog.module('test_files.default.default');var module = module || {id: 'test_files/default/default.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {number} x

--- a/test_files/default/default.tsickle.ts
+++ b/test_files/default/default.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,6 +1,6 @@
 goog.module('test_files.enum.untyped.enum.untyped');var module = module || {id: 'test_files/enum.untyped/enum.untyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 let EnumUntypedTest1 = {};

--- a/test_files/enum.untyped/enum.untyped.tsickle.ts
+++ b/test_files/enum.untyped/enum.untyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,6 +1,6 @@
 goog.module('test_files.enum.enum');var module = module || {id: 'test_files/enum/enum.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // Line with a missing semicolon should not break the following enum.

--- a/test_files/enum/enum.tsickle.ts
+++ b/test_files/enum/enum.tsickle.ts
@@ -2,7 +2,7 @@ Warning at test_files/enum/enum.ts:2:7: should not emit a 'never' type
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // Line with a missing semicolon should not break the following enum.

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export.export');var module = module || {id: 'test_files/export/export.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var export_helper_1 = goog.require('test_files.export.export_helper');

--- a/test_files/export/export.tsickle.ts
+++ b/test_files/export/export.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export {export2,Bar,export5,RenamedTypeDef,export4,TypeDef,Interface} from './export_helper';

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export.export_helper');var module = module || {id: 'test_files/export/export_helper.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // This file isn't itself a test case, but it is imported by the

--- a/test_files/export/export_helper.tsickle.ts
+++ b/test_files/export/export_helper.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // This file isn't itself a test case, but it is imported by the

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export.export_helper_2');var module = module || {id: 'test_files/export/export_helper_2.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // This file isn't itself a test case, but it is imported by the

--- a/test_files/export/export_helper_2.tsickle.ts
+++ b/test_files/export/export_helper_2.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // This file isn't itself a test case, but it is imported by the

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export.type_and_value');var module = module || {id: 'test_files/export/type_and_value.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 exports.TypeAndValue = 1;

--- a/test_files/export/type_and_value.tsickle.ts
+++ b/test_files/export/type_and_value.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export const /** @type {number} */ TypeAndValue = 1;

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export_types_values.untyped.importer');var module = module || {id: 'test_files/export_types_values.untyped/importer.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var value_exporter_1 = goog.require('test_files.export_types_values.untyped.value_exporter');

--- a/test_files/export_types_values.untyped/importer.tsickle.ts
+++ b/test_files/export_types_values.untyped/importer.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export {TypeDef} from './type_exporter';

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,5 +1,5 @@
 goog.module('test_files.export_types_values.untyped.type_exporter');var module = module || {id: 'test_files/export_types_values.untyped/type_exporter.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 

--- a/test_files/export_types_values.untyped/type_exporter.tsickle.ts
+++ b/test_files/export_types_values.untyped/type_exporter.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export type TypeDef = number;

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,6 +1,6 @@
 goog.module('test_files.export_types_values.untyped.value_exporter');var module = module || {id: 'test_files/export_types_values.untyped/value_exporter.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class Clazz {

--- a/test_files/export_types_values.untyped/value_exporter.tsickle.ts
+++ b/test_files/export_types_values.untyped/value_exporter.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,6 +1,6 @@
 goog.module('test_files.exporting_decorator.exporting');var module = module || {id: 'test_files/exporting_decorator/exporting.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * \@ExportDecoratedItems

--- a/test_files/exporting_decorator/exporting.tsickle.ts
+++ b/test_files/exporting_decorator/exporting.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,6 +1,6 @@
 goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class FieldsTest {
     /**

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -2,7 +2,7 @@ Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,6 +1,6 @@
 goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class NoCtor {
 }

--- a/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
+++ b/test_files/fields_no_ctor/fields_no_ctor.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,6 +1,6 @@
 goog.module('test_files.file_comment.comment_no_tag');var module = module || {id: 'test_files/file_comment/comment_no_tag.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /** A comment without any tags. */

--- a/test_files/file_comment/comment_no_tag.tsickle.ts
+++ b/test_files/file_comment/comment_no_tag.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /** A comment without any tags. */

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,0 +1,5 @@
+goog.module('test_files.file_comment.comment_with_text');var module = module || {id: 'test_files/file_comment/comment_with_text.js'};/**
+ * @fileoverview
+ * @suppress {undefinedVars,checkTypes}  because we don't like them errors
+ */
+console.log('hello');

--- a/test_files/file_comment/comment_with_text.ts
+++ b/test_files/file_comment/comment_with_text.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview
+ * @suppress {undefinedVars} because we don't like them errors
+ */
+
+console.log('hello');

--- a/test_files/file_comment/comment_with_text.tsickle.ts
+++ b/test_files/file_comment/comment_with_text.tsickle.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview
+ * @suppress {undefinedVars,checkTypes}  because we don't like them errors
+ */
+
+
+console.log('hello');

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,6 +1,6 @@
 goog.module('test_files.file_comment.file_comment');var module = module || {id: 'test_files/file_comment/file_comment.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @return {string}

--- a/test_files/file_comment/file_comment.tsickle.ts
+++ b/test_files/file_comment/file_comment.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -1,6 +1,6 @@
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');var module = module || {id: 'test_files/file_comment/fileoverview_comment_add_suppress.js'};/**
  * @fileoverview a comment without a suppress tag.
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // here comes code.

--- a/test_files/file_comment/fileoverview_comment_add_suppress.tsickle.ts
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview a comment without a suppress tag.
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,0 +1,6 @@
+goog.module('test_files.file_comment.other_fileoverview_comments');var module = module || {id: 'test_files/file_comment/other_fileoverview_comments.js'};/**
+ * @modName {some_mod}
+ * @suppress {checkTypes} checked by tsc
+ */
+// @modName also belongs in a fileoverview comment, so must be merged.
+console.log('hello');

--- a/test_files/file_comment/other_fileoverview_comments.ts
+++ b/test_files/file_comment/other_fileoverview_comments.ts
@@ -1,0 +1,4 @@
+/** @modName {some_mod} */
+
+// @modName also belongs in a fileoverview comment, so must be merged.
+console.log('hello');

--- a/test_files/file_comment/other_fileoverview_comments.tsickle.ts
+++ b/test_files/file_comment/other_fileoverview_comments.tsickle.ts
@@ -1,0 +1,8 @@
+/**
+ * @modName {some_mod}
+ * @suppress {checkTypes} checked by tsc
+ */
+
+
+// @modName also belongs in a fileoverview comment, so must be merged.
+console.log('hello');

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,6 +1,6 @@
 goog.module('test_files.functions.untyped.functions');var module = module || {id: 'test_files/functions.untyped/functions.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {?} a

--- a/test_files/functions.untyped/functions.tsickle.ts
+++ b/test_files/functions.untyped/functions.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,6 +1,6 @@
 goog.module('test_files.functions.functions');var module = module || {id: 'test_files/functions/functions.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {number} a

--- a/test_files/functions/functions.tsickle.ts
+++ b/test_files/functions/functions.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,6 +1,6 @@
 goog.module('test_files.import_from_goog.import_from_goog');var module = module || {id: 'test_files/import_from_goog/import_from_goog.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare('closure.Module');

--- a/test_files/import_from_goog/import_from_goog.tsickle.ts
+++ b/test_files/import_from_goog/import_from_goog.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import LocalName from 'goog:closure.Module';

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,6 +1,6 @@
 goog.module('test_files.import_only_types.import_only_types');var module = module || {id: 'test_files/import_only_types/import_only_types.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare('test_files.import_only_types.types_only');

--- a/test_files/import_only_types/import_only_types.tsickle.ts
+++ b/test_files/import_only_types/import_only_types.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import {Foo} from './types_only';

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,6 +1,6 @@
 goog.module('test_files.import_only_types.types_only');var module = module || {id: 'test_files/import_only_types/types_only.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/import_only_types/types_only.tsickle.ts
+++ b/test_files/import_only_types/types_only.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,6 +1,6 @@
 goog.module('test_files.index_import.has_index.index');var module = module || {id: 'test_files/index_import/has_index/index.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 exports.a = 1;

--- a/test_files/index_import/has_index/index.tsickle.ts
+++ b/test_files/index_import/has_index/index.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export const /** @type {number} */ a = 1;

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,6 +1,6 @@
 goog.module('test_files.index_import.has_index.relative');var module = module || {id: 'test_files/index_import/has_index/relative.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare('test_files.index_import.has_index.index');

--- a/test_files/index_import/has_index/relative.tsickle.ts
+++ b/test_files/index_import/has_index/relative.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import {a as a2} from './index';

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,6 +1,6 @@
 goog.module('test_files.index_import.lib');var module = module || {id: 'test_files/index_import/lib.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 exports.b = 2;

--- a/test_files/index_import/lib.tsickle.ts
+++ b/test_files/index_import/lib.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export const /** @type {number} */ b = 2;

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,6 +1,6 @@
 goog.module('test_files.index_import.user');var module = module || {id: 'test_files/index_import/user.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare('test_files.index_import.has_index.index');

--- a/test_files/index_import/user.tsickle.ts
+++ b/test_files/index_import/user.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /// <ref './library.d.ts'>

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,6 +1,6 @@
 goog.module('test_files.interface.implement_import');var module = module || {id: 'test_files/interface/implement_import.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var interface_1 = goog.require('test_files.interface.interface');

--- a/test_files/interface/implement_import.tsickle.ts
+++ b/test_files/interface/implement_import.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import {Point, User} from './interface';

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,6 +1,6 @@
 goog.module('test_files.interface.interface');var module = module || {id: 'test_files/interface/interface.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/interface/interface.tsickle.ts
+++ b/test_files/interface/interface.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,6 +1,6 @@
 goog.module('test_files.interface.interface_extends');var module = module || {id: 'test_files/interface/interface_extends.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @record

--- a/test_files/interface/interface_extends.tsickle.ts
+++ b/test_files/interface/interface_extends.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,6 +1,6 @@
 goog.module('test_files.interface.interface_type_params');var module = module || {id: 'test_files/interface/interface_type_params.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @record

--- a/test_files/interface/interface_type_params.tsickle.ts
+++ b/test_files/interface/interface_type_params.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc.jsdoc');var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {string} foo a string.

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -21,7 +21,7 @@ Warning at test_files/jsdoc/jsdoc.ts:41:3: unhandled anonymous type
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.untyped.default');var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class DefaultClass {

--- a/test_files/jsdoc_types.untyped/default.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/default.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.untyped.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types.untyped/jsdoc_types.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types.untyped/jsdoc_types.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class Class {

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.untyped.module2');var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class ClassOne {

--- a/test_files/jsdoc_types.untyped/module2.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module2.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.default');var module = module || {id: 'test_files/jsdoc_types/default.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class DefaultClass {

--- a/test_files/jsdoc_types/default.tsickle.ts
+++ b/test_files/jsdoc_types/default.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types/jsdoc_types.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types/jsdoc_types.tsickle.ts
+++ b/test_files/jsdoc_types/jsdoc_types.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.module1');var module = module || {id: 'test_files/jsdoc_types/module1.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class Class {

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.module2');var module = module || {id: 'test_files/jsdoc_types/module2.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 class ClassOne {

--- a/test_files/jsdoc_types/module2.tsickle.ts
+++ b/test_files/jsdoc_types/module2.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsdoc_types.nevertyped');var module = module || {id: 'test_files/jsdoc_types/nevertyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /**

--- a/test_files/jsdoc_types/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types/nevertyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,6 +1,6 @@
 goog.module('test_files.jsx.jsx');var module = module || {id: 'test_files/jsx/jsx.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 let /** @type {!JSX.Element} */ simple = React.createElement("div", null);
 let /** @type {string} */ hello = 'hello';

--- a/test_files/jsx/jsx.tsickle.tsx
+++ b/test_files/jsx/jsx.tsickle.tsx
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // TypeScript compiles JSX into code that uses a special "JSX" module.

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,6 +1,6 @@
 goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class HasMethods {
     /**

--- a/test_files/methods/methods.tsickle.ts
+++ b/test_files/methods/methods.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,4 +1,4 @@
 goog.module('test_files.namespaced.ambient_namespaced');var module = module || {id: 'test_files/namespaced/ambient_namespaced.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */

--- a/test_files/namespaced/ambient_namespaced.tsickle.ts
+++ b/test_files/namespaced/ambient_namespaced.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 declare namespace decl.ns.one {

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,6 +1,6 @@
 goog.module('test_files.nullable.nullable');var module = module || {id: 'test_files/nullable/nullable.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class Primitives {
 }

--- a/test_files/nullable/nullable.tsickle.ts
+++ b/test_files/nullable/nullable.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,6 +1,6 @@
 goog.module('test_files.optional.optional');var module = module || {id: 'test_files/optional/optional.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 /**
  * @param {number} x

--- a/test_files/optional/optional.tsickle.ts
+++ b/test_files/optional/optional.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,6 +1,6 @@
 goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class ParamProps {
     /**

--- a/test_files/parameter_properties/parameter_properties.tsickle.ts
+++ b/test_files/parameter_properties/parameter_properties.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,6 +1,6 @@
 goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class Static {
 }

--- a/test_files/static/static.tsickle.ts
+++ b/test_files/static/static.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,6 +1,6 @@
 goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class StructuralTest {
     /**

--- a/test_files/structural.untyped/structural.untyped.tsickle.ts
+++ b/test_files/structural.untyped/structural.untyped.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,6 +1,6 @@
 goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 class SuperTestBaseNoArg {
     constructor() { }

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,6 +1,6 @@
 goog.module('test_files.type.type');var module = module || {id: 'test_files/type/type.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 let /** @type {?} */ typeAny;
 let /** @type {!Array<?>} */ typeArr;

--- a/test_files/type/type.tsickle.ts
+++ b/test_files/type/type.tsickle.ts
@@ -3,7 +3,7 @@ Warning at test_files/type/type.ts:15:5: symbol has no declarations
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // Ensure we still understand what Array is, even when it has been

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,6 +1,6 @@
 goog.module('test_files.type_and_value.module');var module = module || {id: 'test_files/type_and_value/module.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 exports.TypeAndValue = 3;

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // TypeAndValue is both a type and a value, which is allowed in TypeScript

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -1,6 +1,6 @@
 goog.module('test_files.type_and_value.type_and_value');var module = module || {id: 'test_files/type_and_value/type_and_value.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var conflict = goog.require('test_files.type_and_value.module');

--- a/test_files/type_and_value/type_and_value.tsickle.ts
+++ b/test_files/type_and_value/type_and_value.tsickle.ts
@@ -3,7 +3,7 @@ Warning at test_files/type_and_value/type_and_value.ts:16:5: type/symbol conflic
 ====
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 import * as conflict from './module';

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,6 +1,6 @@
 goog.module('test_files.typedef.untyped.typedef');var module = module || {id: 'test_files/typedef.untyped/typedef.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var /** @type {?} */ y = 3;

--- a/test_files/typedef.untyped/typedef.tsickle.ts
+++ b/test_files/typedef.untyped/typedef.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 type MyType = number;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,6 +1,6 @@
 goog.module('test_files.typedef.typedef');var module = module || {id: 'test_files/typedef/typedef.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 /** @typedef {number} */

--- a/test_files/typedef/typedef.tsickle.ts
+++ b/test_files/typedef/typedef.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 type MyType = number;

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,6 +1,6 @@
 goog.module('test_files.underscore.export_underscore');var module = module || {id: 'test_files/underscore/export_underscore.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 exports.__test = 1;

--- a/test_files/underscore/export_underscore.tsickle.ts
+++ b/test_files/underscore/export_underscore.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 export var /** @type {number} */ __test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,6 +1,6 @@
 goog.module('test_files.underscore.underscore');var module = module || {id: 'test_files/underscore/underscore.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // Verify that double-underscored names in various places don't get corrupted.

--- a/test_files/underscore/underscore.tsickle.ts
+++ b/test_files/underscore/underscore.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 // Verify that double-underscored names in various places don't get corrupted.

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -1,7 +1,7 @@
 goog.module('test_files.use_closure_externs.use_closure_externs');var module = module || {id: 'test_files/use_closure_externs/use_closure_externs.js'};/**
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 console.log('work around TS dropping consecutive comments');
 let /** @type {!NodeListOf<!HTMLParagraphElement>} */ x = document.getElementsByTagName('p');

--- a/test_files/use_closure_externs/use_closure_externs.tsickle.ts
+++ b/test_files/use_closure_externs/use_closure_externs.tsickle.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,6 +1,6 @@
 goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};/**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 var /** @type {string} */ v1;
 var /** @type {string} */ v2, /** @type {number} */ v3;

--- a/test_files/variables/variables.tsickle.ts
+++ b/test_files/variables/variables.tsickle.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes}
+ * @suppress {checkTypes} checked by tsc
  */
 
 var /** @type {string} */ v1: string;


### PR DESCRIPTION
It turns out that various tooling treats comments containing `@modName`,
`@mods`, and `@pintomodule` as a file overview comment.

Also adds some more allowed JSDoc comments I found in Closure Compiler's
source code.