### PR TITLE
Canonicalize line breaks in input sources.

### DIFF
--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -92,6 +92,7 @@ testFn('golden tests', () => {
       for (let tsFile of test.tsFiles) {
         let tsPath = path.join(test.path, tsFile);
         let tsSource = fs.readFileSync(tsPath, 'utf-8');
+        tsSource = tsSource.replace(/\r\n/g, '\n');
         tsSources.set(tsPath, tsSource);
       }
       let program = testSupport.createProgram(tsSources);


### PR DESCRIPTION
This fixes cases where tsickle tests for `something\n`, missing the \r bit.