### PR TITLE
Introduce transformer support for tsickle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",
+    "@types/diff": "^3.2.0",
     "@types/glob": "^5.0.29",
     "@types/google-closure-compiler": "0.0.18",
     "@types/minimatch": "^2.0.28",
@@ -30,6 +31,7 @@
     "@types/source-map-support": "^0.2.27",
     "chai": "^3.5.0",
     "clang-format": "^1.0.51",
+    "diff": "^3.2.0",
     "glob": "^7.0.0",
     "google-closure-compiler": "^20161024.1.0",
     "gulp": "^3.8.11",

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -133,6 +133,18 @@ export class DecoratorClassVisitor {
     this.propDecorators.set(name, decorators);
   }
 
+  /**
+   * For lowering decorators, we need to refer to constructor types.
+   * So we start with the identifiers that represent these types.
+   * However, TypeScript does not allow use to emit them in a value position
+   * as it associated different symbol information with it.
+   *
+   * This method looks for the place where the value that is associated to
+   * the type is defined and returns that identifier instead.
+   *
+   * @param typeSymbol
+   * @return The identifier
+   */
   private getValueIdentifierForType(typeSymbol: ts.Symbol): ts.Identifier|null {
     if (!typeSymbol.valueDeclaration) {
       return null;
@@ -348,6 +360,7 @@ export function visitClassContentIncludingDecorators(
     classDecl: ts.ClassDeclaration, rewriter: Rewriter, decoratorVisitor?: DecoratorClassVisitor) {
   if (rewriter.file.text[classDecl.getEnd() - 1] !== '}') {
     rewriter.error(classDecl, 'unexpected class terminator');
+    return;
   }
   rewriter.writeNodeFrom(classDecl, classDecl.getStart(), classDecl.getEnd() - 1);
   // At this point, we've emitted up through the final child of the class, so all that

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -205,19 +205,10 @@ export class DecoratorClassVisitor {
       this.rewriter.emit(
           `static ctorParameters: () => ({type: any, decorators?: ` + decoratorInvocations +
           `}|null)[] = () => [\n`);
-      let emittedInline = false;
       for (const param of this.ctorParameters || []) {
         if (!param) {
-          if (emittedInline) {
-            this.rewriter.emit(' ');
-          }
-          this.rewriter.emit('null,');
-          emittedInline = true;
+          this.rewriter.emit('null,\n');
           continue;
-        }
-        if (emittedInline) {
-          this.rewriter.emit('\n');
-          emittedInline = false;
         }
         const [ctor, decorators] = param;
         this.rewriter.emit(`{type: ${ctor}, `);

--- a/src/modules_manifest.ts
+++ b/src/modules_manifest.ts
@@ -15,6 +15,11 @@ export class ModulesManifest {
   /** Map of file name to arrays of imported googmodule module names */
   private referencedModules: FileMap<string[]> = {};
 
+  addManifest(other: ModulesManifest) {
+    Object.assign(this.moduleToFileName, other.moduleToFileName);
+    Object.assign(this.referencedModules, other.referencedModules);
+  }
+
   addModule(fileName: string, module: string): void {
     this.moduleToFileName[module] = fileName;
     this.referencedModules[fileName] = [];

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -84,8 +84,8 @@ export abstract class Rewriter {
     this.writeNodeFrom(node, pos);
   }
 
-  writeNodeFrom(node: ts.Node, pos: number, end = Number.MAX_SAFE_INTEGER) {
-    if (node.getEnd() <= this.skipUpToOffset) {
+  writeNodeFrom(node: ts.Node, pos: number, end = node.getEnd()) {
+    if (end <= this.skipUpToOffset) {
       return;
     }
     const oldSkipUpToOffset = this.skipUpToOffset;
@@ -95,7 +95,7 @@ export abstract class Rewriter {
       this.visit(child);
       pos = child.getEnd();
     });
-    this.writeRange(node, pos, Math.min(end, node.getEnd()));
+    this.writeRange(node, pos, end);
     this.skipUpToOffset = oldSkipUpToOffset;
   }
 

--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
+import {RawSourceMap, SourceMapConsumer, SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 /**
@@ -60,6 +60,17 @@ export function setInlineSourceMap(source: string, sourceMap: string): string {
   } else {
     return `${source}\n//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`;
   }
+}
+
+export function parseSourceMap(text: string, fileName?: string, sourceName?: string): RawSourceMap {
+  const rawSourceMap = JSON.parse(text) as RawSourceMap;
+  if (sourceName) {
+    rawSourceMap.sources = [sourceName];
+  }
+  if (fileName) {
+    rawSourceMap.file = fileName;
+  }
+  return rawSourceMap;
 }
 
 export function sourceMapConsumerToGenerator(sourceMapConsumer: SourceMapConsumer):

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as path from 'path';
+import {RawSourceMap, SourceMapConsumer, SourceMapGenerator} from 'source-map';
+import * as ts from 'typescript';
+
+import * as decorator from './decorator-annotator';
+import * as es5processor from './es5processor';
+import {ModulesManifest} from './modules_manifest';
+import {containsInlineSourceMap, extractInlineSourceMap, parseSourceMap, removeInlineSourceMap, setInlineSourceMap, SourceMapper, SourcePosition} from './source_map_utils';
+import {createTransformerFromSourceMap} from './transformer_sourcemap';
+import {createCustomTransformers} from './transformer_util';
+import * as tsickle from './tsickle';
+
+export interface TransformerOptions extends es5processor.Es5ProcessorOptions, tsickle.Options {
+  /**
+   * Whether to downlevel decorators
+   */
+  transformDecorators?: boolean;
+  /**
+   * Whether to convers types to closure
+   */
+  transformTypesToClosure?: boolean;
+}
+
+export interface TransformerHost extends es5processor.Es5ProcessorHost, tsickle.AnnotatorHost {
+  /**
+   * If true, tsickle and decorator downlevel processing will be skipped for
+   * that file.
+   */
+  shouldSkipTsickleProcessing(fileName: string): boolean;
+  /**
+   * Tsickle treats warnings as errors, if true, ignore warnings.  This might be
+   * useful for e.g. third party code.
+   */
+  shouldIgnoreWarningsForPath(filePath: string): boolean;
+}
+
+export function mergeEmitResults(emitResults: EmitResult[]): EmitResult {
+  const diagnostics: ts.Diagnostic[] = [];
+  let emitSkipped = true;
+  const emittedFiles: string[] = [];
+  const externs: {[fileName: string]: string} = {};
+  const modulesManifest = new ModulesManifest();
+  emitResults.forEach(er => {
+    diagnostics.push(...er.diagnostics);
+    emitSkipped = emitSkipped || er.emitSkipped;
+    emittedFiles.push(...er.emittedFiles);
+    Object.assign(externs, er.externs);
+    modulesManifest.addManifest(er.modulesManifest);
+  });
+  return {diagnostics, emitSkipped, emittedFiles, externs, modulesManifest};
+}
+
+export interface EmitResult extends ts.EmitResult {
+  // The manifest of JS modules output by the compiler.
+  modulesManifest: ModulesManifest;
+  /** externs.js files produced by tsickle, if any. */
+  externs: {[fileName: string]: string};
+}
+
+export interface EmitTransformers {
+  beforeTsickle?: Array<ts.TransformerFactory<ts.SourceFile>>;
+  beforeTs?: Array<ts.TransformerFactory<ts.SourceFile>>;
+  afterTs?: Array<ts.TransformerFactory<ts.SourceFile>>;
+}
+
+export function emitWithTsickle(
+    program: ts.Program, host: TransformerHost, options: TransformerOptions,
+    tsHost: ts.CompilerHost, tsOptions: ts.CompilerOptions, targetSourceFile?: ts.SourceFile,
+    writeFile?: ts.WriteFileCallback, cancellationToken?: ts.CancellationToken,
+    emitOnlyDtsFiles?: boolean, customTransformers?: EmitTransformers): EmitResult {
+  let tsickleDiagnostics: ts.Diagnostic[] = [];
+  const typeChecker = program.getTypeChecker();
+  const beforeTsTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
+  // add tsickle transformers
+  if (options.transformTypesToClosure) {
+    // Note: tsickle.annotate can also lower decorators in the same run.
+    beforeTsTransformers.push(createTransformerFromSourceMap((sourceFile, sourceMapper) => {
+      const tisckleOptions: tsickle.Options = {...options, filterTypesForExport: true};
+      const {output, diagnostics} = tsickle.annotate(
+          typeChecker, sourceFile, host, tisckleOptions, tsHost, tsOptions, sourceMapper,
+          tsickle.AnnotatorFeatures.Transformer);
+      tsickleDiagnostics.push(...diagnostics);
+      return output;
+    }));
+  } else if (options.transformDecorators) {
+    beforeTsTransformers.push(createTransformerFromSourceMap((sourceFile, sourceMapper) => {
+      const {output, diagnostics} =
+          decorator.convertDecorators(typeChecker, sourceFile, sourceMapper);
+      tsickleDiagnostics.push(...diagnostics);
+      return output;
+    }));
+  }
+  // // For debugging: transformer that just emits the same text.
+  // beforeTsTransformers.push(createTransformer(host, typeChecker, (sourceFile, sourceMapper) => {
+  //   sourceMapper.addMapping(sourceFile, {position: 0, line: 0, column: 0}, {position: 0, line: 0,
+  //   column: 0}, sourceFile.text.length); return sourceFile.text;
+  // }));
+  // add user supplied transformers
+  const afterTsTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
+  if (customTransformers) {
+    if (customTransformers.beforeTsickle) {
+      beforeTsTransformers.unshift(...customTransformers.beforeTsickle);
+    }
+
+    if (customTransformers.beforeTs) {
+      beforeTsTransformers.push(...customTransformers.beforeTs);
+    }
+    if (customTransformers.afterTs) {
+      afterTsTransformers.push(...customTransformers.afterTs);
+    }
+  }
+  customTransformers = createCustomTransformers({
+    before: beforeTsTransformers.map(tf => skipTransformForSourceFileIfNeeded(host, tf)),
+    after: afterTsTransformers.map(tf => skipTransformForSourceFileIfNeeded(host, tf))
+  });
+
+  const writeFileDelegate = writeFile || tsHost.writeFile.bind(tsHost);
+  const modulesManifest = new ModulesManifest();
+  const writeFileImpl =
+      (fileName: string, content: string, writeByteOrderMark: boolean,
+       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) => {
+        if (path.extname(fileName) !== '.map') {
+          if (tsOptions.inlineSourceMap) {
+            content = combineInlineSourceMaps(program, fileName, content);
+          } else {
+            content = removeInlineSourceMap(content);
+          }
+          content = es5processor.convertCommonJsToGoogModuleIfNeeded(
+              host, options, modulesManifest, fileName, content);
+        } else {
+          content = combineSourceMaps(program, fileName, content);
+        }
+        writeFileDelegate(fileName, content, writeByteOrderMark, onError, sourceFiles);
+      };
+
+  const {diagnostics: tsDiagnostics, emitSkipped, emittedFiles} = program.emit(
+      targetSourceFile, writeFileImpl, cancellationToken, emitOnlyDtsFiles, customTransformers);
+
+  const externs: {[fileName: string]: string} = {};
+  if (options.transformTypesToClosure) {
+    const sourceFiles = targetSourceFile ? [targetSourceFile] : program.getSourceFiles();
+    sourceFiles.forEach(sf => {
+      if (tsickle.isDtsFileName(sf.fileName) && host.shouldSkipTsickleProcessing(sf.fileName)) {
+        return;
+      }
+      const {output, diagnostics} = tsickle.writeExterns(typeChecker, sf, host, options);
+      if (output) {
+        externs[sf.fileName] = output;
+      }
+      if (diagnostics) {
+        tsickleDiagnostics.push(...diagnostics);
+      }
+    });
+  }
+  // All diagnostics (including warnings) are treated as errors.
+  // If we've decided to ignore them, just discard them.
+  // Warnings include stuff like "don't use @type in your jsdoc"; tsickle
+  // warns and then fixes up the code to be Closure-compatible anyway.
+  tsickleDiagnostics = tsickleDiagnostics.filter(
+      d => d.category === ts.DiagnosticCategory.Error ||
+          !host.shouldIgnoreWarningsForPath(d.file.fileName));
+
+  return {
+    modulesManifest,
+    emitSkipped,
+    emittedFiles: emittedFiles || [],
+    diagnostics: [...tsDiagnostics, ...tsickleDiagnostics],
+    externs
+  };
+}
+
+function skipTransformForSourceFileIfNeeded(
+    host: TransformerHost,
+    delegateFactory: ts.TransformerFactory<ts.SourceFile>): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    const delegate = delegateFactory(context);
+    return (sourceFile: ts.SourceFile) => {
+      if (host.shouldSkipTsickleProcessing(sourceFile.fileName)) {
+        return sourceFile;
+      }
+      return delegate(sourceFile);
+    };
+  };
+}
+
+function combineInlineSourceMaps(
+    program: ts.Program, filePath: string, compiledJsWithInlineSourceMap: string): string {
+  if (tsickle.isDtsFileName(filePath)) {
+    return compiledJsWithInlineSourceMap;
+  }
+  const sourceMapJson = extractInlineSourceMap(compiledJsWithInlineSourceMap);
+  compiledJsWithInlineSourceMap = removeInlineSourceMap(compiledJsWithInlineSourceMap);
+  const composedSourceMap = combineSourceMaps(program, filePath, sourceMapJson);
+  return setInlineSourceMap(compiledJsWithInlineSourceMap, composedSourceMap);
+}
+
+function combineSourceMaps(
+    program: ts.Program, filePath: string, tscSourceMapText: string): string {
+  const tscSourceMap = parseSourceMap(tscSourceMapText);
+  let tscSourceMapGenerator: SourceMapGenerator|undefined;
+  for (const sourceFileName of tscSourceMap.sources) {
+    const sourceFile = program.getSourceFile(sourceFileName);
+    if (!sourceFile || !containsInlineSourceMap(sourceFile.text)) {
+      continue;
+    }
+    const preexistingSourceMapText = extractInlineSourceMap(sourceFile.text);
+    if (!tscSourceMapGenerator) {
+      tscSourceMapGenerator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(tscSourceMap));
+    }
+    tscSourceMapGenerator.applySourceMap(
+        new SourceMapConsumer(parseSourceMap(preexistingSourceMapText, sourceFileName)));
+  }
+  return tscSourceMapGenerator ? tscSourceMapGenerator.toString() : tscSourceMapText;
+}

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -48,13 +48,13 @@ export function mergeEmitResults(emitResults: EmitResult[]): EmitResult {
   const emittedFiles: string[] = [];
   const externs: {[fileName: string]: string} = {};
   const modulesManifest = new ModulesManifest();
-  emitResults.forEach(er => {
+  for (const er of emitResults) {
     diagnostics.push(...er.diagnostics);
     emitSkipped = emitSkipped || er.emitSkipped;
     emittedFiles.push(...er.emittedFiles);
     Object.assign(externs, er.externs);
     modulesManifest.addManifest(er.modulesManifest);
-  });
+  }
   return {diagnostics, emitSkipped, emittedFiles, externs, modulesManifest};
 }
 
@@ -161,7 +161,7 @@ export function emitWithTsickle(
     });
   }
   // All diagnostics (including warnings) are treated as errors.
-  // If we've decided to ignore them, just discard them.
+  // If the host decides to ignore warnings, just discard them.
   // Warnings include stuff like "don't use @type in your jsdoc"; tsickle
   // warns and then fixes up the code to be Closure-compatible anyway.
   tsickleDiagnostics = tsickleDiagnostics.filter(

--- a/src/transformer_sourcemap.ts
+++ b/src/transformer_sourcemap.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {SourceMapper, SourcePosition} from './source_map_utils';
+import {isTypeNodeKind, updateSourceFileNode, visitEachChild, visitNodeWithSynthesizedComments} from './transformer_util';
+
+export function createTransformerFromSourceMap(
+    operator: (sourceFile: ts.SourceFile, sourceMapper: SourceMapper) =>
+        string): ts.TransformerFactory<ts.SourceFile> {
+  return (context) => (sourceFile) => {
+    const sourceMapper = new NodeSourceMapper();
+    const newFile = ts.createSourceFile(
+        sourceFile.fileName, operator(sourceFile, sourceMapper), ts.ScriptTarget.Latest, true);
+    const mappedFile = visitNode(newFile);
+    return updateSourceFileNode(sourceFile, mappedFile.statements);
+
+    function visitNode<T extends ts.Node>(node: T): T {
+      return visitNodeWithSynthesizedComments(context, newFile, node, visitNodeImpl) as T;
+    }
+
+    function visitNodeImpl(node: ts.Node) {
+      if (node.flags & ts.NodeFlags.Synthesized) {
+        return node;
+      }
+      const originalNode = sourceMapper.getOriginalNode(node);
+
+      // Use the originalNode for:
+      // - literals: as e.g. typescript does not support synthetic regex literals
+      // - identifiers: as they don't have children and behave well
+      //    regarding comment synthesization
+      // - types: as they are not emited anyways
+      //          and it leads to errors with `extends` cases.
+      if (originalNode &&
+          (isLiteralKind(node.kind) || node.kind === ts.SyntaxKind.Identifier ||
+           isTypeNodeKind(node.kind) || node.kind === ts.SyntaxKind.IndexSignature)) {
+        return originalNode;
+      }
+      node = visitEachChild(node, visitNode, context);
+
+      node.flags |= ts.NodeFlags.Synthesized;
+      node.parent = undefined;
+      ts.setTextRange(node, originalNode ? originalNode : {pos: -1, end: -1});
+      ts.setOriginalNode(node, originalNode);
+
+      // tslint:disable-next-line:no-any
+      const nodeAny = node as {[key: string]: any};
+      // tslint:disable-next-line:no-any
+      const originalNodeAny = originalNode as {[key: string]: any};
+      for (const prop in nodeAny) {
+        if (nodeAny.hasOwnProperty(prop)) {
+          // tslint:disable-next-line:no-any
+          const value = nodeAny[prop];
+          if (isNodeArray(value)) {
+            // reset the pos/end of all NodeArrays so that we don't emit comments
+            // from them.
+            ts.setTextRange(value, {pos: -1, end: -1});
+          } else if (
+              isToken(value) && !(value.flags & ts.NodeFlags.Synthesized) &&
+              value.getSourceFile() !== sourceFile) {
+            // Use the original TextRange for all non visited tokens (e.g. the
+            // `BinaryExpression.operatorToken`) to preserve the formatting
+            const textRange = originalNode ? originalNodeAny[prop] : {pos: -1, end: -1};
+            ts.setTextRange(value, textRange);
+          }
+        }
+      }
+
+      return node;
+    }
+  };
+}
+
+class NodeSourceMapper implements SourceMapper {
+  private originalNodeByGeneratedRange = new Map<string, ts.Node>();
+  private genStartPositions = new Map<ts.Node, number>();
+
+  private addFullNodeRange(node: ts.Node, genStartPos: number) {
+    this.originalNodeByGeneratedRange.set(
+        this.nodeCacheKey(node.kind, genStartPos, genStartPos + (node.getEnd() - node.getStart())),
+        node);
+    node.forEachChild(
+        child => this.addFullNodeRange(child, genStartPos + (child.getStart() - node.getStart())));
+  }
+
+  addMapping(
+      originalNode: ts.Node, original: SourcePosition, generated: SourcePosition, length: number) {
+    let originalStartPos = original.position;
+    let genStartPos = generated.position;
+    if (originalStartPos >= originalNode.getFullStart() &&
+        originalStartPos <= originalNode.getStart()) {
+      // always use the node.getStart() for the index,
+      // as comments and whitespaces might differ between the original and transformed code.
+      const diffToStart = originalNode.getStart() - originalStartPos;
+      originalStartPos += diffToStart;
+      genStartPos += diffToStart;
+      length -= diffToStart;
+      this.genStartPositions.set(originalNode, genStartPos);
+    }
+    if (originalStartPos + length === originalNode.getEnd()) {
+      this.originalNodeByGeneratedRange.set(
+          this.nodeCacheKey(
+              originalNode.kind, this.genStartPositions.get(originalNode)!, genStartPos + length),
+          originalNode);
+    }
+    originalNode.forEachChild((child) => {
+      if (child.getStart() >= originalStartPos && child.getEnd() <= originalStartPos + length) {
+        this.addFullNodeRange(child, genStartPos + (child.getStart() - originalStartPos));
+      }
+    });
+  }
+
+  getOriginalNode(node: ts.Node): ts.Node|undefined {
+    return this.originalNodeByGeneratedRange.get(
+        this.nodeCacheKey(node.kind, node.getStart(), node.getEnd()));
+  }
+
+  private nodeCacheKey(kind: ts.SyntaxKind, start: number, end: number): string {
+    return `${kind}#${start}#${end}`;
+  }
+}
+
+// tslint:disable-next-line:no-any
+function isNodeArray(value: any): value is ts.NodeArray<any> {
+  const anyValue = value;
+  return Array.isArray(value) && anyValue.pos !== undefined && anyValue.end !== undefined;
+}
+
+// tslint:disable-next-line:no-any
+function isToken(value: any): value is ts.Token<any> {
+  return value != null && typeof value === 'object' && value.kind >= ts.SyntaxKind.FirstToken &&
+      value.kind <= ts.SyntaxKind.LastToken;
+}
+
+// Copied from TypeScript
+function isLiteralKind(kind: ts.SyntaxKind) {
+  return ts.SyntaxKind.FirstLiteralToken <= kind && kind <= ts.SyntaxKind.LastLiteralToken;
+}

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -1,0 +1,545 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+import * as tsickle from './tsickle';
+
+/**
+ * Adjusts the given CustomTransformers with additional transformers
+ * to fix bugs in TypeScript.
+ * @param given A
+ */
+export function createCustomTransformers(given: ts.CustomTransformers): ts.CustomTransformers {
+  if (!given.after && !given.before) {
+    return given;
+  }
+  const before = given.before || [];
+  before.unshift(firstTransform);
+  before.push(preTypeScriptTransform);
+  const after = given.after || [];
+  after.unshift(postTypescriptTransform);
+  return {before, after};
+}
+
+/**
+ * Transform to be used as first transform to reset some state.
+ */
+function firstTransform(context: ts.TransformationContext) {
+  return (sourceFile: ts.SourceFile) => {
+    (context as TransformationContext).fileContext = new FileContext(sourceFile);
+    return sourceFile;
+  };
+}
+
+function assertFileContext(context: TransformationContext, sourceFile: ts.SourceFile): FileContext {
+  if (!context.fileContext) {
+    throw new Error(
+        `Illegal State: FileContext not initialized. ` +
+        `Did you forget to add the "firstTransform" as first transformer? ` +
+        `File: ${sourceFile.fileName}`);
+  }
+  if (context.fileContext.file.fileName !== sourceFile.fileName) {
+    throw new Error(
+        `Illegal State: File of the FileContext does not match. File: ${sourceFile.fileName}`);
+  }
+  return context.fileContext;
+}
+
+/**
+ * And extended version of the TransformationContext that stores the FileContext as well.
+ */
+interface TransformationContext extends ts.TransformationContext {
+  fileContext?: FileContext;
+}
+
+/**
+ * A context that stores information per file to e.g. allow communication
+ * between transformers.
+ * Note that the ts.TransformationContext stores context about all files
+ * in the emit.
+ */
+class FileContext {
+  syntheticNodeParents = new Map<ts.Node, ts.Node|undefined>();
+  importOrReexportDeclarations: Array<ts.Node&{moduleSpecifier: ts.StringLiteral}> = [];
+  lastCommentEnd = -1;
+  constructor(public file: ts.SourceFile) {}
+}
+
+/**
+ * Transform that needs to be executed right before TypeScript's transform.
+ *
+ * This prepares the node tree to workaround some bugs in the TypeScript emitter.
+ */
+function preTypeScriptTransform(context: ts.TransformationContext) {
+  return (sourceFile: ts.SourceFile) => {
+    const fileCtx = assertFileContext(context, sourceFile);
+
+    const nodePath: ts.Node[] = [];
+    visitNode(sourceFile);
+    return sourceFile;
+
+    function visitNode(node: ts.Node) {
+      const startNode = node;
+      const parent = nodePath[nodePath.length - 1];
+
+      if (node.flags & ts.NodeFlags.Synthesized) {
+        // Set `parent` for synthetic nodes as well,
+        // as otherwise the TS emit will crash for decorators.
+        // Note: don't update the `parent` of original nodes, as:
+        // 1) we don't want to change them at all
+        // 2) TS emit becomes errorneous in some cases if we add a synthetic parent.
+        node.parent = parent;
+      }
+      fileCtx.syntheticNodeParents.set(node, parent);
+
+      const originalNode = ts.getOriginalNode(node);
+      // Needed so that e.g. `module { ... }` prints the variable statement
+      // before the closure.
+      // tslint:disable-next-line:no-any
+      (node as any).symbol = (originalNode as any).symbol;
+
+      if (originalNode && node.kind === ts.SyntaxKind.ExportDeclaration) {
+        const originalEd = originalNode as ts.ExportDeclaration;
+        const ed = node as ts.ExportDeclaration;
+        if (!!originalEd.exportClause !== !!ed.exportClause) {
+          // Tsickle changes `export * ...` into named exports.
+          // In this case, don't set the original node for the ExportDeclaration
+          // as otherwise TypeScript gets confused.
+          ts.setOriginalNode(node, undefined);
+        }
+      }
+
+      let importOrReexportNode: ts.Node&{moduleSpecifier: ts.StringLiteral}|undefined;
+      if (node.kind === ts.SyntaxKind.ImportDeclaration) {
+        const id = node as ts.ImportDeclaration;
+        // this should always be a StringLiteral, see the typescript docs.
+        if (id.moduleSpecifier.kind !== ts.SyntaxKind.StringLiteral) {
+          throw new Error(`Unexpected moduleSpecifier kind: ${id.moduleSpecifier.kind}`);
+        }
+        importOrReexportNode = node as ts.Node & {moduleSpecifier: ts.StringLiteral};
+      } else if (node.kind === ts.SyntaxKind.ExportDeclaration) {
+        const ed = node as ts.ExportDeclaration;
+        if (ed.moduleSpecifier) {
+          // this should always be a StringLiteral, see the typescript docs.
+          if (ed.moduleSpecifier.kind !== ts.SyntaxKind.StringLiteral) {
+            throw new Error(`Unexpected moduleSpecifier kind: ${ed.moduleSpecifier.kind}`);
+          }
+          importOrReexportNode = ed as ts.Node as ts.Node & {moduleSpecifier: ts.StringLiteral};
+        }
+      }
+      if (importOrReexportNode) {
+        fileCtx.importOrReexportDeclarations.push(importOrReexportNode);
+      }
+
+      // recurse
+      nodePath.push(node);
+      node.forEachChild(visitNode);
+      nodePath.pop();
+    }
+  };
+}
+
+/**
+ * Transform that needs to be executed after TypeScript's transform.
+ *
+ * This fixes places where the TypeScript transformer does not
+ * emit synthetic comments.
+ */
+function postTypescriptTransform(context: ts.TransformationContext) {
+  return (sourceFile: ts.SourceFile) => {
+    const fileContext = assertFileContext(context, sourceFile);
+    const nodePath: ts.Node[] = [];
+    let importOrReexportsCount = 0;
+    visitNode(sourceFile);
+    (context as TransformationContext).fileContext = undefined;
+    return sourceFile;
+
+    function visitNode(node: ts.Node) {
+      if (node.kind === ts.SyntaxKind.Identifier) {
+        const parent1 = fileContext.syntheticNodeParents.get(node);
+        const parent2 = parent1 && fileContext.syntheticNodeParents.get(parent1);
+        const parent3 = parent2 && fileContext.syntheticNodeParents.get(parent2);
+
+        if (parent1 && parent1.kind === ts.SyntaxKind.PropertyDeclaration) {
+          // TypeScript ignores synthetic comments on (static) property declarations
+          // with initializers.
+          // find the parent ExpressionStatement like MyClass.foo = ...
+          const expressionStmt =
+              lastNodeWith(nodePath, (node) => node.kind === ts.SyntaxKind.ExpressionStatement);
+          if (expressionStmt) {
+            ts.setSyntheticLeadingComments(
+                expressionStmt, ts.getSyntheticLeadingComments(parent1) || []);
+          }
+        } else if (
+            parent3 && parent3.kind === ts.SyntaxKind.VariableStatement &&
+            tsickle.hasModifierFlag(parent3, ts.ModifierFlags.Export)) {
+          // TypeScript ignore synthetic comments on exported variables.
+          // find the parent ExpressionStatement like exports.foo = ...
+          const expressionStmt =
+              lastNodeWith(nodePath, (node) => node.kind === ts.SyntaxKind.ExpressionStatement);
+          if (expressionStmt) {
+            ts.setSyntheticLeadingComments(
+                expressionStmt, ts.getSyntheticLeadingComments(parent3) || []);
+          }
+        }
+      }
+      // TypeScript ignore synthetic comments on reexport / import statements.
+      const moduleName = extractModuleNameFromRequireVariableStatement(node);
+      if (moduleName && fileContext.importOrReexportDeclarations) {
+        const index = importOrReexportsCount++;
+        const originalImportOrReexportNode = fileContext.importOrReexportDeclarations[index];
+        if (originalImportOrReexportNode) {
+          ts.setSyntheticLeadingComments(
+              node, ts.getSyntheticLeadingComments(originalImportOrReexportNode) || []);
+        }
+      }
+      nodePath.push(node);
+      node.forEachChild(visitNode);
+      nodePath.pop();
+    }
+  };
+}
+
+function extractModuleNameFromRequireVariableStatement(node: ts.Node): string|null {
+  if (node.kind !== ts.SyntaxKind.VariableStatement) {
+    return null;
+  }
+  const varStmt = node as ts.VariableStatement;
+  const decls = varStmt.declarationList.declarations;
+  let init: ts.Expression|undefined;
+  if (decls.length !== 1 || !(init = decls[0].initializer) ||
+      init.kind !== ts.SyntaxKind.CallExpression) {
+    return null;
+  }
+  const callExpr = init as ts.CallExpression;
+  if (callExpr.expression.kind !== ts.SyntaxKind.Identifier ||
+      (callExpr.expression as ts.Identifier).text !== 'require' ||
+      callExpr.arguments.length !== 1) {
+    return null;
+  }
+  const moduleExpr = callExpr.arguments[0];
+  if (moduleExpr.kind !== ts.SyntaxKind.StringLiteral) {
+    return null;
+  }
+  return (moduleExpr as ts.StringLiteral).text;
+}
+
+function lastNodeWith(nodes: ts.Node[], predicate: (node: ts.Node) => boolean): ts.Node|null {
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const node = nodes[i];
+    if (predicate(node)) {
+      return node;
+    }
+  }
+  return null;
+}
+
+/**
+ * Synthesizes the comments before and after a node
+ * befor calling a callback.
+ */
+export function visitNodeWithSynthesizedComments<T extends ts.Node>(
+    context: ts.TransformationContext, sourceFile: ts.SourceFile, node: T,
+    visitor: (node: T) => T): T {
+  if (node.flags & ts.NodeFlags.Synthesized) {
+    return visitor(node);
+  }
+  if (node.kind === ts.SyntaxKind.Block) {
+    const block = node as ts.Node as ts.Block;
+    node = visitNodeStatementsWithSynthesizedComments(
+        context, sourceFile, node, block.statements,
+        (node, stmts) => visitor(ts.updateBlock(block, stmts) as ts.Node as T));
+  } else if (node.kind === ts.SyntaxKind.SourceFile) {
+    node = visitNodeStatementsWithSynthesizedComments(
+        context, sourceFile, node, sourceFile.statements,
+        (node, stmts) => visitor(updateSourceFileNode(sourceFile, stmts) as ts.Node as T));
+  } else {
+    const fileContext = assertFileContext(context, sourceFile);
+    const leadingLastCommentEnd =
+        synthesizeLeadingComments(sourceFile, node, fileContext.lastCommentEnd);
+    const trailingLastCommentEnd = synthesizeTrailingComments(sourceFile, node);
+    if (leadingLastCommentEnd !== -1) {
+      fileContext.lastCommentEnd = leadingLastCommentEnd;
+    }
+    node = visitor(node);
+    if (trailingLastCommentEnd !== -1) {
+      fileContext.lastCommentEnd = trailingLastCommentEnd;
+    }
+  }
+  return resetNodeTextRangeToPreventDuplicateComments(node);
+}
+
+function resetNodeTextRangeToPreventDuplicateComments<T extends ts.Node>(node: T): T {
+  ts.setEmitFlags(node, (ts.getEmitFlags(node) || 0) | ts.EmitFlags.NoComments);
+  // Reset the text range for some special nodes as otherwise TypeScript
+  // would always emit the original comments for them.
+  // See also addSyntheticCommentsAfterTsTransformer.
+  let allowTextRange = node.kind !== ts.SyntaxKind.ClassDeclaration &&
+      node.kind !== ts.SyntaxKind.ExportDeclaration &&
+      node.kind !== ts.SyntaxKind.ImportDeclaration &&
+      node.kind !== ts.SyntaxKind.VariableDeclaration &&
+      !(node.kind === ts.SyntaxKind.VariableStatement &&
+        tsickle.hasModifierFlag(node, ts.ModifierFlags.Export));
+  if (node.kind === ts.SyntaxKind.PropertyDeclaration) {
+    allowTextRange = false;
+    const pd = node as ts.Node as ts.PropertyDeclaration;
+    // TODO(tbosch): Using pd.initializer! as the typescript typings for intializer are incorrect.
+    node = ts.updateProperty(
+               pd, pd.decorators, pd.modifiers, resetTextRange(pd.name) as ts.PropertyName, pd.type,
+               pd.initializer!) as ts.Node as T;
+  }
+  if (!allowTextRange) {
+    node = resetTextRange(node);
+  }
+  return node;
+
+  function resetTextRange<T extends ts.Node>(node: T): T {
+    if (!(node.flags & ts.NodeFlags.Synthesized)) {
+      // need to clone as we don't want to modify source nodes,
+      // as the parsed SourceFiles could be cached!
+      node = getMutableClone(node);
+    }
+    const textRange = {pos: node.pos, end: node.end};
+    ts.setSourceMapRange(node, textRange);
+    ts.setTextRange(node, {pos: -1, end: -1});
+    return node;
+  }
+}
+
+function synthesizeLeadingComments(
+    sourceFile: ts.SourceFile, node: ts.Node, lastCommentEnd: number): number {
+  const parent = node.parent;
+  const sharesStartWithParent = parent && parent.kind !== ts.SyntaxKind.Block &&
+      parent.kind !== ts.SyntaxKind.SourceFile && parent.getFullStart() === node.getFullStart();
+  if (sharesStartWithParent || lastCommentEnd >= node.getStart()) {
+    return -1;
+  }
+  const adjustedNodeFullStart = Math.max(lastCommentEnd, node.getFullStart());
+  const leadingComments =
+      getAllLeadingCommentRanges(sourceFile, adjustedNodeFullStart, node.getStart());
+  if (leadingComments && leadingComments.length) {
+    ts.setSyntheticLeadingComments(node, synthesizeCommentRanges(sourceFile, leadingComments));
+    lastCommentEnd = node.getStart();
+  }
+  return -1;
+}
+
+function synthesizeTrailingComments(sourceFile: ts.SourceFile, node: ts.Node): number {
+  const parent = node.parent;
+  const sharesEndWithParent = parent && parent.kind !== ts.SyntaxKind.Block &&
+      parent.kind !== ts.SyntaxKind.SourceFile && parent.getEnd() === node.getEnd();
+  if (sharesEndWithParent) {
+    return -1;
+  }
+  const trailingComments = ts.getTrailingCommentRanges(sourceFile.text, node.getEnd());
+  if (trailingComments && trailingComments.length) {
+    ts.setSyntheticTrailingComments(node, synthesizeCommentRanges(sourceFile, trailingComments));
+    return trailingComments[trailingComments.length - 1].end;
+  }
+  return -1;
+}
+
+function visitNodeStatementsWithSynthesizedComments<T extends ts.Node>(
+    context: ts.TransformationContext, sourceFile: ts.SourceFile, node: T,
+    statements: ts.NodeArray<ts.Statement>,
+    visitor: (node: T, statements: ts.NodeArray<ts.Statement>) => T): T {
+  const leading = synthesizeDetachedLeadingComments(sourceFile, node, statements);
+  const trailing = synthesizeDetachedTrailingComments(sourceFile, node, statements);
+  if (leading.commentStmt || trailing.commentStmt) {
+    statements = ts.setTextRange(ts.createNodeArray(statements), {pos: -1, end: -1});
+    if (leading.commentStmt) {
+      statements.unshift(leading.commentStmt);
+    }
+    if (trailing.commentStmt) {
+      statements.push(trailing.commentStmt);
+    }
+    const fileContext = assertFileContext(context, sourceFile);
+    if (leading.lastCommentEnd !== -1) {
+      fileContext.lastCommentEnd = leading.lastCommentEnd;
+    }
+    node = visitor(node, statements);
+    if (trailing.lastCommentEnd !== -1) {
+      fileContext.lastCommentEnd = trailing.lastCommentEnd;
+    }
+    return node;
+  }
+  return visitor(node, statements);
+}
+
+function synthesizeDetachedLeadingComments(
+    sourceFile: ts.SourceFile, node: ts.Node, statements: ts.NodeArray<ts.Statement>):
+    {commentStmt: ts.Statement | null, lastCommentEnd: number} {
+  let triviaEnd = statements.end;
+  if (statements.length) {
+    triviaEnd = statements[statements.length - 1].getStart();
+  }
+  const detachedComments = getDetachedStartingComments(sourceFile, statements.pos, triviaEnd);
+  if (!detachedComments.length) {
+    return {commentStmt: null, lastCommentEnd: -1};
+  }
+  const lastCommentEnd = detachedComments[detachedComments.length - 1].end;
+  const commentStmt = createNotEmittedStatement(sourceFile);
+  ts.setEmitFlags(commentStmt, ts.EmitFlags.CustomPrologue);
+  ts.setSyntheticTrailingComments(
+      commentStmt, synthesizeCommentRanges(sourceFile, detachedComments));
+  return {commentStmt, lastCommentEnd};
+}
+
+function synthesizeDetachedTrailingComments(
+    sourceFile: ts.SourceFile, node: ts.Node, statements: ts.NodeArray<ts.Statement>):
+    {commentStmt: ts.Statement | null, lastCommentEnd: number} {
+  let trailingCommentStart = statements.end;
+  if (statements.length) {
+    const lastStmt = statements[statements.length - 1];
+    const lastStmtTrailingComments = ts.getTrailingCommentRanges(sourceFile.text, lastStmt.end);
+    if (lastStmtTrailingComments && lastStmtTrailingComments.length) {
+      trailingCommentStart = lastStmtTrailingComments[lastStmtTrailingComments.length - 1].end;
+    }
+  }
+  const detachedComments = getAllLeadingCommentRanges(sourceFile, trailingCommentStart, node.end);
+  if (!detachedComments || !detachedComments.length) {
+    return {commentStmt: null, lastCommentEnd: -1};
+  }
+  const lastCommentEnd = detachedComments[detachedComments.length - 1].end;
+  const commentStmt = createNotEmittedStatement(sourceFile);
+  ts.setEmitFlags(commentStmt, ts.EmitFlags.CustomPrologue);
+  ts.setSyntheticLeadingComments(
+      commentStmt, synthesizeCommentRanges(sourceFile, detachedComments));
+  return {commentStmt, lastCommentEnd};
+}
+
+// Adapted from compiler/comments.ts in TypeScript
+function getDetachedStartingComments(
+    sourceFile: ts.SourceFile, start: number, end: number): ts.CommentRange[] {
+  const leadingComments = getAllLeadingCommentRanges(sourceFile, start, end);
+  if (!leadingComments || !leadingComments.length) {
+    return [];
+  }
+  const detachedComments: ts.CommentRange[] = [];
+  let lastComment: ts.CommentRange|undefined = undefined;
+
+  for (const comment of leadingComments) {
+    if (lastComment) {
+      const lastCommentLine = getLineOfPos(sourceFile, lastComment.end);
+      const commentLine = getLineOfPos(sourceFile, comment.pos);
+
+      if (commentLine >= lastCommentLine + 2) {
+        // There was a blank line between the last comment and this comment.  This
+        // comment is not part of the copyright comments.  Return what we have so
+        // far.
+        break;
+      }
+    }
+
+    detachedComments.push(comment);
+    lastComment = comment;
+  }
+
+  if (detachedComments.length) {
+    // All comments look like they could have been part of the copyright header.  Make
+    // sure there is at least one blank line between it and the node.  If not, it's not
+    // a copyright header.
+    const lastCommentLine =
+        getLineOfPos(sourceFile, detachedComments[detachedComments.length - 1].end);
+    const nodeLine = getLineOfPos(sourceFile, end);
+    if (nodeLine >= lastCommentLine + 2) {
+      // Valid detachedComments
+      return detachedComments;
+    }
+  }
+  return [];
+}
+
+function getLineOfPos(sourceFile: ts.SourceFile, pos: number): number {
+  return ts.getLineAndCharacterOfPosition(sourceFile, pos).line;
+}
+
+
+function synthesizeCommentRanges(sourceFile: ts.SourceFile, parsedComments: ts.CommentRange[]) {
+  const synthesizedComments: ts.SynthesizedComment[] = [];
+  parsedComments.forEach(({kind, pos, end, hasTrailingNewLine}, commentIdx) => {
+    let commentText = sourceFile.text.substring(pos, end).trim();
+    if (kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+      commentText = commentText.replace(/(^\/\*)|(\*\/$)/g, '');
+    } else if (kind === ts.SyntaxKind.SingleLineCommentTrivia) {
+      if (commentText.startsWith('///')) {
+        // tripple-slash comments are typescript specific, ignore them in the output.
+        return;
+      }
+      commentText = commentText.replace(/(^\/\/)/g, '');
+    }
+    synthesizedComments.push({kind, text: commentText, hasTrailingNewLine, pos: -1, end: -1});
+  });
+  return synthesizedComments;
+}
+
+function createNotEmittedStatement(sourceFile: ts.SourceFile) {
+  const stmt = ts.createNotEmittedStatement(sourceFile);
+  ts.setOriginalNode(stmt, undefined);
+  ts.setTextRange(stmt, {pos: 0, end: 0});
+  return stmt;
+}
+
+function getAllLeadingCommentRanges(
+    sourceFile: ts.SourceFile, start: number, end: number): ts.CommentRange[] {
+  // exeute ts.getLeadingCommentRanges with pos = 0 so that it does not skip
+  // comments until the first newline.
+  const commentRanges = ts.getLeadingCommentRanges(sourceFile.text.substring(start, end), 0) || [];
+  return commentRanges.map(cr => ({
+                             hasTrailingNewLine: cr.hasTrailingNewLine,
+                             kind: cr.kind as number,
+                             pos: cr.pos + start,
+                             end: cr.end + start
+                           }));
+}
+
+export function updateSourceFileNode(
+    sf: ts.SourceFile, statements: ts.NodeArray<ts.Statement>): ts.SourceFile {
+  if (statements === sf.statements) {
+    return sf;
+  }
+  // Note: Need to clone the original file (and not use `ts.updateSourceFileNode`)
+  // as otherwise TS fails when resolving types for decorators.
+  sf = getMutableClone(sf);
+  sf.statements = statements;
+  return sf;
+}
+
+/**
+ * A version of ts.getMutableClone that does not always set the synthesized flag.
+ * @param node
+ */
+export function getMutableClone<T extends ts.Node>(node: T): T {
+  const clone = ts.getMutableClone(node);
+  if (!(node.flags & ts.NodeFlags.Synthesized)) {
+    clone.flags &= ~ts.NodeFlags.Synthesized;
+  }
+  return clone;
+}
+
+export function visitEachChild<T extends ts.Node>(
+    node: T, visitor: ts.Visitor, context: ts.TransformationContext): T {
+  // Don't visit children of types,
+  // as they lead to problems with visitEachChild (e.g. suspended lexical environments, or not
+  // implemented), and they are not printed anyways.
+  if (isTypeNodeKind(node.kind) || node.kind === ts.SyntaxKind.IndexSignature) {
+    return node;
+  }
+  return ts.visitEachChild(node, visitor, context);
+}
+
+// Copied from TypeScript
+export function isTypeNodeKind(kind: ts.SyntaxKind) {
+  return (kind >= ts.SyntaxKind.FirstTypeNode && kind <= ts.SyntaxKind.LastTypeNode) ||
+      kind === ts.SyntaxKind.AnyKeyword || kind === ts.SyntaxKind.NumberKeyword ||
+      kind === ts.SyntaxKind.ObjectKeyword || kind === ts.SyntaxKind.BooleanKeyword ||
+      kind === ts.SyntaxKind.StringKeyword || kind === ts.SyntaxKind.SymbolKeyword ||
+      kind === ts.SyntaxKind.ThisKeyword || kind === ts.SyntaxKind.VoidKeyword ||
+      kind === ts.SyntaxKind.UndefinedKeyword || kind === ts.SyntaxKind.NullKeyword ||
+      kind === ts.SyntaxKind.NeverKeyword || kind === ts.SyntaxKind.ExpressionWithTypeArguments;
+}

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -298,7 +298,8 @@ static decorators: {type: Function, args?: any[]}[] = [
 /** @nocollapse */
 static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: BarService, },
-null,];
+null,
+];
 }`);
         });
 
@@ -320,7 +321,8 @@ class Foo {
 /** @nocollapse */
 static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: bar.BarService, decorators: [{ type: Inject, args: [param, ] }, ]},
-null, null,
+null,
+null,
 {type: bar.BarService, },
 ];
 }`);

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -47,8 +47,16 @@ const {cachedLibPath, cachedLib} = (() => {
 })();
 
 /** Creates a ts.Program from a set of input files. */
-export function createProgram(sources: Map<string, string>): ts.Program {
-  const host = ts.createCompilerHost(compilerOptions);
+export function createProgram(
+    sources: Map<string, string>,
+    tsCompilerOptions: ts.CompilerOptions = compilerOptions): ts.Program {
+  return createProgramAndHost(sources, tsCompilerOptions).program;
+}
+
+export function createProgramAndHost(
+    sources: Map<string, string>, tsCompilerOptions: ts.CompilerOptions = compilerOptions):
+    {host: ts.CompilerHost, program: ts.Program} {
+  const host = ts.createCompilerHost(tsCompilerOptions);
 
   host.getSourceFile = (fileName: string, languageVersion: ts.ScriptTarget,
                         onError?: (msg: string) => void): ts.SourceFile => {
@@ -64,7 +72,8 @@ export function createProgram(sources: Map<string, string>): ts.Program {
     throw new Error('unexpected file read of ' + fileName + ' not in ' + toArray(sources.keys()));
   };
 
-  return ts.createProgram(toArray(sources.keys()), compilerOptions, host);
+  const program = ts.createProgram(toArray(sources.keys()), tsCompilerOptions, host);
+  return {program, host};
 }
 
 /** Emits transpiled output with tsickle postprocessing.  Throws an exception on errors. */

--- a/test/transformer_util_test.ts
+++ b/test/transformer_util_test.ts
@@ -1,0 +1,378 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {expect} from 'chai';
+import * as ts from 'typescript';
+
+import {createCustomTransformers, visitEachChild, visitNodeWithSynthesizedComments} from '../src/transformer_util';
+
+import * as testSupport from './test_support';
+
+const MODULE_HEADER = `Object.defineProperty(exports, "__esModule", { value: true });`;
+
+describe('transformer util', () => {
+  function emitWithTransform(
+      tsSources: {[fileName: string]: string},
+      transform: ts.TransformerFactory<ts.SourceFile>): {[fileName: string]: string} {
+    const {program, host} = testSupport.createProgramAndHost(objectToMap(tsSources));
+    const transformers = createCustomTransformers({before: [transform]});
+    const jsSources: {[fileName: string]: string} = {};
+    program.emit(undefined, (fileName: string, data: string) => {
+      jsSources[fileName] = data;
+    }, undefined, undefined, transformers);
+
+    return jsSources;
+  }
+
+  describe('comments', () => {
+
+    function transformComments(context: ts.TransformationContext) {
+      return (sourceFile: ts.SourceFile): ts.SourceFile => {
+        return visitNode(sourceFile);
+
+        function visitNode<T extends ts.Node>(node: T) {
+          return visitNodeWithSynthesizedComments(context, sourceFile, node, visitNodeImpl);
+        }
+
+        function visitNodeImpl<T extends ts.Node>(node: T): T {
+          visitComments(node, ts.getSyntheticLeadingComments(node));
+          visitComments(node, ts.getSyntheticTrailingComments(node));
+          return visitEachChild(node, visitNode, context);
+        }
+
+        function visitComments(node: ts.Node, comments: ts.SynthesizedComment[]|undefined) {
+          if (comments) {
+            comments.forEach(c => c.text = `<${node.kind}>${c.text}`);
+          }
+        }
+      };
+    }
+
+    it('should synthesize leading file comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `/*fc*/`,
+          ``,
+          `/*sc*/`,
+          `const x = 1;`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `/*<${ts.SyntaxKind.NotEmittedStatement}>fc*/`,
+        `/*<${ts.SyntaxKind.VariableStatement}>sc*/`,
+        `const x = 1;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize trailing file comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `const x = 1; /*sc*/`,
+          `/*fc*/`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
+        `/*<${ts.SyntaxKind.NotEmittedStatement}>fc*/ `,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize leading block comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `{`,
+          `  /*bc*/`,
+          ``,
+          `  /*sc*/`,
+          `  const x = 1;`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `{`,
+        `    /*<${ts.SyntaxKind.NotEmittedStatement}>bc*/`,
+        `    /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
+        `    const x = 1;`,
+        `}`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize trailing block comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `{`,
+          `  const x = 1;/*sc*/`,
+          `  /*bc*/`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `{`,
+        `    const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
+        `    /*<${ts.SyntaxKind.NotEmittedStatement}>bc*/`,
+        `}`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize different kinds of comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `/*mlc*/`,
+          `//slc`,
+          `///tc`,
+          `const x = 1;`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      // Note: tripple line comments contain typescript specific information
+      // and are removed.
+      expect(jsSources['./a.js']).to.eq([
+        `/*<${ts.SyntaxKind.VariableStatement}>mlc*/`,
+        `//<${ts.SyntaxKind.VariableStatement}>slc`,
+        `const x = 1;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize leading comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `/*sc1*/`,
+          `/*sc2*/`,
+          `const x = 1;`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `/*<${ts.SyntaxKind.VariableStatement}>sc1*/`,
+        `/*<${ts.SyntaxKind.VariableStatement}>sc2*/`,
+        `const x = 1;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize trailing comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `const x = 1; /*sc*/`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should separate leading and trailing comments', () => {
+      const tsSources = {
+        'a.ts': [
+          `/*lc1*/ const x = 1; /*tc1*/`,
+          `/*lc2*/ const x = 1; /*tc2*/`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `/*<${
+              ts.SyntaxKind.VariableStatement
+            }>lc1*/ const x = 1; /*<${ts.SyntaxKind.VariableStatement}>tc1*/`,
+        `/*<${
+              ts.SyntaxKind.VariableStatement
+            }>lc2*/ const x = 1; /*<${ts.SyntaxKind.VariableStatement}>tc2*/`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize comments on variables', () => {
+      const tsSources = {'a.ts': `/*c*/ const /*x*/ x = 1, /*y*/ y = 1;`};
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js'])
+          .to.eq(
+              `/*<${ts.SyntaxKind.VariableStatement}>c*/ const ` +
+              `/*<${ts.SyntaxKind.VariableDeclaration}>x*/ x = 1, ` +
+              `/*<${ts.SyntaxKind.VariableDeclaration}>y*/ y = 1;\n`);
+    });
+
+    it('should synthesize comments on exported variables', () => {
+      const tsSources = {'a.ts': `/*c*/export const x = 1;`};
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        MODULE_HEADER,
+        `/*<${ts.SyntaxKind.VariableStatement}>c*/ exports.x = 1;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize comments on reexport stmts', () => {
+      const tsSources = {'a.ts': 'export const x = 1', 'b.ts': `/*c*/export {x} from './a';`};
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./b.js']).to.eq([
+        MODULE_HEADER,
+        `/*<${ts.SyntaxKind.ExportDeclaration}>c*/ var a_1 = require("./a");`,
+        `exports.x = a_1.x;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize comments on import stmts', () => {
+      const tsSources = {
+        'a.ts': 'export const x = 1',
+        'b.ts': `/*c*/import {x} from './a';console.log(x);`
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./b.js']).to.eq([
+        MODULE_HEADER,
+        `/*<${ts.SyntaxKind.ImportDeclaration}>c*/ const a_1 = require("./a");`,
+        `console.log(a_1.x);`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize comments on properties with initializers', () => {
+      const tsSources = {
+        'a.ts': [
+          `class C {`,
+          `  /*c1*/static p1 = true;`,
+          `  /*c2*/p2 = true;`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `class C {`,
+        `    constructor() {`,
+        `        /*<${ts.SyntaxKind.PropertyDeclaration}>c2*/ this.p2 = true;`,
+        `    }`,
+        `}`,
+        `/*<${ts.SyntaxKind.PropertyDeclaration}>c1*/ C.p1 = true;`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should synthesize comments on classes', () => {
+      const tsSources = {
+        'a.ts': [
+          `/*c*/`,
+          `class C {`,
+          `  prop1 = 1;`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, transformComments);
+      expect(jsSources['./a.js']).to.eq([
+        `/*<${ts.SyntaxKind.ClassDeclaration}>c*/`,
+        `class C {`,
+        `    constructor() {`,
+        `        this.prop1 = 1;`,
+        `    }`,
+        `}`,
+        ``,
+      ].join('\n'));
+    });
+  });
+
+  describe('synthetic nodes with filled originalNode', () => {
+    function synthesizeTransform(context: ts.TransformationContext) {
+      return (sourceFile: ts.SourceFile): ts.SourceFile => {
+        return visitNode(sourceFile);
+
+        function visitNode<T extends ts.Node>(node: T): T {
+          if (node.kind === ts.SyntaxKind.Identifier) {
+            const synthNode = ts.createIdentifier((node as ts.Node as ts.Identifier).text);
+            ts.setOriginalNode(synthNode, node);
+            ts.setTextRange(synthNode, node);
+            node = synthNode as ts.Node as T;
+          }
+          return visitEachChild(node, visitNode, context);
+        }
+      };
+    }
+
+    it('should not crash for synthetic property decorators', () => {
+      const tsSources = {
+        'a.ts': [
+          `let decorator: any`,
+          `class X {`,
+          `  @decorator`,
+          `  private x: number;`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, synthesizeTransform);
+      expect(jsSources['./a.js']).to.eq([
+        `let decorator;`,
+        `class X {`,
+        `}`,
+        `__decorate([`,
+        `    decorator,`,
+        `    __metadata("design:type", Number)`,
+        `], X.prototype, "x", void 0);`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should emit the top level variable for `module` statements', () => {
+      const tsSources = {
+        'a.ts': [
+          `module Reflect {`,
+          `  const x = 1;`,
+          `}`,
+        ].join('\n')
+      };
+      const jsSources = emitWithTransform(tsSources, synthesizeTransform);
+      expect(jsSources['./a.js']).to.eq([
+        `var Reflect;`,
+        `(function (Reflect) {`,
+        `    const x = 1;`,
+        `})(Reflect || (Reflect = {}));`,
+        ``,
+      ].join('\n'));
+    });
+
+    it('should allow to change an export * into named exports', () => {
+      function expandExportStar(context: ts.TransformationContext) {
+        return (sourceFile: ts.SourceFile): ts.SourceFile => {
+          return visitNode(sourceFile);
+
+          function visitNode<T extends ts.Node>(node: T): T {
+            if (node.kind === ts.SyntaxKind.ExportDeclaration) {
+              const ed = node as ts.Node as ts.ExportDeclaration;
+              const namedExports = ts.createNamedExports([ts.createExportSpecifier('x', 'x')]);
+              return ts.updateExportDeclaration(
+                         ed, undefined, undefined, namedExports, ed.moduleSpecifier) as ts.Node as
+                  T;
+            }
+            return visitEachChild(node, visitNode, context);
+          }
+        };
+      }
+
+      const tsSources = {'a.ts': `export const x = 1;`, 'b.ts': `export * from './a';`};
+      const jsSources = emitWithTransform(tsSources, expandExportStar);
+      expect(jsSources['./b.js']).to.eq([
+        MODULE_HEADER,
+        `var a_1 = require("./a");`,
+        `exports.x = a_1.x;`,
+        ``,
+      ].join('\n'));
+    });
+  });
+});
+
+function objectToMap(data: {[key: string]: string}): Map<string, string> {
+  const entries = Object.keys(data).map(key => [key, data[key]]) as Array<[string, string]>;
+  return new Map(entries);
+}

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -74,7 +74,7 @@ function compareAgainstGolden(output: string|null, path: string) {
 // Only run golden tests if we filter for a specific one.
 const testFn = TEST_FILTER ? describe.only : describe;
 
-testFn('golden tests', () => {
+testFn('golden tests with TsickleCompilerHost', () => {
   testFn('with separate passes', () => {
     runGoldenTests(true);
   });

--- a/test/tsickle_transformer_test.ts
+++ b/test/tsickle_transformer_test.ts
@@ -50,7 +50,7 @@ function patchGolden(golden: string|null, path: string): string|null {
   }
   const patchPath = calcPatchPath(path);
   if (fs.existsSync(patchPath)) {
-    // Note: the typings for `diff.applyPath` are wrong in that the function
+    // Note: the typings for `diff.applyPatch` are wrong in that the function
     // can also return `false`.
     const patchedGolden =
         diff.applyPatch(golden, fs.readFileSync(patchPath, 'utf-8')) as string | false;

--- a/test/tsickle_transformer_test.ts
+++ b/test/tsickle_transformer_test.ts
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {expect} from 'chai';
+import * as diff from 'diff';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import * as transformer from '../src/transformer';
+import * as tsickle from '../src/tsickle';
+import {toArray} from '../src/util';
+
+import * as testSupport from './test_support';
+
+const TEST_FILTER: RegExp|null =
+    process.env.TEST_FILTER ? new RegExp(process.env.TEST_FILTER) : null;
+
+// If true, update all the golden .transformer.patch files to be whatever tsickle
+// produces from the .ts source. Do not change this code but run as:
+//     UPDATE_TRANSFORMER_GOLDENS=y gulp test
+const UPDATE_GOLDENS = !!process.env.UPDATE_TRANSFORMER_GOLDENS;
+
+function calcPatchPath(path: string): string {
+  return `${path}.transform.patch`;
+}
+
+function readGolden(path: string): string|null {
+  let golden: string|null = null;
+  try {
+    golden = fs.readFileSync(path, 'utf-8');
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return null;
+    } else {
+      throw e;
+    }
+  }
+  return golden;
+}
+
+function patchGolden(golden: string|null, path: string): string|null {
+  if (golden == null) {
+    return golden;
+  }
+  const patchPath = calcPatchPath(path);
+  if (fs.existsSync(patchPath)) {
+    // Note: the typings for `diff.applyPath` are wrong in that the function
+    // can also return `false`.
+    const patchedGolden =
+        diff.applyPatch(golden, fs.readFileSync(patchPath, 'utf-8')) as string | false;
+    if (patchedGolden === false) {
+      return golden;
+    }
+    return patchedGolden;
+  }
+  return golden;
+}
+
+/**
+ * compareAgainstGoldens compares a test output against the content in a golden
+ * path, updating the content of the golden when UPDATE_GOLDENS is true.
+ *
+ * @param output The expected output, where the empty string indicates
+ *    the file is expected to exist and be empty, while null indicates
+ *    the file is expected to not exist.  (This subtlety is used for
+ *    externs files, where the majority of tests are not expected to
+ *    produce one.)
+ */
+function compareAgainstGolden(output: string|null, path: string) {
+  const golden = readGolden(path);
+  let patchedGolden = patchGolden(golden, path);
+
+  // Make sure we have proper line endings when testing on Windows.
+  if (patchedGolden != null) patchedGolden = patchedGolden.replace(/\r\n/g, '\n');
+  if (output != null) output = output.replace(/\r\n/g, '\n');
+
+  const patchPath = calcPatchPath(path);
+  if (UPDATE_GOLDENS) {
+    if (golden !== null && golden !== output) {
+      console.log(`Updating golden patch file for ${path} with ${patchPath}`);
+      const patchOutput =
+          diff.createPatch(path, golden || '', output || '', 'golden', 'tsickle with transformer')!;
+      fs.writeFileSync(patchPath, patchOutput, 'utf-8');
+    } else {
+      // The desired golden state is for there to be no output file.
+      // Ensure no file exists.
+      try {
+        fs.unlinkSync(patchPath);
+      } catch (e) {
+        // ignore.
+      }
+    }
+  } else {
+    expect(output).to.equal(patchedGolden, `${path} with ${patchPath}`);
+  }
+}
+
+const DIAGONSTIC_FILE_REGEX = /(test_files.*?):\s/;
+
+function compareAgainstGoldenDiagnostics(diagnostics: ts.Diagnostic[], path: string) {
+  // Munge the filenames in the diagnostics so that they don't include
+  // the tsickle checkout path.
+  for (const diag of diagnostics) {
+    const fileName = diag.file.fileName;
+    diag.file.fileName = fileName.substr(fileName.indexOf('test_files'));
+  }
+  const tsicklePath = path.replace(/((\.d)?\.tsx?)$/, '.tsickle$1');
+  expect(tsicklePath).to.not.equal(path);
+  const golden = patchGolden(readGolden(tsicklePath), tsicklePath) || '';
+  const goldenFormattedDiagnostics =
+      sortDiagnostics(golden.substring(0, golden.indexOf('\n====\n')));
+  const outputFormattedDiagnostics = sortDiagnostics(
+      tsickle.formatDiagnostics(diagnostics.filter(diag => diag.file.fileName === path)));
+
+  expect(outputFormattedDiagnostics).to.equal(goldenFormattedDiagnostics, '<diagnostics>');
+}
+
+function sortDiagnostics(diagnostics: string): string {
+  const lines = diagnostics.split('\n');
+  return lines
+      .sort((l1, l2) => {
+        const m1 = DIAGONSTIC_FILE_REGEX.exec(l1) || [l1];
+        const m2 = DIAGONSTIC_FILE_REGEX.exec(l2) || [l2];
+        return m1[0].localeCompare(m2[0]);
+      })
+      .join('\n');
+}
+
+// Only run golden tests if we filter for a specific one.
+const testFn = TEST_FILTER ? describe.only : describe;
+
+testFn('golden tests with transformer', () => {
+  testSupport.goldenTests().forEach((test) => {
+    if (TEST_FILTER && !TEST_FILTER.exec(test.name)) {
+      it.skip(test.name);
+      return;
+    }
+    let emitDeclarations = true;
+    const transfromerOptions: transformer.TransformerOptions = {
+      // See test_files/jsdoc_types/nevertyped.ts.
+      es5Mode: true,
+      prelude: '',
+      googmodule: true,
+      typeBlackListPaths: new Set(['test_files/jsdoc_types/nevertyped.ts']),
+      convertIndexImportShorthand: true,
+      transformDecorators: true,
+      transformTypesToClosure: true,
+    };
+    if (/\.untyped\b/.test(test.name)) {
+      transfromerOptions.untyped = true;
+    }
+    if (test.name === 'fields') {
+      emitDeclarations = false;
+    }
+    it(test.name, () => {
+      // Read all the inputs into a map, and create a ts.Program from them.
+      const tsSources = new Map<string, string>();
+      for (const tsFile of test.tsFiles) {
+        const tsPath = path.join(test.path, tsFile);
+        let tsSource = fs.readFileSync(tsPath, 'utf-8');
+        tsSource = tsSource.replace(/\r\n/g, '\n');
+        tsSources.set(tsPath, tsSource);
+      }
+      const tsCompilerOptions: ts.CompilerOptions = {
+        ...testSupport.compilerOptions,
+        // Test that creating declarations does not throw
+        declaration: emitDeclarations
+      };
+      const {program, host: tsHost} =
+          testSupport.createProgramAndHost(tsSources, tsCompilerOptions);
+      {
+        const diagnostics = ts.getPreEmitDiagnostics(program);
+        if (diagnostics.length) {
+          throw new Error(tsickle.formatDiagnostics(diagnostics));
+        }
+      }
+      const allDiagnostics: ts.Diagnostic[] = [];
+      const transformerHost: transformer.TransformerHost = {
+        logWarning: (diag: ts.Diagnostic) => {
+          allDiagnostics.push(diag);
+        },
+        shouldSkipTsickleProcessing: (fileName) => !tsSources.has(fileName),
+        shouldIgnoreWarningsForPath: () => false,
+        pathToModuleName: (context, importPath) => {
+          importPath = importPath.replace(/(\.d)?\.[tj]s$/, '');
+          if (importPath[0] === '.') importPath = path.join(path.dirname(context), importPath);
+          return importPath.replace(/\/|\\/g, '.');
+        },
+        fileNameToModuleId: (fileName) => fileName.replace(/^\.\//, ''),
+      };
+      const jsSources: {[fileName: string]: string} = {};
+      const {diagnostics, externs} = transformer.emitWithTsickle(
+          program, transformerHost, transfromerOptions, tsHost, tsCompilerOptions, undefined,
+          (fileName: string, data: string) => {
+            if (!fileName.endsWith('.d.ts')) {
+              // Don't check .d.ts files, we are only interested to test
+              // that we don't throw when we generate them.
+              jsSources[fileName] = data;
+            }
+          });
+      allDiagnostics.push(...diagnostics);
+      let allExterns: string|null = null;
+      if (!test.name.endsWith('.no_externs')) {
+        for (const tsPath of toArray(tsSources.keys())) {
+          if (externs[tsPath]) {
+            if (!allExterns) allExterns = tsickle.EXTERNS_HEADER;
+            allExterns += externs[tsPath];
+          }
+        }
+      }
+      compareAgainstGolden(allExterns, test.externsPath);
+      Object.keys(jsSources).forEach(jsPath => {
+        compareAgainstGolden(jsSources[jsPath], jsPath);
+      });
+      Array.from(tsSources.keys())
+          .forEach(tsPath => compareAgainstGoldenDiagnostics(allDiagnostics, tsPath));
+    });
+  });
+});

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -2,5 +2,7 @@ goog.module('test_files.arrow_fn.arrow_fn');var module = module || {id: 'test_fi
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+
 var /** @type {function(number): number} */ fn3 = (a) => 12;
 var /** @type {function(?): ?} */ fn4 = (a) => a + 12;
+exports.fn5 = (a = 10) => a;

--- a/test_files/arrow_fn/arrow_fn.ts
+++ b/test_files/arrow_fn/arrow_fn.ts
@@ -1,2 +1,3 @@
 var fn3 = (a: number): number => 12;
 var fn4 = (a) => a + 12;
+export var fn5 = (a = 10) => a;

--- a/test_files/arrow_fn/arrow_fn.tsickle.ts
+++ b/test_files/arrow_fn/arrow_fn.tsickle.ts
@@ -5,3 +5,4 @@
 
 var /** @type {function(number): number} */ fn3 = (a: number): number => 12;
 var /** @type {function(?): ?} */ fn4 = (a) => a + 12;
+export var /** @type {function(number): number} */ fn5 = (a = 10) => a;

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -9,3 +9,4 @@ goog.module('test_files.coerce.coerce');var module = module || {id: 'test_files/
 function acceptString(arg) { return arg; }
 acceptString(/** @type {?} */ (3));
 acceptString(/** @type {?} */ (3));
+acceptString(`${((3))}`);

--- a/test_files/coerce/coerce.js.transform.patch
+++ b/test_files/coerce/coerce.js.transform.patch
@@ -1,0 +1,11 @@
+Index: ./test_files/coerce/coerce.js
+===================================================================
+--- ./test_files/coerce/coerce.js	golden
++++ ./test_files/coerce/coerce.js	tsickle with transformer
+@@ -8,5 +8,5 @@
+  */
+ function acceptString(arg) { return arg; }
+ acceptString(/** @type {?} */ (3));
+ acceptString(/** @type {?} */ (3));
+-acceptString(`${((3))}`);
++acceptString(`${(/** @type {?} */ (3))}`);

--- a/test_files/coerce/coerce.ts
+++ b/test_files/coerce/coerce.ts
@@ -1,3 +1,4 @@
 function acceptString(arg: string): string { return arg; }
 acceptString(<any>3);
 acceptString(3 as any);
+acceptString(`${3 as any}`);

--- a/test_files/coerce/coerce.tsickle.ts
+++ b/test_files/coerce/coerce.tsickle.ts
@@ -11,3 +11,4 @@
 function acceptString(arg: string): string { return arg; }
 acceptString( /** @type {?} */((<any>3)));
 acceptString( /** @type {?} */((3 as any)));
+acceptString(`${( /** @type {?} */((3 as any)))}`);

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -17,7 +17,7 @@ function classAnnotation(t: any) { return t; }
 
 
 class DecoratorTest {
-  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
+  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRenamedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
   
   get w(): number {

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -19,6 +19,12 @@ function classAnnotation(t: any) { return t; }
 class DecoratorTest {
   constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
+  
+  get w(): number {
+    return 1;
+  }
+
+  /** Some comment */
   @decorator
   private x: number;
 
@@ -40,6 +46,7 @@ null, null,
 {type: AClassWithGenerics, },
 null,];
 static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
+"w": [{ type: annotationDecorator },],
 "y": [{ type: annotationDecorator },],
 };
 }

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -39,12 +39,14 @@ static decorators: {type: Function, args?: any[]}[] = [
 /** @nocollapse */
 static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: Array, },
-null, null,
+null,
+null,
 {type: Promise, },
 {type: Array, },
 {type: AClass, },
 {type: AClassWithGenerics, },
-null,];
+null,
+];
 static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 "w": [{ type: annotationDecorator },],
 "y": [{ type: annotationDecorator },],

--- a/test_files/decorator/decorator.decorated.ts
+++ b/test_files/decorator/decorator.decorated.ts
@@ -1,4 +1,4 @@
-import {AClass, AType, AClassWithGenerics} from './external';
+import {AClass, AClass as ARenamedClass, AType, AClassWithGenerics} from './external';
 
 function decorator(a: Object, b: string) {}
 
@@ -17,7 +17,7 @@ function classAnnotation(t: any) { return t; }
 
 
 class DecoratorTest {
-  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
+  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
   
   get w(): number {
@@ -43,6 +43,8 @@ null,
 null,
 {type: Promise, },
 {type: Array, },
+{type: AClass, },
+{type: AClass, },
 {type: AClass, },
 {type: AClassWithGenerics, },
 null,

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -41,6 +41,12 @@ class DecoratorTest {
      * @param {!tsickle_forward_declare_1.AType} aType
      */
     constructor(a, n, b, promise, arr, aClass, aClassWithGenerics, aType) { }
+    /**
+     * @return {number}
+     */
+    get w() {
+        return 1;
+    }
 }
 DecoratorTest.decorators = [
     { type: classAnnotation },
@@ -56,6 +62,7 @@ DecoratorTest.ctorParameters = () => [
     null,
 ];
 DecoratorTest.propDecorators = {
+    "w": [{ type: annotationDecorator },],
     "y": [{ type: annotationDecorator },],
 };
 __decorate([
@@ -76,7 +83,10 @@ function DecoratorTest_tsickle_Closure_declarations() {
     DecoratorTest.ctorParameters;
     /** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
     DecoratorTest.propDecorators;
-    /** @type {number} */
+    /**
+     * Some comment
+     * @type {number}
+     */
     DecoratorTest.prototype.x;
     /** @type {number} */
     DecoratorTest.prototype.y;

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -38,11 +38,11 @@ class DecoratorTest {
      * @param {!Array<string>} arr
      * @param {!tsickle_forward_declare_1.AClass} aClass
      * @param {!tsickle_forward_declare_1.AClass} AClass
-     * @param {!tsickle_forward_declare_1.AClass} aRanmedClass
+     * @param {!tsickle_forward_declare_1.AClass} aRenamedClass
      * @param {!tsickle_forward_declare_1.AClassWithGenerics<string>} aClassWithGenerics
      * @param {!tsickle_forward_declare_1.AType} aType
      */
-    constructor(a, n, b, promise, arr, aClass, AClass, aRanmedClass, aClassWithGenerics, aType) { }
+    constructor(a, n, b, promise, arr, aClass, AClass, aRenamedClass, aClassWithGenerics, aType) { }
     /**
      * @return {number}
      */

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -37,10 +37,12 @@ class DecoratorTest {
      * @param {!Promise<string>} promise
      * @param {!Array<string>} arr
      * @param {!tsickle_forward_declare_1.AClass} aClass
+     * @param {!tsickle_forward_declare_1.AClass} AClass
+     * @param {!tsickle_forward_declare_1.AClass} aRanmedClass
      * @param {!tsickle_forward_declare_1.AClassWithGenerics<string>} aClassWithGenerics
      * @param {!tsickle_forward_declare_1.AType} aType
      */
-    constructor(a, n, b, promise, arr, aClass, aClassWithGenerics, aType) { }
+    constructor(a, n, b, promise, arr, aClass, AClass, aRanmedClass, aClassWithGenerics, aType) { }
     /**
      * @return {number}
      */
@@ -58,6 +60,8 @@ DecoratorTest.ctorParameters = () => [
     null,
     { type: Promise, },
     { type: Array, },
+    { type: external_1.AClass, },
+    { type: external_1.AClass, },
     { type: external_1.AClass, },
     { type: external_1.AClassWithGenerics, },
     null,

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -54,7 +54,8 @@ DecoratorTest.decorators = [
 /** @nocollapse */
 DecoratorTest.ctorParameters = () => [
     { type: Array, },
-    null, null,
+    null,
+    null,
     { type: Promise, },
     { type: Array, },
     { type: external_1.AClass, },

--- a/test_files/decorator/decorator.ts
+++ b/test_files/decorator/decorator.ts
@@ -19,6 +19,12 @@ function classAnnotation(t: any) { return t; }
 class DecoratorTest {
   constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
+  @annotationDecorator
+  get w(): number {
+    return 1;
+  }
+
+  /** Some comment */
   @decorator
   private x: number;
 

--- a/test_files/decorator/decorator.ts
+++ b/test_files/decorator/decorator.ts
@@ -17,7 +17,7 @@ function classAnnotation(t: any) { return t; }
 
 @classAnnotation
 class DecoratorTest {
-  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
+  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRenamedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
   @annotationDecorator
   get w(): number {

--- a/test_files/decorator/decorator.ts
+++ b/test_files/decorator/decorator.ts
@@ -1,4 +1,4 @@
-import {AClass, AType, AClassWithGenerics} from './external';
+import {AClass, AClass as ARenamedClass, AType, AClassWithGenerics} from './external';
 
 function decorator(a: Object, b: string) {}
 
@@ -17,7 +17,7 @@ function classAnnotation(t: any) { return t; }
 
 @classAnnotation
 class DecoratorTest {
-  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
+  constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
   @annotationDecorator
   get w(): number {

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -40,11 +40,11 @@ class DecoratorTest {
  * @param {!Array<string>} arr
  * @param {!tsickle_forward_declare_1.AClass} aClass
  * @param {!tsickle_forward_declare_1.AClass} AClass
- * @param {!tsickle_forward_declare_1.AClass} aRanmedClass
+ * @param {!tsickle_forward_declare_1.AClass} aRenamedClass
  * @param {!tsickle_forward_declare_1.AClassWithGenerics<string>} aClassWithGenerics
  * @param {!tsickle_forward_declare_1.AType} aType
  */
-constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
+constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRenamedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 /**
  * @return {number}
  */

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -3,7 +3,7 @@
  * @suppress {checkTypes} checked by tsc
  */
 
-import {AClass, AType, AClassWithGenerics} from './external';
+import {AClass, AClass as ARenamedClass, AType, AClassWithGenerics} from './external';
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.decorator.external");
 /**
  * @param {!Object} a
@@ -39,11 +39,12 @@ class DecoratorTest {
  * @param {!Promise<string>} promise
  * @param {!Array<string>} arr
  * @param {!tsickle_forward_declare_1.AClass} aClass
+ * @param {!tsickle_forward_declare_1.AClass} AClass
+ * @param {!tsickle_forward_declare_1.AClass} aRanmedClass
  * @param {!tsickle_forward_declare_1.AClassWithGenerics<string>} aClassWithGenerics
  * @param {!tsickle_forward_declare_1.AType} aType
  */
-constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
-
+constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, AClass: AClass, aRanmedClass: ARenamedClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 /**
  * @return {number}
  */
@@ -69,6 +70,8 @@ null,
 null,
 {type: Promise, },
 {type: Array, },
+{type: AClass, },
+{type: AClass, },
 {type: AClass, },
 {type: AClassWithGenerics, },
 null,

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -65,12 +65,14 @@ static decorators: {type: Function, args?: any[]}[] = [
 /** @nocollapse */
 static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
 {type: Array, },
-null, null,
+null,
+null,
 {type: Promise, },
 {type: Array, },
 {type: AClass, },
 {type: AClassWithGenerics, },
-null,];
+null,
+];
 static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
 "w": [{ type: annotationDecorator },],
 "y": [{ type: annotationDecorator },],

--- a/test_files/decorator/decorator.tsickle.ts
+++ b/test_files/decorator/decorator.tsickle.ts
@@ -44,7 +44,16 @@ class DecoratorTest {
  */
 constructor(a: any[], n: number, b: boolean, promise: Promise<string>, arr: Array<string>, aClass: AClass, aClassWithGenerics: AClassWithGenerics<string>, aType: AType) {}
 
-  @decorator
+/**
+ * @return {number}
+ */
+get w(): number {
+    return 1;
+  }
+/**
+ * Some comment
+ */
+@decorator
 private x: number;
 private y: number;
 
@@ -63,6 +72,7 @@ null, null,
 {type: AClassWithGenerics, },
 null,];
 static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
+"w": [{ type: annotationDecorator },],
 "y": [{ type: annotationDecorator },],
 };
 }
@@ -77,7 +87,10 @@ DecoratorTest.decorators;
 DecoratorTest.ctorParameters;
 /** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
 DecoratorTest.propDecorators;
-/** @type {number} */
+/**
+ * Some comment
+ * @type {number}
+ */
 DecoratorTest.prototype.x;
 /** @type {number} */
 DecoratorTest.prototype.y;

--- a/test_files/enum.untyped/enum.untyped.js.transform.patch
+++ b/test_files/enum.untyped/enum.untyped.js.transform.patch
@@ -1,0 +1,20 @@
+Index: ./test_files/enum.untyped/enum.untyped.js
+===================================================================
+--- ./test_files/enum.untyped/enum.untyped.js	golden
++++ ./test_files/enum.untyped/enum.untyped.js	tsickle with transformer
+@@ -7,9 +7,10 @@
+ EnumUntypedTest1.XYZ = 0;
+ EnumUntypedTest1.PI = 3.14159;
+ EnumUntypedTest1[EnumUntypedTest1.XYZ] = "XYZ";
+ EnumUntypedTest1[EnumUntypedTest1.PI] = "PI";
+-exports.EnumUntypedTest2 = {};
+-exports.EnumUntypedTest2.XYZ = 0;
+-exports.EnumUntypedTest2.PI = 3.14159;
+-exports.EnumUntypedTest2[exports.EnumUntypedTest2.XYZ] = "XYZ";
+-exports.EnumUntypedTest2[exports.EnumUntypedTest2.PI] = "PI";
++let EnumUntypedTest2 = {};
++exports.EnumUntypedTest2 = EnumUntypedTest2;
++EnumUntypedTest2.XYZ = 0;
++EnumUntypedTest2.PI = 3.14159;
++EnumUntypedTest2[EnumUntypedTest2.XYZ] = "XYZ";
++EnumUntypedTest2[EnumUntypedTest2.PI] = "PI";

--- a/test_files/enum/enum.js.transform.patch
+++ b/test_files/enum/enum.js.transform.patch
@@ -1,0 +1,38 @@
+Index: ./test_files/enum/enum.js
+===================================================================
+--- ./test_files/enum/enum.js	golden
++++ ./test_files/enum/enum.js	tsickle with transformer
+@@ -16,25 +16,26 @@
+ // number.  Verify that the resulting TypeScript still allows you to
+ // index into the enum with all the various ways allowed of enums.
+ let /** @type {number} */ enumTestValue = EnumTest1.XYZ;
+ let /** @type {number} */ enumTestValue2 = EnumTest1['XYZ'];
+-let /** @type {string} */ enumNumIndex = EnumTest1[((null))];
+-let /** @type {number} */ enumStrIndex = EnumTest1[((null))];
++let /** @type {string} */ enumNumIndex = EnumTest1[/** @type {number} */ ((null))];
++let /** @type {number} */ enumStrIndex = EnumTest1[/** @type {string} */ ((null))];
+ /**
+  * @param {number} val
+  * @return {void}
+  */
+ function enumTestFunction(val) { }
+ enumTestFunction(enumTestValue);
+ let /** @type {number} */ enumTestLookup = EnumTest1["XYZ"];
+ let /** @type {?} */ enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
+-exports.EnumTest2 = {};
++let EnumTest2 = {};
++exports.EnumTest2 = EnumTest2;
+ /** @type {number} */
+-exports.EnumTest2.XYZ = 0;
++EnumTest2.XYZ = 0;
+ /** @type {number} */
+-exports.EnumTest2.PI = 3.14159;
+-exports.EnumTest2[exports.EnumTest2.XYZ] = "XYZ";
+-exports.EnumTest2[exports.EnumTest2.PI] = "PI";
++EnumTest2.PI = 3.14159;
++EnumTest2[EnumTest2.XYZ] = "XYZ";
++EnumTest2[EnumTest2.PI] = "PI";
+ let ComponentIndex = {};
+ /** @type {number} */
+ ComponentIndex.Scheme = 1;
+ /** @type {number} */

--- a/test_files/export/export.js.transform.patch
+++ b/test_files/export/export.js.transform.patch
@@ -1,0 +1,40 @@
+Index: ./test_files/export/export.js
+===================================================================
+--- ./test_files/export/export.js	golden
++++ ./test_files/export/export.js	tsickle with transformer
+@@ -4,27 +4,32 @@
+  */
+ 
+ var export_helper_1 = goog.require('test_files.export.export_helper');
+ exports.export2 = export_helper_1.export2;
+-exports.Bar = export_helper_1.Bar;
+ exports.export5 = export_helper_1.export5;
+ exports.export4 = export_helper_1.export4;
+-exports.Interface = export_helper_1.Interface;
+ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
++/** @typedef {tsickle_forward_declare_1.Bar} */
++exports.Bar; // re-export typedef
+ /** @typedef {tsickle_forward_declare_1.TypeDef} */
+ exports.RenamedTypeDef; // re-export typedef
+ /** @typedef {tsickle_forward_declare_1.TypeDef} */
+ exports.TypeDef; // re-export typedef
++/** @typedef {tsickle_forward_declare_1.Interface} */
++exports.Interface; // re-export typedef
+ /** @typedef {tsickle_forward_declare_1.DeclaredType} */
+ exports.DeclaredType; // re-export typedef
++/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
++exports.DeclaredInterface; // re-export typedef
+ const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
+ // These conflict with an export discovered via the above exports,
+ // so the above export's versions should not show up.
+ exports.export1 = 'wins';
+ var export_helper_2 = export_helper_1;
+ exports.export3 = export_helper_2.export4;
+-exports.RenamedInterface = export_helper_2.Interface;
+ const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
++/** @typedef {tsickle_forward_declare_3.Interface} */
++exports.RenamedInterface; // re-export typedef
+ // This local should be fine to export.
+ exports.exportLocal = 3;
+ // The existence of a local should not prevent "export2" from making
+ // it to the exports list.  export2 should only show up once in the

--- a/test_files/export/export_helper.js.transform.patch
+++ b/test_files/export/export_helper.js.transform.patch
@@ -1,0 +1,23 @@
+Index: ./test_files/export/export_helper.js
+===================================================================
+--- ./test_files/export/export_helper.js	golden
++++ ./test_files/export/export_helper.js	tsickle with transformer
+@@ -6,14 +6,17 @@
+ // This file isn't itself a test case, but it is imported by the
+ // export.in.ts test case.
+ var export_helper_2_1 = goog.require('test_files.export.export_helper_2');
+ exports.export4 = export_helper_2_1.export4;
+-exports.Interface = export_helper_2_1.Interface;
+ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper_2");
+ /** @typedef {tsickle_forward_declare_1.TypeDef} */
+ exports.TypeDef; // re-export typedef
++/** @typedef {tsickle_forward_declare_1.Interface} */
++exports.Interface; // re-export typedef
+ /** @typedef {tsickle_forward_declare_1.DeclaredType} */
+ exports.DeclaredType; // re-export typedef
++/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
++exports.DeclaredInterface; // re-export typedef
+ exports.export1 = 3;
+ exports.export2 = 3;
+ /**
+  * @record

--- a/test_files/export/export_star_imported.js.transform.patch
+++ b/test_files/export/export_star_imported.js.transform.patch
@@ -1,0 +1,29 @@
+Index: ./test_files/export/export_star_imported.js
+===================================================================
+--- ./test_files/export/export_star_imported.js	golden
++++ ./test_files/export/export_star_imported.js	tsickle with transformer
+@@ -5,18 +5,22 @@
+ 
+ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
+ var export_helper_1 = goog.require('test_files.export.export_helper');
+ exports.export1 = export_helper_1.export1;
+-exports.Bar = export_helper_1.Bar;
+ exports.export3 = export_helper_1.export3;
+ exports.export5 = export_helper_1.export5;
+ exports.export4 = export_helper_1.export4;
+-exports.Interface = export_helper_1.Interface;
+ const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper");
++/** @typedef {tsickle_forward_declare_2.Bar} */
++exports.Bar; // re-export typedef
+ /** @typedef {tsickle_forward_declare_2.TypeDef} */
+ exports.RenamedTypeDef; // re-export typedef
+ /** @typedef {tsickle_forward_declare_2.TypeDef} */
+ exports.TypeDef; // re-export typedef
++/** @typedef {tsickle_forward_declare_2.Interface} */
++exports.Interface; // re-export typedef
+ /** @typedef {tsickle_forward_declare_2.DeclaredType} */
+ exports.DeclaredType; // re-export typedef
++/** @typedef {tsickle_forward_declare_2.DeclaredInterface} */
++exports.DeclaredInterface; // re-export typedef
+ const /** @type {number} */ something = 1;
+ exports.export2 = something;

--- a/test_files/index_import/user.js.transform.patch
+++ b/test_files/index_import/user.js.transform.patch
@@ -1,0 +1,17 @@
+Index: ./test_files/index_import/user.js
+===================================================================
+--- ./test_files/index_import/user.js	golden
++++ ./test_files/index_import/user.js	tsickle with transformer
+@@ -3,10 +3,10 @@
+  * @suppress {checkTypes} checked by tsc
+  */
+ 
+ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.index_import.has_index.index");
+-var index_1 = goog.require('test_files.index_import.has_index.index');
+-exports.a = index_1.a;
++var has_index_1 = goog.require('test_files.index_import.has_index.index');
++exports.a = has_index_1.a;
+ const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.index_import.has_index.index");
+ const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.index_import.has_index.index");
+ const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.index_import.has_index.index");
+ const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.index_import.has_index.index");

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -109,4 +109,11 @@ function JSDocWithBadTag() { }
  * For example,
  * \@madeUpTag
  */
-const c = 'c';
+const /** @type {string} */ c = 'c';
+/**
+ * Don't emit type comments for Polymer behaviors,
+ * as this breaks their closure plugin :-(
+ *
+ * @polymerBehavior
+ */
+const somePolymerBehavior = {};

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -27,6 +27,10 @@ function jsDocTestBadDoc(foo) { }
  */
 class JSDocTest {
     constructor() {
+        /**
+         * \@internal
+         */
+        this.x = [];
         /** @enum {string} */
         this.badEnumThing = { A: 'a' };
         /** @const {string} */
@@ -43,6 +47,11 @@ function JSDocTest_tsickle_Closure_declarations() {
      * @type {!Array<string>}
      */
     JSDocTest.X;
+    /**
+     * \@internal
+     * @type {!Array<string>}
+     */
+    JSDocTest.prototype.x;
     /**
      * @export
      * @type {string}

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -98,3 +98,11 @@ function JSDocWithBadTag() {}
  * @madeUpTag
  */
 const c = 'c';
+
+/**
+ * Don't emit type comments for Polymer behaviors,
+ * as this breaks their closure plugin :-(
+ *
+ * @polymerBehavior
+ */
+const somePolymerBehavior = {};

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -26,6 +26,9 @@ class JSDocTest {
   /** @internal */
   static X: string[] = [];
 
+  /** @internal */
+  x: string[] = [];
+
   /** @export */
   exported: string;
 

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -145,4 +145,11 @@ function JSDocWithBadTag() {}
  * For example,
  * \@madeUpTag
  */
-const c = 'c';
+const /** @type {string} */ c = 'c';
+/**
+ * Don't emit type comments for Polymer behaviors,
+ * as this breaks their closure plugin :-(
+ * 
+ * @polymerBehavior
+ */
+const somePolymerBehavior = {};

--- a/test_files/jsdoc/jsdoc.tsickle.ts
+++ b/test_files/jsdoc/jsdoc.tsickle.ts
@@ -1,23 +1,23 @@
 Warning at test_files/jsdoc/jsdoc.ts:16:1: the type annotation on @param is redundant with its TypeScript type, remove the {...} part
-Warning at test_files/jsdoc/jsdoc.ts:32:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
-Warning at test_files/jsdoc/jsdoc.ts:37:3: @type annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:40:3: @enum annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:43:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
-Warning at test_files/jsdoc/jsdoc.ts:46:3: @typedef annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:32:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
-Warning at test_files/jsdoc/jsdoc.ts:37:3: @type annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:40:3: @enum annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:43:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
-Warning at test_files/jsdoc/jsdoc.ts:46:3: @typedef annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:50:1: @template annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:53:1: use index signatures (`[k: string]: type`) instead of @dict
-Warning at test_files/jsdoc/jsdoc.ts:56:1: @lends annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:62:1: @this annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:65:1: @interface annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:74:1: @extends annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:35:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:40:3: @type annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:43:3: @enum annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:46:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:49:3: @typedef annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:35:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:40:3: @type annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:43:3: @enum annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:46:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+Warning at test_files/jsdoc/jsdoc.ts:49:3: @typedef annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:53:1: @template annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:56:1: use index signatures (`[k: string]: type`) instead of @dict
+Warning at test_files/jsdoc/jsdoc.ts:59:1: @lends annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:65:1: @this annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:68:1: @interface annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:77:1: @extends annotations are redundant with TypeScript equivalents
 @implements annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:81:3: @constructor annotations are redundant with TypeScript equivalents
-Warning at test_files/jsdoc/jsdoc.ts:41:3: unhandled anonymous type
+Warning at test_files/jsdoc/jsdoc.ts:84:3: @constructor annotations are redundant with TypeScript equivalents
+Warning at test_files/jsdoc/jsdoc.ts:44:3: unhandled anonymous type
 ====
 /**
  * @fileoverview added by tsickle
@@ -54,6 +54,10 @@ class JSDocTest {
  */
 static X: string[] = [];
 /**
+ * \@internal
+ */
+x: string[] = [];
+/**
  * @export
  */
 exported: string;
@@ -82,6 +86,11 @@ function JSDocTest_tsickle_Closure_declarations() {
  * @type {!Array<string>}
  */
 JSDocTest.X;
+/**
+ * \@internal
+ * @type {!Array<string>}
+ */
+JSDocTest.prototype.x;
 /**
  * @export
  * @type {string}

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -37,3 +37,6 @@ function NonPrimitives_tsickle_Closure_declarations() {
 function takesNonNullable(val) { }
 let /** @type {{field: (null|string|number)}} */ x = { field: null };
 takesNonNullable(/** @type {(string|number)} */ ((x.field)));
+takesNonNullable(`${(((x.field)))}`);
+let /** @type {?} */ ctx;
+takesNonNullable(`org/${(((ctx.getTargetOrganization()))).key}/admin/folders`);

--- a/test_files/nullable/nullable.js.transform.patch
+++ b/test_files/nullable/nullable.js.transform.patch
@@ -1,0 +1,14 @@
+Index: ./test_files/nullable/nullable.js
+===================================================================
+--- ./test_files/nullable/nullable.js	golden
++++ ./test_files/nullable/nullable.js	tsickle with transformer
+@@ -36,7 +36,7 @@
+  */
+ function takesNonNullable(val) { }
+ let /** @type {{field: (null|string|number)}} */ x = { field: null };
+ takesNonNullable(/** @type {(string|number)} */ ((x.field)));
+-takesNonNullable(`${(((x.field)))}`);
++takesNonNullable(`${(/** @type {(string|number)} */ ((x.field)))}`);
+ let /** @type {?} */ ctx;
+-takesNonNullable(`org/${(((ctx.getTargetOrganization()))).key}/admin/folders`);
++takesNonNullable(`org/${(/** @type {?} */ ((ctx.getTargetOrganization()))).key}/admin/folders`);

--- a/test_files/nullable/nullable.ts
+++ b/test_files/nullable/nullable.ts
@@ -20,3 +20,6 @@ function takesNonNullable(val: string|number) {}
 
 let x: {field: string | null | number} = {field: null};
 takesNonNullable(x.field!);
+takesNonNullable(`${x.field!}`);
+let ctx: any;
+takesNonNullable(`org/${ctx.getTargetOrganization()!.key}/admin/folders`);

--- a/test_files/nullable/nullable.tsickle.ts
+++ b/test_files/nullable/nullable.tsickle.ts
@@ -52,3 +52,6 @@ function takesNonNullable(val: string|number) {}
 
 let /** @type {{field: (null|string|number)}} */ x: {field: string | null | number} = {field: null};
 takesNonNullable( /** @type {(string|number)} */((x.field)));
+takesNonNullable(`${( /** @type {(string|number)} */((x.field)))}`);
+let /** @type {?} */ ctx: any;
+takesNonNullable(`org/${( /** @type {?} */((ctx.getTargetOrganization()))).key}/admin/folders`);

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -11,6 +11,8 @@ let /** @type {!Quoted} */ quoted = {};
 console.log(quoted["hello"]);
 quoted["hello"] = 1;
 quoted['hello'] = 1;
+/** some comment */
+quoted["hello"] = 1;
 /**
  * @record
  * @extends {Quoted}

--- a/test_files/quote_props/quote.ts
+++ b/test_files/quote_props/quote.ts
@@ -9,6 +9,8 @@ let quoted: Quoted = {};
 console.log(quoted.hello);
 quoted.hello = 1;
 quoted['hello'] = 1;
+/** some comment */
+quoted.hello = 1;
 
 interface QuotedMixed extends Quoted {
   // Even though foo is explicitly declared as a property, assume it should not

--- a/test_files/quote_props/quote.tsickle.ts
+++ b/test_files/quote_props/quote.tsickle.ts
@@ -1,6 +1,7 @@
 Warning at test_files/quote_props/quote.ts:9:13: Quoted has a string index type but is accessed using dotted access. Quoting the access.
 Warning at test_files/quote_props/quote.ts:10:1: Quoted has a string index type but is accessed using dotted access. Quoting the access.
-Warning at test_files/quote_props/quote.ts:27:1: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
+Warning at test_files/quote_props/quote.ts:13:1: Quoted has a string index type but is accessed using dotted access. Quoting the access.
+Warning at test_files/quote_props/quote.ts:29:1: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 ====
 /**
  * @fileoverview added by tsickle
@@ -26,6 +27,8 @@ let /** @type {!Quoted} */ quoted: Quoted = {};
 console.log(quoted["hello"]);
 quoted["hello"] = 1;
 quoted['hello'] = 1;
+/** some comment */
+quoted["hello"] = 1;
 /**
  * @record
  * @extends {Quoted}

--- a/test_files/use_closure_externs/use_closure_externs.js.transform.patch
+++ b/test_files/use_closure_externs/use_closure_externs.js.transform.patch
@@ -1,0 +1,12 @@
+Index: ./test_files/use_closure_externs/use_closure_externs.js
+===================================================================
+--- ./test_files/use_closure_externs/use_closure_externs.js	golden
++++ ./test_files/use_closure_externs/use_closure_externs.js	tsickle with transformer
+@@ -5,6 +5,6 @@
+  */
+ console.log('work around TS dropping consecutive comments');
+ let /** @type {!NodeListOf<!HTMLParagraphElement>} */ x = document.getElementsByTagName('p');
+ console.log(x);
+-const /** @type {(null|!RegExpExecArray)} */ res = ((/asd/.exec('asd asd')));
++const /** @type {(null|!RegExpExecArray)} */ res = /** @type {!RegExpExecArray} */ ((/asd/.exec('asd asd')));
+ console.log(res);


### PR DESCRIPTION
This PR introduces transformer support for tsickle.
The first 6 commits are prefactorings, which are used by the last commit which introduces the main API.

Global TAP presubmit is looking good using the new transformer API in G3.

Proposed way of landing this PR:
1. Review this PR and land it (hopefully mostly as is) on master
2. Continue to use the old entry point in G3 which is still fully functional
3. Use the new entry point in G3.

This way, we can have a bit of time between 2. and 3., without blocking other fixes for Tsickle. We are also able to rollback to using the old entry point without creating branches of Tsickle.