### PR TITLE
avoid redeclaring augmented modules

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1631,14 +1631,17 @@ class ExternsWriter extends ClosureRewriter {
             this.writeExternsVariable('tsickle_declare_module', [], '{}');
             namespace = ['tsickle_declare_module'];
 
-            // Declare the inner "tsickle_declare_module.foo".
+            // Declare the inner "tsickle_declare_module.foo", if it's not
+            // declared already elsewhere.
             let importName = (decl.name as ts.StringLiteral).text;
             this.emit(`// Derived from: declare module "${importName}"\n`);
             // We also don't care about the actual name of the module ("foo"
             // in the above example), except that we want it to not conflict.
             importName = importName.replace(/_/, '__').replace(/[^A-Za-z]/g, '_');
-            this.emit('/** @const */\n');
-            this.writeExternsVariable(importName, namespace, '{}');
+            if (this.isFirstDeclaration(decl)) {
+              this.emit('/** @const */\n');
+              this.writeExternsVariable(importName, namespace, '{}');
+            }
 
             // Declare the contents inside the "tsickle_declare_module.foo".
             if (decl.body) this.visit(decl.body, namespace.concat(importName));

--- a/test_files/augment/externs.js
+++ b/test_files/augment/externs.js
@@ -8,8 +8,6 @@
 /** @const */
 var tsickle_declare_module = {};
 // Derived from: declare module "./angular"
-/** @const */
-tsickle_declare_module.__angular = {};
 
 /** @typedef {string} */
 tsickle_declare_module.__angular.sub.AugmentSubType;


### PR DESCRIPTION
Assume that the first person who declares a given namespace
will emit the externs for it, so we shouldn't emit them again.

In the output externs, you can see that the "local" namespace
is still emitted, but we avoid re-emitting this "angular"
namespace because the module we're augmenting already emitted
it.