### PR TITLE
Wrap interface members in a function _tsickle_Closure_declarations().

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1331,11 +1331,13 @@ class Annotator extends ClosureRewriter {
     const name = getIdentifierText(iface.name);
     this.emit(`function ${name}() {}\n`);
 
+    this.emit(`\n\nfunction ${name}_tsickle_Closure_declarations() {\n`);
     const memberNamespace = [name, 'prototype'];
     for (const elem of iface.members) {
       const isOptional = elem.questionToken != null;
       this.visitProperty(memberNamespace, elem, isOptional);
     }
+    this.emit(`}\n`);
   }
 
   /**

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -6,8 +6,10 @@ goog.module('test_files.class.untyped.class');var module = module || {id: 'test_
  * @record
  */
 function Interface() { }
-/** @type {?} */
-Interface.prototype.interfaceFunc;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {?} */
+    Interface.prototype.interfaceFunc;
+}
 class Super {
     /**
      * @return {?}

--- a/test_files/class.untyped/class.tsickle.ts
+++ b/test_files/class.untyped/class.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {?} */
 Interface.prototype.interfaceFunc;
+}
 interface Interface {
   interfaceFunc(): void;
 }

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -6,8 +6,10 @@ goog.module('test_files.class.class');var module = module || {id: 'test_files/cl
  * @record
  */
 function Interface() { }
-/** @type {function(): void} */
-Interface.prototype.interfaceFunc;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {function(): void} */
+    Interface.prototype.interfaceFunc;
+}
 class Class {
     /**
      * @return {void}
@@ -35,8 +37,10 @@ function AbstractClass_tsickle_Closure_declarations() {
  * @extends {Interface}
  */
 function InterfaceExtendsInterface() { }
-/** @type {function(): void} */
-InterfaceExtendsInterface.prototype.interfaceFunc2;
+function InterfaceExtendsInterface_tsickle_Closure_declarations() {
+    /** @type {function(): void} */
+    InterfaceExtendsInterface.prototype.interfaceFunc2;
+}
 let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = {
     /**
      * @return {void}
@@ -51,8 +55,10 @@ let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = {
  * @record
  */
 function InterfaceExtendsClass() { }
-/** @type {function(): void} */
-InterfaceExtendsClass.prototype.interfaceFunc3;
+function InterfaceExtendsClass_tsickle_Closure_declarations() {
+    /** @type {function(): void} */
+    InterfaceExtendsClass.prototype.interfaceFunc3;
+}
 /**
  * @implements {Interface}
  */

--- a/test_files/class/class.tsickle.ts
+++ b/test_files/class/class.tsickle.ts
@@ -10,8 +10,12 @@ Warning at test_files/class/class.ts:129:1: type/symbol conflict for Zone, using
  * @record
  */
 function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {function(): void} */
 Interface.prototype.interfaceFunc;
+}
 // This test exercises the various ways classes and interfaces can interact.
 // There are three types of classy things:
 //   interface, class, abstract class
@@ -56,8 +60,12 @@ AbstractClass.prototype.abstractFunc = function() {};
  * @extends {Interface}
  */
 function InterfaceExtendsInterface() {}
+
+
+function InterfaceExtendsInterface_tsickle_Closure_declarations() {
 /** @type {function(): void} */
 InterfaceExtendsInterface.prototype.interfaceFunc2;
+}
 
 
 // Write out all permutations:
@@ -90,8 +98,12 @@ interfaceFunc2() {}
  * @record
  */
 function InterfaceExtendsClass() {}
+
+
+function InterfaceExtendsClass_tsickle_Closure_declarations() {
 /** @type {function(): void} */
 InterfaceExtendsClass.prototype.interfaceFunc3;
+}
 
 
 // Permutation 2: interface extends class.

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -17,3 +17,5 @@ exports.AClassWithGenerics = AClassWithGenerics;
  */
 function AType() { }
 exports.AType = AType;
+function AType_tsickle_Closure_declarations() {
+}

--- a/test_files/decorator/external.tsickle.ts
+++ b/test_files/decorator/external.tsickle.ts
@@ -15,4 +15,8 @@ export class AClassWithGenerics<T> {}
 export function AType() {}
 
 
+function AType_tsickle_Closure_declarations() {
+}
+
+
 export interface AType {}

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -20,8 +20,10 @@ exports.export2 = 3;
  */
 function Bar() { }
 exports.Bar = Bar;
-/** @type {number} */
-Bar.prototype.barField;
+function Bar_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Bar.prototype.barField;
+}
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
 /** @typedef {tsickle_forward_declare_2.TypeDef} */

--- a/test_files/export/export_helper.tsickle.ts
+++ b/test_files/export/export_helper.tsickle.ts
@@ -17,8 +17,12 @@ export let /** @type {number} */ export2 = 3;
  * @record
  */
 export function Bar() {}
+
+
+function Bar_tsickle_Closure_declarations() {
 /** @type {number} */
 Bar.prototype.barField;
+}
 
 
 export interface Bar { barField: number; }

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -15,8 +15,10 @@ exports.TypeDef;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {string} */
-Interface.prototype.x;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Interface.prototype.x;
+}
 /** @typedef {DeclaredType} */
 exports.DeclaredType;
 /** @typedef {DeclaredInterface} */

--- a/test_files/export/export_helper_2.tsickle.ts
+++ b/test_files/export/export_helper_2.tsickle.ts
@@ -17,8 +17,12 @@ exports.TypeDef;
  * @record
  */
 export function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {string} */
 Interface.prototype.x;
+}
 
 export interface Interface { x: string; }
 

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -8,7 +8,9 @@ goog.module('test_files.import_only_types.types_only');var module = module || {i
  */
 function Foo() { }
 exports.Foo = Foo;
-/** @type {string} */
-Foo.prototype.x;
+function Foo_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Foo.prototype.x;
+}
 /** @typedef {number} */
 exports.Bar;

--- a/test_files/import_only_types/types_only.tsickle.ts
+++ b/test_files/import_only_types/types_only.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 export function Foo() {}
+
+
+function Foo_tsickle_Closure_declarations() {
 /** @type {string} */
 Foo.prototype.x;
+}
 // Exports only types, but must still be goog.require'd for Closure Compiler.
 
 export interface Foo {

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -9,10 +9,12 @@ goog.module('test_files.interface.interface');var module = module || {id: 'test_
  */
 function Point() { }
 exports.Point = Point;
-/** @type {number} */
-Point.prototype.x;
-/** @type {number} */
-Point.prototype.y;
+function Point_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Point.prototype.x;
+    /** @type {number} */
+    Point.prototype.y;
+}
 /**
  * Used by implement_import.ts
  */
@@ -37,23 +39,25 @@ usePoint({ x: 1, y: 1 });
  * @record
  */
 function TrickyInterface() { }
-/* TODO: handle strange member:
-[offset: number]: number;
-*/
-/** @type {number} */
-TrickyInterface.prototype.foo;
-/* TODO: handle strange member:
-(x: number): __ yuck __
-      number;
-*/
-/** @type {(undefined|string)} */
-TrickyInterface.prototype.foobar;
-/** @type {?|undefined} */
-TrickyInterface.prototype.optAny;
-/**
- * \@param a some string value
- * \@return some number value
- * @override
- * @type {function(string): number}
- */
-TrickyInterface.prototype.hasSomeParamJsDoc;
+function TrickyInterface_tsickle_Closure_declarations() {
+    /* TODO: handle strange member:
+    [offset: number]: number;
+    */
+    /** @type {number} */
+    TrickyInterface.prototype.foo;
+    /* TODO: handle strange member:
+    (x: number): __ yuck __
+          number;
+    */
+    /** @type {(undefined|string)} */
+    TrickyInterface.prototype.foobar;
+    /** @type {?|undefined} */
+    TrickyInterface.prototype.optAny;
+    /**
+     * \@param a some string value
+     * \@return some number value
+     * @override
+     * @type {function(string): number}
+     */
+    TrickyInterface.prototype.hasSomeParamJsDoc;
+}

--- a/test_files/interface/interface.tsickle.ts
+++ b/test_files/interface/interface.tsickle.ts
@@ -9,10 +9,14 @@
  * @record
  */
 export function Point() {}
+
+
+function Point_tsickle_Closure_declarations() {
 /** @type {number} */
 Point.prototype.x;
 /** @type {number} */
 Point.prototype.y;
+}
 /** Used by implement_import.ts */
 export interface Point {
   x: number;
@@ -43,6 +47,9 @@ usePoint({x: 1, y: 1});
  * @record
  */
 function TrickyInterface() {}
+
+
+function TrickyInterface_tsickle_Closure_declarations() {
 /* TODO: handle strange member:
 [offset: number]: number;
 */
@@ -63,6 +70,7 @@ TrickyInterface.prototype.optAny;
  * @type {function(string): number}
  */
 TrickyInterface.prototype.hasSomeParamJsDoc;
+}
 
 
 /*

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -6,20 +6,26 @@ goog.module('test_files.interface.interface_extends');var module = module || {id
  * @record
  */
 function ParentInterface() { }
-/** @type {number} */
-ParentInterface.prototype.x;
+function ParentInterface_tsickle_Closure_declarations() {
+    /** @type {number} */
+    ParentInterface.prototype.x;
+}
 /**
  * @record
  * @extends {ParentInterface}
  */
 function SubType() { }
-/** @type {number} */
-SubType.prototype.y;
+function SubType_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SubType.prototype.y;
+}
 /**
  * @record
  * @extends {ParentInterface}
  * @extends {SubType}
  */
 function SubMulti() { }
-/** @type {number} */
-SubMulti.prototype.z;
+function SubMulti_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SubMulti.prototype.z;
+}

--- a/test_files/interface/interface_extends.tsickle.ts
+++ b/test_files/interface/interface_extends.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 function ParentInterface() {}
+
+
+function ParentInterface_tsickle_Closure_declarations() {
 /** @type {number} */
 ParentInterface.prototype.x;
+}
 interface ParentInterface {
   x: number;
 }
@@ -18,8 +22,12 @@ interface ParentInterface {
  * @extends {ParentInterface}
  */
 function SubType() {}
+
+
+function SubType_tsickle_Closure_declarations() {
 /** @type {number} */
 SubType.prototype.y;
+}
 
 
 interface SubType extends ParentInterface {
@@ -31,8 +39,12 @@ interface SubType extends ParentInterface {
  * @extends {SubType}
  */
 function SubMulti() {}
+
+
+function SubMulti_tsickle_Closure_declarations() {
 /** @type {number} */
 SubMulti.prototype.z;
+}
 
 
 interface SubMulti extends ParentInterface, SubType {

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -6,15 +6,19 @@ goog.module('test_files.interface.interface_type_params');var module = module ||
  * @record
  */
 function UpperBound() { }
-/** @type {number} */
-UpperBound.prototype.x;
+function UpperBound_tsickle_Closure_declarations() {
+    /** @type {number} */
+    UpperBound.prototype.x;
+}
 // unsupported: template constraints.
 /**
  * @record
  * @template T, U
  */
 function WithTypeParam() { }
-/** @type {T} */
-WithTypeParam.prototype.tea;
-/** @type {U} */
-WithTypeParam.prototype.you;
+function WithTypeParam_tsickle_Closure_declarations() {
+    /** @type {T} */
+    WithTypeParam.prototype.tea;
+    /** @type {U} */
+    WithTypeParam.prototype.you;
+}

--- a/test_files/interface/interface_type_params.tsickle.ts
+++ b/test_files/interface/interface_type_params.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 function UpperBound() {}
+
+
+function UpperBound_tsickle_Closure_declarations() {
 /** @type {number} */
 UpperBound.prototype.x;
+}
 interface UpperBound {
   x: number;
 }
@@ -19,10 +23,14 @@ interface UpperBound {
  * @template T, U
  */
 function WithTypeParam() {}
+
+
+function WithTypeParam_tsickle_Closure_declarations() {
 /** @type {T} */
 WithTypeParam.prototype.tea;
 /** @type {U} */
 WithTypeParam.prototype.you;
+}
 
 
 interface WithTypeParam<T extends UpperBound, U> {

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -11,5 +11,10 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {?} */
-Interface.prototype.x;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {?} */
+    Interface.prototype.x;
+    /* TODO: handle strange member:
+    "quoted-bad-name": string;
+    */
+}

--- a/test_files/jsdoc_types.untyped/module1.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module1.tsickle.ts
@@ -9,11 +9,15 @@ export class Class {}
  * @record
  */
 export function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {?} */
 Interface.prototype.x;
 /* TODO: handle strange member:
 "quoted-bad-name": string;
 */
+}
 
 export interface Interface {
   x: number;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -14,8 +14,10 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {?} */
-Interface.prototype.x;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {?} */
+    Interface.prototype.x;
+}
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;

--- a/test_files/jsdoc_types.untyped/module2.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/module2.tsickle.ts
@@ -10,8 +10,12 @@ export class ClassTwo {}
  * @record
  */
 export function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {?} */
 Interface.prototype.x;
+}
 
 export interface Interface { x: number }
 export class ClassWithParams<T> {}

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -8,5 +8,7 @@ goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || 
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-/** @type {?} */
-NeverTyped.prototype.foo;
+function NeverTyped_tsickle_Closure_declarations() {
+    /** @type {?} */
+    NeverTyped.prototype.foo;
+}

--- a/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types.untyped/nevertyped.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 export function NeverTyped() {}
+
+
+function NeverTyped_tsickle_Closure_declarations() {
 /** @type {?} */
 NeverTyped.prototype.foo;
+}
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -11,5 +11,10 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {number} */
-Interface.prototype.x;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Interface.prototype.x;
+    /* TODO: handle strange member:
+    "quoted-bad-name": string;
+    */
+}

--- a/test_files/jsdoc_types/module1.tsickle.ts
+++ b/test_files/jsdoc_types/module1.tsickle.ts
@@ -9,11 +9,15 @@ export class Class {}
  * @record
  */
 export function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {number} */
 Interface.prototype.x;
 /* TODO: handle strange member:
 "quoted-bad-name": string;
 */
+}
 
 export interface Interface {
   x: number;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -14,8 +14,10 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {number} */
-Interface.prototype.x;
+function Interface_tsickle_Closure_declarations() {
+    /** @type {number} */
+    Interface.prototype.x;
+}
 /**
  * @template T
  */

--- a/test_files/jsdoc_types/module2.tsickle.ts
+++ b/test_files/jsdoc_types/module2.tsickle.ts
@@ -10,8 +10,12 @@ export class ClassTwo {}
  * @record
  */
 export function Interface() {}
+
+
+function Interface_tsickle_Closure_declarations() {
 /** @type {number} */
 Interface.prototype.x;
+}
 
 export interface Interface { x: number }
 /**

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -8,5 +8,7 @@ goog.module('test_files.jsdoc_types.nevertyped');var module = module || {id: 'te
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-/** @type {number} */
-NeverTyped.prototype.foo;
+function NeverTyped_tsickle_Closure_declarations() {
+    /** @type {number} */
+    NeverTyped.prototype.foo;
+}

--- a/test_files/jsdoc_types/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types/nevertyped.tsickle.ts
@@ -8,8 +8,12 @@
  * @record
  */
 export function NeverTyped() {}
+
+
+function NeverTyped_tsickle_Closure_declarations() {
 /** @type {number} */
 NeverTyped.prototype.foo;
+}
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -7,6 +7,11 @@ goog.module('test_files.quote_props.quote');var module = module || {id: 'test_fi
  * @record
  */
 function Quoted() { }
+function Quoted_tsickle_Closure_declarations() {
+    /* TODO: handle strange member:
+    [k: string]: number;
+    */
+}
 let /** @type {!Quoted} */ quoted = {};
 console.log(quoted["hello"]);
 quoted["hello"] = 1;
@@ -18,13 +23,15 @@ quoted["hello"] = 1;
  * @extends {Quoted}
  */
 function QuotedMixed() { }
-/** @type {number} */
-QuotedMixed.prototype.foo;
-/* TODO: handle strange member:
-'invalid-identifier': number;
-*/
-/** @type {number} */
-QuotedMixed.prototype.quotedIdent;
+function QuotedMixed_tsickle_Closure_declarations() {
+    /** @type {number} */
+    QuotedMixed.prototype.foo;
+    /* TODO: handle strange member:
+    'invalid-identifier': number;
+    */
+    /** @type {number} */
+    QuotedMixed.prototype.quotedIdent;
+}
 let /** @type {!QuotedMixed} */ quotedMixed = { foo: 1, 'invalid-identifier': 2, 'quotedIdent': 3 };
 console.log(quotedMixed.foo);
 quotedMixed.foo = 1;

--- a/test_files/quote_props/quote.tsickle.ts
+++ b/test_files/quote_props/quote.tsickle.ts
@@ -14,9 +14,13 @@ export {};
  * @record
  */
 function Quoted() {}
+
+
+function Quoted_tsickle_Closure_declarations() {
 /* TODO: handle strange member:
 [k: string]: number;
 */
+}
 
 
 interface Quoted {
@@ -34,6 +38,9 @@ quoted["hello"] = 1;
  * @extends {Quoted}
  */
 function QuotedMixed() {}
+
+
+function QuotedMixed_tsickle_Closure_declarations() {
 /** @type {number} */
 QuotedMixed.prototype.foo;
 /* TODO: handle strange member:
@@ -41,6 +48,7 @@ QuotedMixed.prototype.foo;
 */
 /** @type {number} */
 QuotedMixed.prototype.quotedIdent;
+}
 
 
 interface QuotedMixed extends Quoted {

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -53,8 +53,10 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
  * @record
  */
 function SuperTestInterface() { }
-/** @type {number} */
-SuperTestInterface.prototype.foo;
+function SuperTestInterface_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SuperTestInterface.prototype.foo;
+}
 /**
  * @implements {SuperTestInterface}
  */

--- a/test_files/super/super.tsickle.ts
+++ b/test_files/super/super.tsickle.ts
@@ -61,8 +61,12 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
  * @record
  */
 function SuperTestInterface() {}
+
+
+function SuperTestInterface_tsickle_Closure_declarations() {
 /** @type {number} */
 SuperTestInterface.prototype.foo;
+}
 
 
 interface SuperTestInterface {

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -27,3 +27,5 @@ function __Class_tsickle_Closure_declarations() {
  * @record
  */
 function __Interface() { }
+function __Interface_tsickle_Closure_declarations() {
+}

--- a/test_files/underscore/underscore.tsickle.ts
+++ b/test_files/underscore/underscore.tsickle.ts
@@ -32,6 +32,10 @@ __Class.prototype.__member;
  */
 function __Interface() {}
 
+
+function __Interface_tsickle_Closure_declarations() {
+}
+
 interface __Interface {}
 
 declare namespace __NS {


### PR DESCRIPTION
This makes it easier for tools such as rollup or uglify to detect that these
declarations are unused, which will allow users to compile the Closure emit
with such tools without getting a code size hit.