### PR TITLE
Ensure TypeScript can emit a .d.ts for the given code.

### DIFF
--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -2,6 +2,7 @@ goog.module('test_files.fields.fields');var module = module || {id: 'test_files/
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+
 class FieldsTest {
     /**
      * @param {number} field3

--- a/test_files/fields/fields.ts
+++ b/test_files/fields/fields.ts
@@ -22,3 +22,5 @@ fieldsTest.field1 = 'hi';
 let AnonymousClass = class {
   field: number;
 };
+
+export {};

--- a/test_files/fields/fields.tsickle.ts
+++ b/test_files/fields/fields.tsickle.ts
@@ -46,3 +46,5 @@ fieldsTest.field1 = 'hi';
 let /** @type {?} */ AnonymousClass = class {
   field: number;
 };
+
+export {};


### PR DESCRIPTION
If the effective type shape of a program refers to private names,
TypeScript cannot generate a .d.ts for it, and fails during emit.
Previously tsickle did not test for this.

This requires updating fields.ts. Because it is not a module, it
effectively exports every global variable it defines, which means its
private class type is affected by this change. Simply changing it to a
module resolves the problem.