### PR TITLE
Polish enum emit a bit.

### DIFF
--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -5,15 +5,13 @@ goog.module('test_files.enum.untyped.enum.untyped');var module = module || {id: 
 
 /** @enum {number} */
 const EnumUntypedTest1 = {
-    XYZ: 0,
-    PI: 3.14159,
+    XYZ: 0, PI: 3.14159,
 };
 EnumUntypedTest1[EnumUntypedTest1.XYZ] = "XYZ";
 EnumUntypedTest1[EnumUntypedTest1.PI] = "PI";
 /** @enum {number} */
 const EnumUntypedTest2 = {
-    XYZ: 0,
-    PI: 3.14159,
+    XYZ: 0, PI: 3.14159,
 };
 exports.EnumUntypedTest2 = EnumUntypedTest2;
 EnumUntypedTest2[EnumUntypedTest2.XYZ] = "XYZ";

--- a/test_files/enum.untyped/enum.untyped.js.transform.patch
+++ b/test_files/enum.untyped/enum.untyped.js.transform.patch
@@ -1,0 +1,24 @@
+Index: ./test_files/enum.untyped/enum.untyped.js
+===================================================================
+--- ./test_files/enum.untyped/enum.untyped.js	golden
++++ ./test_files/enum.untyped/enum.untyped.js	tsickle with transformer
+@@ -4,15 +4,17 @@
+  */
+ 
+ /** @enum {number} */
+ const EnumUntypedTest1 = {
+-    XYZ: 0, PI: 3.14159,
++    XYZ: 0,
++    PI: 3.14159,
+ };
+ EnumUntypedTest1[EnumUntypedTest1.XYZ] = "XYZ";
+ EnumUntypedTest1[EnumUntypedTest1.PI] = "PI";
+ /** @enum {number} */
+ const EnumUntypedTest2 = {
+-    XYZ: 0, PI: 3.14159,
++    XYZ: 0,
++    PI: 3.14159,
+ };
+ exports.EnumUntypedTest2 = EnumUntypedTest2;
+ EnumUntypedTest2[EnumUntypedTest2.XYZ] = "XYZ";
+ EnumUntypedTest2[EnumUntypedTest2.PI] = "PI";

--- a/test_files/enum.untyped/enum.untyped.tsickle.ts
+++ b/test_files/enum.untyped/enum.untyped.tsickle.ts
@@ -5,18 +5,14 @@
 
 
 /** @enum {number} */
-const EnumUntypedTest1: any = {
-XYZ: 0,
-PI: 3.14159,
-};
+const EnumUntypedTest1: DontTypeCheckMe = {
+XYZ: 0, PI: 3.14159,};
 EnumUntypedTest1[EnumUntypedTest1.XYZ] = "XYZ";
 EnumUntypedTest1[EnumUntypedTest1.PI] = "PI";
 
 /** @enum {number} */
-const EnumUntypedTest2: any = {
-XYZ: 0,
-PI: 3.14159,
-};
+const EnumUntypedTest2: DontTypeCheckMe = {
+XYZ: 0, PI: 3.14159,};
 export {EnumUntypedTest2};
 EnumUntypedTest2[EnumUntypedTest2.XYZ] = "XYZ";
 EnumUntypedTest2[EnumUntypedTest2.PI] = "PI";

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -7,8 +7,7 @@ goog.module('test_files.enum.enum');var module = module || {id: 'test_files/enum
 const /** @type {!Array<?>} */ EnumTestMissingSemi = [];
 /** @enum {number} */
 const EnumTest1 = {
-    XYZ: 0,
-    PI: 3.14159,
+    XYZ: 0, PI: 3.14159,
 };
 EnumTest1[EnumTest1.XYZ] = "XYZ";
 EnumTest1[EnumTest1.PI] = "PI";
@@ -30,8 +29,7 @@ let /** @type {?} */ enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
 let /** @type {(boolean|EnumTest1)} */ enumUnionType = EnumTest1.XYZ;
 /** @enum {number} */
 const EnumTest2 = {
-    XYZ: 0,
-    PI: 3.14159,
+    XYZ: 0, PI: 3.14159,
 };
 exports.EnumTest2 = EnumTest2;
 EnumTest2[EnumTest2.XYZ] = "XYZ";

--- a/test_files/enum/enum.js.transform.patch
+++ b/test_files/enum/enum.js.transform.patch
@@ -2,7 +2,17 @@ Index: ./test_files/enum/enum.js
 ===================================================================
 --- ./test_files/enum/enum.js	golden
 +++ ./test_files/enum/enum.js	tsickle with transformer
-@@ -15,10 +15,10 @@
+@@ -6,18 +6,19 @@
+ // Line with a missing semicolon should not break the following enum.
+ const /** @type {!Array<?>} */ EnumTestMissingSemi = [];
+ /** @enum {number} */
+ const EnumTest1 = {
+-    XYZ: 0, PI: 3.14159,
++    XYZ: 0,
++    PI: 3.14159,
+ };
+ EnumTest1[EnumTest1.XYZ] = "XYZ";
+ EnumTest1[EnumTest1.PI] = "PI";
  // Verify that the resulting TypeScript still allows you to index into the enum with all the various
  // ways allowed of enums.
  let /** @type {EnumTest1} */ enumTestValue = EnumTest1.XYZ;
@@ -15,7 +25,29 @@ Index: ./test_files/enum/enum.js
   * @param {EnumTest1} val
   * @return {void}
   */
-@@ -52,9 +52,9 @@
+@@ -28,9 +29,10 @@
+ // Verify that unions of enum members and other values are handled correctly.
+ let /** @type {(boolean|EnumTest1)} */ enumUnionType = EnumTest1.XYZ;
+ /** @enum {number} */
+ const EnumTest2 = {
+-    XYZ: 0, PI: 3.14159,
++    XYZ: 0,
++    PI: 3.14159,
+ };
+ exports.EnumTest2 = EnumTest2;
+ EnumTest2[EnumTest2.XYZ] = "XYZ";
+ EnumTest2[EnumTest2.PI] = "PI";
+@@ -39,8 +41,9 @@
+ const ComponentIndex = {
+     Scheme: 1,
+     UserInfo: 2,
+     Domain: 0,
++    // Be sure to exercise the code with a 0 enum value.
+     UserInfo2: 2,
+ };
+ ComponentIndex[ComponentIndex.Scheme] = "Scheme";
+ ComponentIndex[ComponentIndex.UserInfo] = "UserInfo";
+@@ -50,9 +53,9 @@
  const ConstEnum = {
      EMITTED_ENUM_VALUE: 0,
  };

--- a/test_files/enum/enum.tsickle.ts
+++ b/test_files/enum/enum.tsickle.ts
@@ -10,10 +10,8 @@ Warning at test_files/enum/enum.ts:15:22: Declared property XYZ accessed with qu
 // Line with a missing semicolon should not break the following enum.
 const /** @type {!Array<?>} */ EnumTestMissingSemi = []
 /** @enum {number} */
-const EnumTest1: any = {
-XYZ: 0,
-PI: 3.14159,
-};
+const EnumTest1: DontTypeCheckMe = {
+XYZ: 0, PI: 3.14159,};
 EnumTest1[EnumTest1.XYZ] = "XYZ";
 EnumTest1[EnumTest1.PI] = "PI";
 
@@ -37,10 +35,8 @@ let /** @type {?} */ enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
 // Verify that unions of enum members and other values are handled correctly.
 let /** @type {(boolean|EnumTest1)} */ enumUnionType: EnumTest1|boolean = EnumTest1.XYZ;
 /** @enum {number} */
-const EnumTest2: any = {
-XYZ: 0,
-PI: 3.14159,
-};
+const EnumTest2: DontTypeCheckMe = {
+XYZ: 0, PI: 3.14159,};
 export {EnumTest2};
 EnumTest2[EnumTest2.XYZ] = "XYZ";
 EnumTest2[EnumTest2.PI] = "PI";
@@ -48,21 +44,21 @@ EnumTest2[EnumTest2.PI] = "PI";
 
 let /** @type {EnumTest2} */ variableUsingExportedEnum: EnumTest2;
 /** @enum {number} */
-const ComponentIndex: any = {
-Scheme: 1,
-UserInfo: 2,
-Domain: 0,
-UserInfo2: 2,
-};
+const ComponentIndex: DontTypeCheckMe = {
+
+  Scheme: 1,
+  UserInfo: 2,
+  Domain: 0,  // Be sure to exercise the code with a 0 enum value.
+  UserInfo2: 2,};
 ComponentIndex[ComponentIndex.Scheme] = "Scheme";
 ComponentIndex[ComponentIndex.UserInfo] = "UserInfo";
 ComponentIndex[ComponentIndex.Domain] = "Domain";
 ComponentIndex[ComponentIndex.UserInfo2] = "UserInfo2";
 
 /** @enum {number} */
-const ConstEnum: any = {
-EMITTED_ENUM_VALUE: 0,
-};
+const ConstEnum: DontTypeCheckMe = {
+
+  EMITTED_ENUM_VALUE: 0,};
 export {ConstEnum};
 
 let /** @type {ConstEnum} */ constEnumValue = ConstEnum.EMITTED_ENUM_VALUE;
@@ -86,10 +82,10 @@ export interface InterfaceUsingConstEnum {
   field2: ConstEnum.EMITTED_ENUM_VALUE;
 }
 /** @enum {number} */
-const EnumWithNonConstValues: any = {
-Scheme:  (x => x + 1)(3),
-UserInfoRenamed: 2,
-};
+const EnumWithNonConstValues: DontTypeCheckMe = {
+
+  Scheme:  (x => x + 1)(3),
+  UserInfoRenamed: 2,};
 EnumWithNonConstValues[EnumWithNonConstValues.Scheme] = "Scheme";
 EnumWithNonConstValues[EnumWithNonConstValues.UserInfoRenamed] = "UserInfoRenamed";
 

--- a/test_files/enum_value_literal_type/enum_value_literal_type.tsickle.ts
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.tsickle.ts
@@ -5,9 +5,9 @@
 
 
 /** @enum {number} */
-const ExportedEnum: any = {
-VALUE: 0,
-};
+const ExportedEnum: DontTypeCheckMe = {
+
+  VALUE: 0,};
 export {ExportedEnum};
 ExportedEnum[ExportedEnum.VALUE] = "VALUE";
 

--- a/test_files/export/export_helper_2.tsickle.ts
+++ b/test_files/export/export_helper_2.tsickle.ts
@@ -26,9 +26,9 @@ Interface.prototype.x;
 
 export interface Interface { x: string; }
 /** @enum {number} */
-const ConstEnum: any = {
-AValue: 1,
-};
+const ConstEnum: DontTypeCheckMe = {
+
+  AValue: 1,};
 export {ConstEnum};
 
 


### PR DESCRIPTION
- simplify value emitting. Collecting the values up front is actually
  not needed.
- make sure to retain comments on enum values, they might carry semantic
  importance (e.g. `/** @export */`).