### PR TITLE
Generate source maps with 0-indexed columns.

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -135,8 +135,9 @@ export class DefaultSourceMapper implements SourceMapper {
 
   constructor(private fileName: string) {
     this.sourceMap.addMapping({
-      original: {line: 1, column: 1},
-      generated: {line: 1, column: 1},
+      // tsc's source maps use 1-indexed lines, 0-indexed columns
+      original: {line: 1, column: 0},
+      generated: {line: 1, column: 0},
       source: this.fileName,
     });
   }
@@ -145,8 +146,9 @@ export class DefaultSourceMapper implements SourceMapper {
       void {
     if (length > 0) {
       this.sourceMap.addMapping({
-        original: {line: original.line + 1, column: original.column + 1},
-        generated: {line: generated.line + 1, column: generated.column + 1},
+        // tsc's source maps use 1-indexed lines, 0-indexed columns
+        original: {line: original.line + 1, column: original.column},
+        generated: {line: generated.line + 1, column: generated.column},
         source: this.fileName,
       });
     }

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -310,6 +310,30 @@ function createTests(useTransformer: boolean) {
           .to.equal('input2.ts', 'input file name');
     }
   });
+
+  it('maps at the start of lines correctly', () => {
+    const sources = new Map([[
+      'input.ts', `let x : number = 2;
+      x + 1;`
+    ]]);
+
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const {compiledJS, sourceMap} = compile(sources, {useTransformer});
+
+    {
+      const {line, column} = getLineAndColumn(compiledJS, 'var /** @type {?} */ x');
+      expect(sourceMap.originalPositionFor({line, column}).line)
+          .to.equal(1, 'variable declaration line');
+      expect(sourceMap.originalPositionFor({line, column}).source)
+          .to.equal('input.ts', 'input file name');
+    }
+    {
+      const {line, column} = getLineAndColumn(compiledJS, 'x + 1');
+      expect(sourceMap.originalPositionFor({line, column}).line).to.equal(2, 'addition line');
+      expect(sourceMap.originalPositionFor({line, column}).source)
+          .to.equal('input.ts', 'input file name');
+    }
+  });
 }
 
 function decoratorDownlevelAndAddInlineSourceMaps(sources: Map<string, string>):


### PR DESCRIPTION
Typescript produces source maps with 1-indexed lines, and 0-indexed columns.  We previously produced source maps with 1-indexed columns. This produced errors most noticable at the beginnings of lines - the composed source maps would have a one character wide mapping into the tsickle generated intermediate file.  The rest of the line would have correct source mappings, so all our source map tests which look for tokens that aren't at the beginnings of lines didn't catch this.