### PR TITLE
Fix compilation when generating .d.ts.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -196,8 +196,8 @@ export class DecoratorClassVisitor {
     return false;
   }
 
-  foundDecorators() {
-    return this.decorators || this.ctorParameters || this.propDecorators;
+  foundDecorators(): boolean {
+    return !!(this.decorators || this.ctorParameters || this.propDecorators);
   }
 
   /**


### PR DESCRIPTION
Without the explicit conversion to boolean, this actually returns the unexported type ConstructorParameter, which makes compilation fail when generating .d.ts files.