### PR TITLE
Emit just `?` for templatized unhandled types.

### DIFF
--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -432,6 +432,9 @@ export class TypeTranslator {
             `reference loop in ${typeToDebugString(referenceType)} ${referenceType.flags}`);
       }
       typeStr += this.translate(referenceType.target);
+      // Translate can return '?' for a number of situations, e.g. type/value conflicts.
+      // `?<?>` is illegal syntax in Closure Compiler, so just return `?` here.
+      if (typeStr === '?') return '?';
       if (referenceType.typeArguments) {
         const params = referenceType.typeArguments.map(t => this.translate(t));
         typeStr += `<${params.join(', ')}>`;

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -33,6 +33,7 @@ let /** @type {!tsickle_forward_declare_2.default} */ useDefaultClassAsType;
 // NeverTyped should be {?}, even in typed mode.
 let /** @type {?} */ useNeverTyped;
 let /** @type {(string|?)} */ useNeverTyped2;
+let /** @type {?} */ useNeverTypedTemplated;
 /**
  * Note: no implements JSDoc clause because the type is blacklisted.
  */
@@ -41,4 +42,13 @@ class ImplementsNeverTyped {
 function ImplementsNeverTyped_tsickle_Closure_declarations() {
     /** @type {number} */
     ImplementsNeverTyped.prototype.foo;
+}
+/**
+ * @template T
+ */
+class ImplementsNeverTypedTemplated {
+}
+function ImplementsNeverTypedTemplated_tsickle_Closure_declarations() {
+    /** @type {T} */
+    ImplementsNeverTypedTemplated.prototype.foo;
 }

--- a/test_files/jsdoc_types/jsdoc_types.ts
+++ b/test_files/jsdoc_types/jsdoc_types.ts
@@ -6,7 +6,7 @@
 import * as module1 from './module1';
 import {ClassOne, value, ClassOne as RenamedClassOne, ClassTwo as RenamedClassTwo, Interface, ClassWithParams} from './module2';
 import DefaultClass from './default';
-import {NeverTyped} from './nevertyped';
+import {NeverTyped, NeverTypedTemplated} from './nevertyped';
 
 // Check that imported types get the proper names in JSDoc.
 let useNamespacedClass = new module1.Class();
@@ -31,7 +31,11 @@ let useDefaultClassAsType: DefaultClass;
 // NeverTyped should be {?}, even in typed mode.
 let useNeverTyped: NeverTyped;
 let useNeverTyped2: string|NeverTyped;
+let useNeverTypedTemplated: NeverTypedTemplated<string>;
 /** Note: no implements JSDoc clause because the type is blacklisted. */
 class ImplementsNeverTyped implements NeverTyped {
   foo: number;
+}
+class ImplementsNeverTypedTemplated<T> implements NeverTypedTemplated<T> {
+  foo: T;
 }

--- a/test_files/jsdoc_types/jsdoc_types.tsickle.ts
+++ b/test_files/jsdoc_types/jsdoc_types.tsickle.ts
@@ -13,7 +13,7 @@ import {ClassOne, value, ClassOne as RenamedClassOne, ClassTwo as RenamedClassTw
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module2");
 import DefaultClass from './default';
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.default");
-import {NeverTyped} from './nevertyped';
+import {NeverTyped, NeverTypedTemplated} from './nevertyped';
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
 goog.require("test_files.jsdoc_types.nevertyped"); // force type-only module to be loaded
 
@@ -40,6 +40,7 @@ let /** @type {!tsickle_forward_declare_2.default} */ useDefaultClassAsType: Def
 // NeverTyped should be {?}, even in typed mode.
 let /** @type {?} */ useNeverTyped: NeverTyped;
 let /** @type {(string|?)} */ useNeverTyped2: string|NeverTyped;
+let /** @type {?} */ useNeverTypedTemplated: NeverTypedTemplated<string>;
 /**
  * Note: no implements JSDoc clause because the type is blacklisted.
  */
@@ -50,5 +51,17 @@ class ImplementsNeverTyped implements NeverTyped {
 function ImplementsNeverTyped_tsickle_Closure_declarations() {
 /** @type {number} */
 ImplementsNeverTyped.prototype.foo;
+}
+
+/**
+ * @template T
+ */
+class ImplementsNeverTypedTemplated<T> implements NeverTypedTemplated<T> {
+  foo: T;
+}
+
+function ImplementsNeverTypedTemplated_tsickle_Closure_declarations() {
+/** @type {T} */
+ImplementsNeverTypedTemplated.prototype.foo;
 }
 

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -12,3 +12,13 @@ function NeverTyped_tsickle_Closure_declarations() {
     /** @type {number} */
     NeverTyped.prototype.foo;
 }
+/**
+ * @record
+ * @template T
+ */
+function NeverTypedTemplated() { }
+exports.NeverTypedTemplated = NeverTypedTemplated;
+function NeverTypedTemplated_tsickle_Closure_declarations() {
+    /** @type {T} */
+    NeverTypedTemplated.prototype.foo;
+}

--- a/test_files/jsdoc_types/nevertyped.ts
+++ b/test_files/jsdoc_types/nevertyped.ts
@@ -2,3 +2,4 @@
  * suite runner so that its types are always {?}.*/
 
 export interface NeverTyped { foo: number; }
+export interface NeverTypedTemplated<T> { foo: T; }

--- a/test_files/jsdoc_types/nevertyped.tsickle.ts
+++ b/test_files/jsdoc_types/nevertyped.tsickle.ts
@@ -18,3 +18,16 @@ NeverTyped.prototype.foo;
  * suite runner so that its types are always {?}.*/
 
 export interface NeverTyped { foo: number; }
+/**
+ * @record
+ * @template T
+ */
+export function NeverTypedTemplated() {}
+
+
+function NeverTypedTemplated_tsickle_Closure_declarations() {
+/** @type {T} */
+NeverTypedTemplated.prototype.foo;
+}
+
+export interface NeverTypedTemplated<T> { foo: T; }

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -4,6 +4,7 @@ goog.module('test_files.type_and_value.module');var module = module || {id: 'tes
  */
 
 exports.TypeAndValue = 3;
+exports.TemplatizedTypeAndValue = 1;
 class Class {
 }
 exports.Class = Class;

--- a/test_files/type_and_value/module.ts
+++ b/test_files/type_and_value/module.ts
@@ -3,4 +3,7 @@
 export interface TypeAndValue { z: number }
 export var TypeAndValue = 3;
 
+export interface TemplatizedTypeAndValue<T> {z: T}
+export var TemplatizedTypeAndValue = 1;
+
 export class Class { z: number }

--- a/test_files/type_and_value/module.tsickle.ts
+++ b/test_files/type_and_value/module.tsickle.ts
@@ -7,9 +7,13 @@
 // but disallowed in Closure.
 export interface TypeAndValue { z: number }
 export var /** @type {number} */ TypeAndValue = 3;
+
+export interface TemplatizedTypeAndValue<T> {z: T}
+export var /** @type {number} */ TemplatizedTypeAndValue = 1;
 export class Class { z: number }
 
 function Class_tsickle_Closure_declarations() {
 /** @type {number} */
 Class.prototype.z;
 }
+

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -15,3 +15,5 @@ let /** @type {!conflict.Class} */ useUserClassAsType;
 let /** @type {number} */ useAsValue = conflict.TypeAndValue;
 // Note: because of the conflict, we currently just use the type {?} here.
 let /** @type {?} */ useAsType;
+// Use a templatized user-defined interface/value pair as a type.
+let /** @type {?} */ useAsTypeTemplatized;

--- a/test_files/type_and_value/type_and_value.ts
+++ b/test_files/type_and_value/type_and_value.ts
@@ -14,3 +14,6 @@ let useUserClassAsType: conflict.Class;
 let useAsValue = conflict.TypeAndValue;
 // Note: because of the conflict, we currently just use the type {?} here.
 let useAsType: conflict.TypeAndValue;
+
+// Use a templatized user-defined interface/value pair as a type.
+let useAsTypeTemplatized: conflict.TemplatizedTypeAndValue<string>;

--- a/test_files/type_and_value/type_and_value.tsickle.ts
+++ b/test_files/type_and_value/type_and_value.tsickle.ts
@@ -1,5 +1,6 @@
 Warning at test_files/type_and_value/type_and_value.ts:10:5: unhandled anonymous type
 Warning at test_files/type_and_value/type_and_value.ts:16:5: type/symbol conflict for TypeAndValue, using {?} for now
+Warning at test_files/type_and_value/type_and_value.ts:19:5: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 ====
 /**
  * @fileoverview added by tsickle
@@ -22,3 +23,6 @@ let /** @type {!conflict.Class} */ useUserClassAsType: conflict.Class;
 let /** @type {number} */ useAsValue = conflict.TypeAndValue;
 // Note: because of the conflict, we currently just use the type {?} here.
 let /** @type {?} */ useAsType: conflict.TypeAndValue;
+
+// Use a templatized user-defined interface/value pair as a type.
+let /** @type {?} */ useAsTypeTemplatized: conflict.TemplatizedTypeAndValue<string>;


### PR DESCRIPTION
tsickle needs to emit `?` for types in several situations. If such a
type is templatized, e.g. `T<U>`, tsickle would previously translate `T`
to `?`, and then emit `?<U>`, which is illegal syntax in Closure
Compiler.

This change avoids the problem by just returning `?` directly in such
situations.

This also adds a test for blacklisted parameterized types which I
originally suspected to be the trigger. It turns out the problem was
caused by type/value conflicts, but the test coverage still seems
useful, so I'm leaving these in.