### PR TITLE
use a glob in tsconfig for file matching

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,24 +14,8 @@
     "noImplicitReturns": true,
     "strictNullChecks": true
   },
-  "files": [
-    "src/cli_support.ts",
-    "src/decorators.ts",
-    "src/decorator-annotator.ts",
-    "src/es5processor.ts",
-    "src/jsdoc.ts",
-    "src/main.ts",
-    "src/rewriter.ts",
-    "src/tsickle.ts",
-    "src/type-translator.ts",
-    "src/util.ts",
-    "test/decorator-annotator_test.ts",
-    "test/e2e_test.ts",
-    "test/es5processor_test.ts",
-    "test/jsdoc_test.ts",
-    "test/source_map_test.ts",
-    "test/test_support.ts",
-    "test/tsickle_test.ts",
-    "test/type-translator_test.ts"
+  "include": [
+    "src/*.ts",
+    "test/*.ts"
   ]
 }


### PR DESCRIPTION
A recent rename meant that tsconfig wasn't covering some test files.
Use a glob to prevent this from happening again.