### PR TITLE
update to typescript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "source-map-support": "^0.4.2"
   },
   "peerDependencies": {
-    "typescript": "2.3.4"
+    "typescript": "2.4.2"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",
@@ -46,7 +46,7 @@
     "protobufjs": "5.0.0",
     "temp": "^0.8.1",
     "tslint": "^5.4.2",
-    "typescript": "~2.3.4"
+    "typescript": "~2.4.2"
   },
   "scripts": {
     "prepublish": "gulp compile",

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -132,10 +132,10 @@ testFn('golden tests with transformer', () => {
         untyped: /\.untyped\b/.test(test.name),
         logWarning: (diag: ts.Diagnostic) => {
           allDiagnostics.push(diag);
-          let diags = diagnosticsByFile.get(diag.file.fileName);
+          let diags = diagnosticsByFile.get(diag.file!.fileName);
           if (!diags) {
             diags = [];
-            diagnosticsByFile.set(diag.file.fileName, diags);
+            diagnosticsByFile.set(diag.file!.fileName, diags);
           }
           diags.push(diag);
         },

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -71,3 +71,13 @@ const EnumWithNonConstValues = {
 };
 EnumWithNonConstValues[EnumWithNonConstValues.Scheme] = "Scheme";
 EnumWithNonConstValues[EnumWithNonConstValues.UserInfoRenamed] = "UserInfoRenamed";
+/** @enum {string} */
+const StringEnum = {
+    STR: 'abc',
+    OTHER_STR: 'xyz',
+};
+/** @enum {number|string} */
+const MixedEnum = {
+    STR: 'abc',
+    NUM: 3,
+};

--- a/test_files/enum/enum.ts
+++ b/test_files/enum/enum.ts
@@ -55,3 +55,13 @@ enum EnumWithNonConstValues {
   Scheme = (x => x + 1)(3),
   UserInfoRenamed = ComponentIndex.UserInfo,
 }
+
+enum StringEnum {
+  STR = 'abc',
+  OTHER_STR = 'xyz',
+}
+
+enum MixedEnum {
+  STR = 'abc',
+  NUM = 3,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,9 +2053,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@~2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
+typescript@~2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
- ts.Declaration was split to not have a name field, and there's
  now ts.NamedDeclaration for those with names.  Adjust all users.
- Drop the unused 'filterTypesForExport' option.
- Handle some more maybe-null values (e.g. 'file' in ts.Diagnostics).
- Change enum emit to handle string enums.  Do one pass over the enum
  to figure out whether it's a number/string/other enum.
- Adjust type translation of enums values because their representation
  changed.  This has the consequence of "inlining" all const enums
  (users of them now look like plain 'number' or 'string') but that
  is the semantics of a const enum so I think it's harmless.