### PR TITLE
adjust enum test to be closer to reality

### DIFF
--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -6,7 +6,9 @@ goog.module('test_files.enum_value_literal_type.enum_value_literal_type');var mo
 /** @enum {number} */
 const ExportedEnum = {
     VALUE: 0,
+    OTHERVALUE: 1,
 };
 exports.ExportedEnum = ExportedEnum;
 ExportedEnum[ExportedEnum.VALUE] = "VALUE";
+ExportedEnum[ExportedEnum.OTHERVALUE] = "OTHERVALUE";
 exports.x = ExportedEnum.VALUE;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.ts
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.ts
@@ -1,4 +1,10 @@
+// Note: if you only have one value in the enum, then the type of "x" below
+// is just ExportedEnum, regardless of the annotation.  This might be a bug
+// in TypeScript but this test is just trying to verify the behavior of
+// exporting an enum's value, not that.
+
 export enum ExportedEnum {
   VALUE = 0,
+  OTHERVALUE,
 }
 export const x: ExportedEnum.VALUE = ExportedEnum.VALUE;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.tsickle.ts
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.tsickle.ts
@@ -6,8 +6,10 @@
 
 /** @enum {number} */
 const ExportedEnum: DontTypeCheckMe = {
-  VALUE: 0,};
+  VALUE: 0,
+  OTHERVALUE: 1,};
 export {ExportedEnum};
 ExportedEnum[ExportedEnum.VALUE] = "VALUE";
+ExportedEnum[ExportedEnum.OTHERVALUE] = "OTHERVALUE";
 
 export const /** @type {ExportedEnum} */ x: ExportedEnum.VALUE = ExportedEnum.VALUE;


### PR DESCRIPTION
With a single-element enum, in code like:
  let x: MyEnum.VALUE = MyEnum.VALUE;
the type of x is just 'MyEnum'.  This might be a bug in TS
but it's certainly the case that this test isn't trying to
exercise that corner of the language.  Avoid it.

This is more preliminary work for TypeScript 2.4.