### PR TITLE
adjust enum test to be closer to reality

### DIFF
--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -45,6 +45,7 @@ ComponentIndex[ComponentIndex.UserInfo2] = "UserInfo2";
 /** @enum {number} */
 const ConstEnum = {
     EMITTED_ENUM_VALUE: 0,
+    EMITTED_ENUM_VALUE_2: 1,
 };
 exports.ConstEnum = ConstEnum;
 let /** @type {ConstEnum} */ constEnumValue = ConstEnum.EMITTED_ENUM_VALUE;

--- a/test_files/enum/enum.js.transform.patch
+++ b/test_files/enum/enum.js.transform.patch
@@ -25,9 +25,9 @@ Index: ./test_files/enum/enum.js
  };
  ComponentIndex[ComponentIndex.Scheme] = "Scheme";
  ComponentIndex[ComponentIndex.UserInfo] = "UserInfo";
-@@ -46,9 +47,9 @@
- const ConstEnum = {
+@@ -47,9 +48,9 @@
      EMITTED_ENUM_VALUE: 0,
+     EMITTED_ENUM_VALUE_2: 1,
  };
  exports.ConstEnum = ConstEnum;
 -let /** @type {ConstEnum} */ constEnumValue = ConstEnum.EMITTED_ENUM_VALUE;

--- a/test_files/enum/enum.ts
+++ b/test_files/enum/enum.ts
@@ -33,7 +33,8 @@ enum ComponentIndex {
 
 // const enums are emitted so that Closure code can refer to their types and values.
 export const enum ConstEnum {
-  EMITTED_ENUM_VALUE = 0,
+  EMITTED_ENUM_VALUE,
+  EMITTED_ENUM_VALUE_2,
 }
 let constEnumValue = ConstEnum.EMITTED_ENUM_VALUE;
 export interface InterfaceUsingConstEnum {

--- a/test_files/enum/enum.tsickle.ts
+++ b/test_files/enum/enum.tsickle.ts
@@ -54,7 +54,8 @@ ComponentIndex[ComponentIndex.UserInfo2] = "UserInfo2";
 
 /** @enum {number} */
 const ConstEnum: DontTypeCheckMe = {
-  EMITTED_ENUM_VALUE: 0,};
+  EMITTED_ENUM_VALUE: 0,
+  EMITTED_ENUM_VALUE_2: 1,};
 export {ConstEnum};
 
 let /** @type {ConstEnum} */ constEnumValue = ConstEnum.EMITTED_ENUM_VALUE;


### PR DESCRIPTION
With a single-element enum, in code like:
  let x: MyEnum.VALUE = MyEnum.VALUE;
the type of x is just 'MyEnum'.  This might be a bug in TS
but it's certainly the case that this test isn't trying to
exercise that corner of the language.  Avoid it.

This is more preliminary work for TypeScript 2.4.
(Same as 170bb99, but in another file.)