### PR TITLE
Provide a source mapping for every emit.

### DIFF
--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -120,7 +120,7 @@ export interface SourcePosition {
 
 export interface SourceMapper {
   addMapping(
-      originalNode: ts.Node, original: SourcePosition, generated: SourcePosition,
+      originalNode: ts.Node|undefined, original: SourcePosition, generated: SourcePosition,
       length: number): void;
 }
 
@@ -133,14 +133,7 @@ export class DefaultSourceMapper implements SourceMapper {
   /** The source map that's generated while rewriting this file. */
   public sourceMap = new SourceMapGenerator();
 
-  constructor(private fileName: string) {
-    this.sourceMap.addMapping({
-      // tsc's source maps use 1-indexed lines, 0-indexed columns
-      original: {line: 1, column: 0},
-      generated: {line: 1, column: 0},
-      source: this.fileName,
-    });
-  }
+  constructor(private fileName: string) {}
 
   addMapping(node: ts.Node, original: SourcePosition, generated: SourcePosition, length: number):
       void {

--- a/src/transformer_sourcemap.ts
+++ b/src/transformer_sourcemap.ts
@@ -103,7 +103,11 @@ class NodeSourceMapper implements SourceMapper {
   }
 
   addMapping(
-      originalNode: ts.Node, original: SourcePosition, generated: SourcePosition, length: number) {
+      originalNode: ts.Node|undefined, original: SourcePosition, generated: SourcePosition,
+      length: number) {
+    if (!originalNode) {
+      return;
+    }
     let originalStartPos = original.position;
     let genStartPos = generated.position;
     if (originalStartPos >= originalNode.getFullStart() &&


### PR DESCRIPTION
When tsickle rewrites a source file, it produces text 2 ways.  First it copies text from an AST node to the output.  Second, it produces its own text and outputs it.  Previously, we only provided source mappings for the first case, since we had the node to map back to.  This PR changes rewriter.ts to keep track of the current node on a stack as it traverses the AST and uses that node to provide source mappings for the second kind of emit.  In certain cases the classes that extend rewriter.ts don't use its node traversal mechanisms to visit the children of certain node types it transforms - in those cases the node stack is manually updated.

This PR also adds a bunch of source map tests, roughly one for each kind of AST node that we transform.  In writing those tests 2 issues arrose:

1.  Typescript doesn't produce good source maps for multiline/jsdoc comments, so we can't currently provide source maps for function signature annotations.
2.  The transformer system doesn't like having custom emits mapped back to original nodes - I got a bunch of errors initially and I was forced to preserve the existing source mapping behavior for the transformer system.  I'll have to work with Tobias on this.