### PR TITLE
Update to the latest typings for source-map.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/mkdirp": "^0.3.28",
     "@types/mocha": "^2.2.31",
     "@types/node": "^6.0.38",
-    "@types/source-map": "^0.1.27",
+    "@types/source-map": "^0.5.1",
     "@types/source-map-support": "^0.2.27",
     "chai": "^3.5.0",
     "clang-format": "^1.0.51",

--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RawSourceMap, SourceMapConsumer, SourceMapGenerator} from 'source-map';
+import {BasicSourceMapConsumer, RawSourceMap, SourceMapConsumer, SourceMapGenerator} from 'source-map';
 import * as ts from 'typescript';
 
 /**
@@ -97,16 +97,16 @@ export function sourceMapGeneratorToConsumer(
   return new SourceMapConsumer(rawSourceMap);
 }
 
-export function sourceMapTextToConsumer(sourceMapText: string): SourceMapConsumer {
-  // tslint:disable-next-line:no-any constructor actually supports text.
-  const sourceMapJson: any = sourceMapText;
-  return new SourceMapConsumer(sourceMapJson);
+export function sourceMapTextToConsumer(sourceMapText: string): BasicSourceMapConsumer {
+  // the SourceMapConsumer constructor returns a BasicSourceMapConsumer or an
+  // IndexedSourceMapConsumer depending on if you pass in a RawSourceMap or a
+  // RawIndexMap or the string json of either.  In this case we're passing in
+  // the string for a RawSourceMap, so we always get a BasicSourceMapConsumer
+  return new SourceMapConsumer(sourceMapText) as BasicSourceMapConsumer;
 }
 
 export function sourceMapTextToGenerator(sourceMapText: string): SourceMapGenerator {
-  // tslint:disable-next-line:no-any constructor actually supports text.
-  const sourceMapJson: any = sourceMapText;
-  return SourceMapGenerator.fromSourceMap(sourceMapTextToConsumer(sourceMapJson));
+  return SourceMapGenerator.fromSourceMap(sourceMapTextToConsumer(sourceMapText));
 }
 
 export interface SourcePosition {

--- a/src/tsickle_compiler_host.ts
+++ b/src/tsickle_compiler_host.ts
@@ -226,9 +226,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
     }
 
     if (this.tsickleSourceMaps.size > 0) {
-      // TODO(lucassloan): remove when the .d.ts has the correct types
-      // tslint:disable-next-line:no-any
-      for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
+      for (const sourceFileName of tscSourceMapConsumer.sources) {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const tsickleSourceMapGenerator = this.tsickleSourceMaps.get(sourceMapKey)!;
         const tsickleSourceMapConsumer = sourceMapUtils.sourceMapGeneratorToConsumer(
@@ -241,9 +239,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       }
     }
     if (this.decoratorDownlevelSourceMaps.size > 0) {
-      // TODO(lucassloan): remove when the .d.ts has the correct types
-      // tslint:disable-next-line:no-any
-      for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
+      for (const sourceFileName of tscSourceMapConsumer.sources) {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const decoratorDownlevelSourceMapGenerator =
             this.decoratorDownlevelSourceMaps.get(sourceMapKey)!;
@@ -257,9 +253,7 @@ export class TsickleCompilerHost implements ts.CompilerHost {
       }
     }
     if (this.preexistingSourceMaps.size > 0) {
-      // TODO(lucassloan): remove when the .d.ts has the correct types
-      // tslint:disable-next-line:no-any
-      for (const sourceFileName of (tscSourceMapConsumer as any).sources) {
+      for (const sourceFileName of tscSourceMapConsumer.sources) {
         const sourceMapKey = this.getSourceMapKeyForPathAndName(filePath, sourceFileName);
         const preexistingSourceMapGenerator = this.preexistingSourceMaps.get(sourceMapKey);
         if (preexistingSourceMapGenerator) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,9 +66,9 @@
   dependencies:
     "@types/node" "*"
 
-"@types/source-map@^0.1.27":
-  version "0.1.28"
-  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.1.28.tgz#ee1fd82cef382cc269be4910f941dd26ea96a974"
+"@types/source-map@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.1.tgz#7e74db5d06ab373a712356eebfaea2fad0ea2367"
 
 "@types/through2@*":
   version "2.0.33"


### PR DESCRIPTION
This enables removing several casts to any, since the latest typings include the constructors and fields we need to use.