### PR TITLE
	Don't publish BUILD/WORKSPACE files in the distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@
 .vscode
 test
 test_files
+BUILD
+WORKSPACE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsickle",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "Transpile TypeScript code to JavaScript with Closure annotations.",
   "main": "built/src/tsickle.js",
   "typings": "built/definitions/tsickle.d.ts",


### PR DESCRIPTION

If any users want to use Bazel to build from head, they need to check out our sources, not use the published distro.