### PR TITLE
Do not emit fileoverview comments twice.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
       "args": [
         "--colors",
         "--timeout=0",
-        "./built/test/tsickle_test.js"
+        "./built/test/golden_tsickle_test.js"
       ],
       "cwd": "${workspaceRoot}",
       "runtimeArgs": [
@@ -38,7 +38,7 @@
       ],
       "env": {
         "NODE_ENV": "development",
-        "TEST_FILTER": "^class$"
+        "TEST_FILTER": "^file_comment$"
       },
       "console": "internalConsole",
       "sourceMaps": true,

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -75,11 +75,11 @@ function compareAgainstGolden(output: string|null, path: string) {
 const testFn = TEST_FILTER ? describe.only : describe;
 
 testFn('golden tests with TsickleCompilerHost', () => {
-  testFn('with separate passes', () => {
-    runGoldenTests(true);
-  });
   testFn('with one pass', () => {
     runGoldenTests(false);
+  });
+  testFn('with separate passes', () => {
+    runGoldenTests(true);
   });
 });
 

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -1,0 +1,8 @@
+goog.module('test_files.file_comment.comment_before_var');var module = module || {id: 'test_files/file_comment/comment_before_var.js'};/**
+ * @fileoverview This comment must not be emitted twice.
+ * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
+ * @modName {foobar}
+ * @suppress {checkTypes} checked by tsc
+ */
+
+exports.y = 3;

--- a/test_files/file_comment/comment_before_var.ts
+++ b/test_files/file_comment/comment_before_var.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview This comment must not be emitted twice.
+ * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
+ * @modName {foobar}
+ */
+
+export const y = 3;

--- a/test_files/file_comment/comment_before_var.tsickle.ts
+++ b/test_files/file_comment/comment_before_var.tsickle.ts
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview This comment must not be emitted twice.
+ * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
+ * @modName {foobar}
+ * @suppress {checkTypes} checked by tsc
+ */
+
+
+export const /** @type {number} */ y = 3;

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,0 +1,8 @@
+goog.module('test_files.file_comment.fileoverview_and_jsdoc');var module = module || {id: 'test_files/file_comment/fileoverview_and_jsdoc.js'};/**
+ * @fileoverview A file.
+ * @suppress {checkTypes} checked by tsc
+ */
+/**
+ * @export
+ */
+const /** @type {number} */ aVariable = 1;

--- a/test_files/file_comment/fileoverview_and_jsdoc.ts
+++ b/test_files/file_comment/fileoverview_and_jsdoc.ts
@@ -1,0 +1,3 @@
+/** @fileoverview A file. */
+/** @export */
+const aVariable = 1;

--- a/test_files/file_comment/fileoverview_and_jsdoc.tsickle.ts
+++ b/test_files/file_comment/fileoverview_and_jsdoc.tsickle.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview A file.
+ * @suppress {checkTypes} checked by tsc
+ */
+
+
+
+/**
+ * @export
+ */
+const /** @type {number} */ aVariable = 1;

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -15,7 +15,6 @@ goog.module('test_files.file_comment.multiple_comments');var module = module || 
  */
 
 /**
- * Here's another trailing comment
  * @return {?}
  */
 function f() {

--- a/test_files/file_comment/multiple_comments.tsickle.ts
+++ b/test_files/file_comment/multiple_comments.tsickle.ts
@@ -17,7 +17,6 @@
 
 
 /**
- * Here's another trailing comment
  * @return {?}
  */
 export function f() {


### PR DESCRIPTION
@fileoverview comments would previously be parsed as JSDoc by various
declarations (variables, functions, etc). This change prevents them from
being picked up as JSDoc.