### PR TITLE
Speed up the e2e test suite.

### DIFF
--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -3,6 +3,6 @@ goog.module('test_files.file_comment.fileoverview_and_jsdoc');var module = modul
  * @suppress {checkTypes} checked by tsc
  */
 /**
- * @export
+ * @noalias
  */
 const /** @type {number} */ aVariable = 1;

--- a/test_files/file_comment/fileoverview_and_jsdoc.ts
+++ b/test_files/file_comment/fileoverview_and_jsdoc.ts
@@ -1,3 +1,5 @@
 /** @fileoverview A file. */
-/** @export */
+/** 
+ * @noalias
+ */
 const aVariable = 1;

--- a/test_files/file_comment/fileoverview_and_jsdoc.tsickle.ts
+++ b/test_files/file_comment/fileoverview_and_jsdoc.tsickle.ts
@@ -6,6 +6,6 @@
 
 
 /**
- * @export
+ * @noalias
  */
 const /** @type {number} */ aVariable = 1;


### PR DESCRIPTION
Improves the performance of the e2e test suite by 10x (40s to 5s on my laptop) by caching typescript's lib.d.ts and setting the types option to the empty list to ensure that typings files in node_modules aren't read.  Improves readability/understandability by removing the old compile() method used for source map tests and replacing it with a set of composable functions to generate the desired compiler options and retrieve the desired output files.  Also reduces boilerplate by introducing a function to make assertions about source maps, instead of copying and pasting 7 lines everywhere.