### PR TITLE
Add Readonly{Array,Map,Set} to closure_externs.js.

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -38,3 +38,12 @@ var NodeListOf;
  * @typedef {Array<string>|null}
  */
 var RegExpExecArray;
+
+/** @typedef {!Array} */
+var ReadonlyArray;
+
+/** @typedef {!Map} */
+var ReadonlyMap;
+
+/** @typedef {!Set} */
+var ReadonlySet;

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -8,3 +8,6 @@ let /** @type {!NodeListOf<!HTMLParagraphElement>} */ x = document.getElementsBy
 console.log(x);
 const /** @type {(null|!RegExpExecArray)} */ res = ((/asd/.exec('asd asd')));
 console.log(res);
+let /** @type {!ReadonlyArray<string>} */ a = [''];
+let /** @type {!ReadonlyMap<string, string>} */ m = new Map();
+let /** @type {!ReadonlySet<string>} */ s = new Set();

--- a/test_files/use_closure_externs/use_closure_externs.ts
+++ b/test_files/use_closure_externs/use_closure_externs.ts
@@ -10,3 +10,6 @@ console.log(x);
 
 const res: RegExpExecArray|null = /asd/.exec('asd asd')!;
 console.log(res);
+let a: ReadonlyArray<string> = [''];
+let m: ReadonlyMap<string, string> = new Map();
+let s: ReadonlySet<string> = new Set();

--- a/test_files/use_closure_externs/use_closure_externs.tsickle.ts
+++ b/test_files/use_closure_externs/use_closure_externs.tsickle.ts
@@ -12,3 +12,6 @@ console.log(x);
 
 const /** @type {(null|!RegExpExecArray)} */ res: RegExpExecArray|null = /** @type {!RegExpExecArray} */(( /asd/.exec('asd asd')));
 console.log(res);
+let /** @type {!ReadonlyArray<string>} */ a: ReadonlyArray<string> = [''];
+let /** @type {!ReadonlyMap<string, string>} */ m: ReadonlyMap<string, string> = new Map();
+let /** @type {!ReadonlySet<string>} */ s: ReadonlySet<string> = new Set();


### PR DESCRIPTION
Since closure does not have these concepts, we typedef them to the
non-readonly ones.