### PR TITLE
no need to change moduleId, maybe

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1091,18 +1091,18 @@ class Annotator extends ClosureRewriter {
         throw new Error(
             'option convertIndexImportShorthand requires that annotate be called with a TypeScript host and options.');
       }
-      const resolved = ts.resolveModuleName(moduleId, this.file.fileName, this.tsOpts, this.tsHost);
-      if (resolved && resolved.resolvedModule) {
-        const requestedModule = moduleId.replace(extension, '');
-        const resolvedModule = resolved.resolvedModule.resolvedFileName.replace(extension, '');
-        if (resolvedModule.indexOf('node_modules') === -1 &&
-            requestedModule.substr(requestedModule.lastIndexOf('/')) !==
-                resolvedModule.substr(resolvedModule.lastIndexOf('/'))) {
-          moduleId = './' +
-              path.relative(path.dirname(this.file.fileName), resolvedModule)
-                  .replace(path.sep, '/');
-        }
-      }
+//       const resolved = ts.resolveModuleName(moduleId, this.file.fileName, this.tsOpts, this.tsHost);
+//       if (resolved && resolved.resolvedModule) {
+//         const requestedModule = moduleId.replace(extension, '');
+//         const resolvedModule = resolved.resolvedModule.resolvedFileName.replace(extension, '');
+//         if (resolvedModule.indexOf('node_modules') === -1 &&
+//             requestedModule.substr(requestedModule.lastIndexOf('/')) !==
+//                 resolvedModule.substr(resolvedModule.lastIndexOf('/'))) {
+//           moduleId = './' +
+//               path.relative(path.dirname(this.file.fileName), resolvedModule)
+//                   .replace(path.sep, '/');
+//         }
+//       }
     }
     return moduleId;
   }


### PR DESCRIPTION
want to know why need to change import. 

we have tsconfig paths map already.

my file structure

```
-----------------------------------
src
----@project
--------my-project
------------src
----------------index.ts
----------------my-component.ts
--------other-project
------------src
----------------index.ts
----------------other-component.ts
```

tsconfig
```
    "baseUrl": "./src",
    "paths": {
      "@project/my-project": [
        "@project/my-project/src/index.ts"
      ],
      "@project/my-project/src/*": [
        "@project/my-project/src/*"
      ],
      "@project/other-project": [
        "@project/other-project/src/index.ts"
      ],
      "@project/other-project/src/*": [
        "@project/other-project/src/*"
      ]
    }
```

since typescript can recognize `@project/other-project` as `@project/other-project/src/index` in `my-component.ts`(maybe tsc can compile well owes to `awesome typescript loader`'s TsConfigPathsPlugin)

no need to rename `moduleId` to `moduleId += '/index'` (old version, for now tsickle have changed to [tsickle](https://github.com/angular/tsickle/edit/master/src/tsickle.ts#L1102))