### PR TITLE
Pin to NodeJS version 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "stable"
+  - "6"
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
This is the version used by internal tooling, and a reasonable compromise between recency and stability.