### PR TITLE
Fix bazel build on CircleCI

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,19 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "build_bazel_rules_typescript",
-    remote = "https://github.com/bazelbuild/rules_typescript.git",
-    tag = "0.0.5",
+    name = "build_bazel_rules_nodejs",
+    remote = "https://github.com/bazelbuild/rules_nodejs.git",
+    tag = "0.1.0",
 )
 
-load("@build_bazel_rules_typescript//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 
-node_repositories(package_json = "//:package.json")
+# NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
+# your npm dependencies. You must still run the package manager.
+node_repositories(package_json = ["//:package.json"])
+
+# Include @bazel/typescript in package.json#devDependencies
+local_repository(
+    name = "build_bazel_rules_typescript",
+    path = "node_modules/@bazel/typescript",
+)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "2.4.2"
   },
   "devDependencies": {
+    "@bazel/typescript": "0.1.0",
     "@types/chai": "^3.4.32",
     "@types/diff": "^3.2.0",
     "@types/glob": "^5.0.29",
@@ -43,7 +44,6 @@
     "gulp-util": "^3.0.4",
     "merge2": "^1.0.2",
     "mocha": "^3.2.0",
-    "protobufjs": "5.0.0",
     "temp": "^0.8.1",
     "tslint": "^5.4.2",
     "typescript": "~2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@bazel/typescript@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.1.0.tgz#14a0a74d06e0acf7cf60295963adbcc5d3f41217"
+  dependencies:
+    "@types/node" "7.0.18"
+    protobufjs "5.0.0"
+    tsickle "0.24.x"
+    typescript "2.4.x"
+
 "@types/chai@^3.4.32":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
@@ -55,6 +64,10 @@
 "@types/node@*", "@types/node@^6.0.38":
   version "6.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.45.tgz#c4842a9d653d767831e4ff495b6008cc0d579966"
+
+"@types/node@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
 "@types/node@^7.0.18":
   version "7.0.23"
@@ -2022,6 +2035,15 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
+tsickle@0.24.x:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.24.1.tgz#039343b205bf517a333b0703978892f80a7d848e"
+  dependencies:
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.6"
+    source-map-support "^0.4.2"
+
 tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
@@ -2053,7 +2075,7 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@~2.4.2:
+typescript@2.4.x, typescript@~2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 


### PR DESCRIPTION
Note, it's fishy that `@bazel/typescript` depends on tsickle, and this change also makes the reverse dependency.
You end up with tsickle 0.23 in the node_modules.

I don't think it breaks anything...