### PR TITLE
fix(): find and emit all JSDoc.

### DIFF
--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -1,0 +1,22 @@
+goog.module('test_files.functions.two_jsdoc_blocks');var module = module || {id: 'test_files/functions/two_jsdoc_blocks.js'};/**
+ * @fileoverview This text here matches the     text below in length.
+ * @suppress {checkTypes} checked by tsc
+ */
+
+/**
+ * A comment.
+ * @return {boolean}
+ */
+function functionA() {
+    return true;
+}
+exports.functionA = functionA;
+/**
+ * This comment is just as long as the \@fileoverview
+ * comment    x
+ * @return {boolean}
+ */
+function functionB() {
+    return true;
+}
+exports.functionB = functionB;

--- a/test_files/functions/two_jsdoc_blocks.ts
+++ b/test_files/functions/two_jsdoc_blocks.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview This text here matches the     text below in length.
+ */
+
+
+
+
+/**
+ * A comment.
+ */
+export function functionA(): boolean {
+  return true;
+}
+
+/**
+ * This comment is just as long as the @fileoverview
+ * comment    x
+ */
+export function functionB(): boolean {
+  return true;
+}


### PR DESCRIPTION
Previously, tsickle would silently drop JSDoc that happened to be in documents
where the JSDoc comment was shorter than the trivia at the front of the document
and the offset of the document following the JSDoc comment's length would
start with `\n\n`.