### PR TITLE
Remove unnecessary usages of toArray().

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -13,7 +13,6 @@ import {getDecoratorDeclarations} from './decorators';
 import {getIdentifierText, Rewriter} from './rewriter';
 import {SourceMapper} from './source_map_utils';
 import {TypeTranslator} from './type-translator';
-import {toArray} from './util';
 
 /**
  * ConstructorParameters are gathered from constructors, so that their type information and
@@ -300,7 +299,7 @@ export class DecoratorClassVisitor {
     if (this.propDecorators) {
       this.rewriter.emit(
           `static propDecorators: {[key: string]: ` + decoratorInvocations + `} = {\n`);
-      for (const name of toArray(this.propDecorators.keys())) {
+      for (const name of this.propDecorators.keys()) {
         this.rewriter.emit(`"${name}": [`);
 
         for (const decorator of this.propDecorators.get(name)!) {

--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -11,7 +11,6 @@ import * as ts from 'typescript';
 import {ModulesManifest} from './modules_manifest';
 import {getIdentifierText, Rewriter} from './rewriter';
 import {isDtsFileName} from './tsickle';
-import {toArray} from './util';
 
 export interface Es5ProcessorHost {
   /**
@@ -111,7 +110,7 @@ class ES5Processor extends Rewriter {
     }
     this.writeRange(this.file, pos, this.file.getEnd());
 
-    const referencedModules = toArray(this.moduleVariables.keys());
+    const referencedModules = Array.from(this.moduleVariables.keys());
     // Note: don't sort referencedModules, as the keys are in the same order
     // they occur in the source file.
     const {output} = this.getOutput();

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import * as ts from 'typescript';
 import * as cliSupport from './cli_support';
 import * as tsickle from './tsickle';
 import {ModulesManifest} from './tsickle';
-import {toArray, createSourceReplacingCompilerHost} from './util';
+import {createSourceReplacingCompilerHost} from './util';
 
 /** Tsickle settings passed on the command line. */
 export interface Settings {

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -20,7 +20,6 @@ import {containsInlineSourceMap, extractInlineSourceMap, parseSourceMap, removeI
 import {createTransformerFromSourceMap} from './transformer_sourcemap';
 import {createCustomTransformers} from './transformer_util';
 import * as typeTranslator from './type-translator';
-import {toArray} from './util';
 
 export {convertDecorators} from './decorator-annotator';
 export {FileMap, ModulesManifest} from './modules_manifest';
@@ -1061,7 +1060,7 @@ class Annotator extends ClosureRewriter {
       this.generatedExports.add(name);
       reexports.add(sym);
     }
-    return toArray(reexports.keys()).map(sym => {
+    return Array.from(reexports.keys()).map(sym => {
       return {name: sym.name, sym};
     });
   }

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -8,7 +8,6 @@
 
 import * as path from 'path';
 import * as ts from 'typescript';
-import {toArray} from './util';
 
 /**
  * Determines if fileName refers to a builtin lib.d.ts file.
@@ -532,7 +531,10 @@ export class TypeTranslator {
       return `function(new: (${constructedType})${paramsStr}): ?`;
     }
 
-    for (const field of toArray(type.symbol.members.keys())) {
+    // members is an ES6 map, but the .d.ts defining it defined their own map
+    // type, so typescript doesn't believe that .keys() is iterable
+    // tslint:disable-next-line:no-any
+    for (const field of (type.symbol.members.keys() as any)) {
       switch (field) {
         case '__call':
           callable = true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,18 +12,6 @@
 
 import * as ts from 'typescript';
 
-export function toArray<T>(iterator: Iterator<T>): T[] {
-  const array: T[] = [];
-  while (true) {
-    const ir = iterator.next();
-    if (ir.done) {
-      break;
-    }
-    array.push(ir.value);
-  }
-  return array;
-}
-
 /**
  * Constructs a new ts.CompilerHost that overlays sources in substituteSource
  * over another ts.CompilerHost.

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import * as tsickle from '../src/tsickle';
-import {normalizeLineEndings, toArray} from '../src/util';
+import {normalizeLineEndings} from '../src/util';
 
 import * as testSupport from './test_support';
 
@@ -161,7 +161,7 @@ testFn('golden tests with transformer', () => {
       allDiagnostics.push(...diagnostics);
       let allExterns: string|null = null;
       if (!test.name.endsWith('.no_externs')) {
-        for (const tsPath of toArray(tsSources.keys())) {
+        for (const tsPath of tsSources.keys()) {
           if (externs[tsPath]) {
             if (!allExterns) allExterns = tsickle.EXTERNS_HEADER;
             allExterns += externs[tsPath];

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -18,7 +18,6 @@ import * as es5processor from '../src/es5processor';
 import {toClosureJS} from '../src/main';
 import {sourceMapTextToConsumer} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
-import {toArray} from '../src/util';
 
 /** Base compiler options to be customized and exposed. */
 const baseCompilerOptions: ts.CompilerOptions = {
@@ -112,7 +111,8 @@ export function createSourceCachingHost(
     if (contents !== undefined) {
       return ts.createSourceFile(fileName, contents, ts.ScriptTarget.Latest, true);
     }
-    throw new Error('unexpected file read of ' + fileName + ' not in ' + toArray(sources.keys()));
+    throw new Error(
+        'unexpected file read of ' + fileName + ' not in ' + Array.from(sources.keys()));
   };
   const originalFileExists = host.fileExists;
   host.fileExists = (fileName: string): boolean => {
@@ -131,7 +131,7 @@ export function createProgramAndHost(
     {host: ts.CompilerHost, program: ts.Program} {
   const host = createSourceCachingHost(sources);
 
-  const program = ts.createProgram(toArray(sources.keys()), tsCompilerOptions, host);
+  const program = ts.createProgram(Array.from(sources.keys()), tsCompilerOptions, host);
   return {program, host};
 }
 
@@ -253,13 +253,14 @@ export function extractInlineSourceMap(source: string): BasicSourceMapConsumer {
 }
 
 export function findFileContentsByName(filename: string, files: Map<string, string>): string {
-  const filePaths = toArray(files.keys());
-  for (const filepath of filePaths) {
+  for (const filepath of files.keys()) {
     if (path.parse(filepath).base === path.parse(filename).base) {
       return files.get(filepath)!;
     }
   }
-  assert(undefined, `Couldn't find file ${filename} in files: ${JSON.stringify(filePaths)}`);
+  assert(
+      undefined,
+      `Couldn't find file ${filename} in files: ${JSON.stringify(Array.from(files.keys()))}`);
   throw new Error('Unreachable');
 }
 
@@ -274,7 +275,7 @@ export function getSourceMapWithName(
  */
 export function compileWithTransfromer(
     sources: Map<string, string>, compilerOptions: ts.CompilerOptions) {
-  const fileNames = toArray(sources.keys());
+  const fileNames = Array.from(sources.keys());
   const tsHost = createSourceCachingHost(sources, compilerOptions);
   const program = ts.createProgram(fileNames, compilerOptions, tsHost);
   expect(ts.getPreEmitDiagnostics(program))


### PR DESCRIPTION
We were using toArray to use iterators in for of loops.  Since we've set the flag that has TypeScript downlevel them for us, we don't need to do it manually, so they're redundant.