### PR TITLE
Run decorator-annotator unit tests through the transformer codepath.

### DIFF
--- a/src/transformer_sourcemap.ts
+++ b/src/transformer_sourcemap.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {SourceMapper, SourcePosition} from './source_map_utils';
-import {isTypeNodeKind, updateSourceFileNode, visitEachChildIgnoringTypes, visitNodeWithSynthesizedComments} from './transformer_util';
+import {isTypeNodeKind, updateSourceFileNode, visitNodeWithSynthesizedComments} from './transformer_util';
 
 /**
  * @fileoverview Creates a TypeScript transformer that parses code into a new `ts.SourceFile`,
@@ -47,7 +47,7 @@ export function createTransformerFromSourceMap(
            isTypeNodeKind(node.kind) || node.kind === ts.SyntaxKind.IndexSignature)) {
         return originalNode;
       }
-      node = visitEachChildIgnoringTypes(node, visitNode, context);
+      node = ts.visitEachChild(node, visitNode, context);
 
       node.flags |= ts.NodeFlags.Synthesized;
       node.parent = undefined;

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -605,18 +605,6 @@ export function updateSourceFileNode(
   return sf;
 }
 
-/**
- * This is a version of `ts.visitEachChild` that does not visit children of types,
- * as this leads to errors in TypeScript < 2.4.0 and as types are not emitted anyways.
- */
-export function visitEachChildIgnoringTypes<T extends ts.Node>(
-    node: T, visitor: ts.Visitor, context: ts.TransformationContext): T {
-  if (isTypeNodeKind(node.kind) || node.kind === ts.SyntaxKind.IndexSignature) {
-    return node;
-  }
-  return ts.visitEachChild(node, visitor, context);
-}
-
 // Copied from TypeScript
 export function isTypeNodeKind(kind: ts.SyntaxKind) {
   return (kind >= ts.SyntaxKind.FirstTypeNode && kind <= ts.SyntaxKind.LastTypeNode) ||

--- a/test/ast_printing_transform.ts
+++ b/test/ast_printing_transform.ts
@@ -1,0 +1,15 @@
+import * as ts from 'typescript';
+
+/**
+ * Creates a transformer that captures the state of the AST as pretty printed
+ * TypeScript in the provided 'files' map.
+ */
+export function createAstPrintingTransform(files: Map<string, string>) {
+  return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
+    return (node: ts.SourceFile): ts.SourceFile => {
+      const sf = node as ts.SourceFile;
+      files.set(sf.fileName, ts.createPrinter().printFile(sf));
+      return sf;
+    };
+  };
+}

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -12,196 +12,257 @@ import {expect} from 'chai';
 import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
+import * as cliSupport from '../src/cli_support';
 import {convertDecorators} from '../src/decorator-annotator';
 import {DefaultSourceMapper} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
 
-import * as testSupport from './test_support';
+import {createAstPrintingTransform} from './ast_printing_transform';
+import {compilerOptions, createProgram, createProgramAndHost} from './test_support';
 
 const testCaseFileName = 'testcase.ts';
 
 function sources(sourceText: string): Map<string, string> {
   const sources = new Map<string, string>([
     [testCaseFileName, sourceText],
-    ['bar.d.ts', 'declare module "bar" { export class BarService {} }']
+    // Provides a rename of any 'FakeDecorator' that we can use as an annotator
+    // without the compiler complaining we didn't actually provide a value
+    [
+      'bar.d.ts', `declare module "bar" {
+      export class BarService {}
+      type FakeDecorator = any;
+    }`
+    ]
   ]);
   return sources;
 }
 
-function verifyCompiles(sourceText: string) {
-  // This throws an exception on error.
-  testSupport.createProgram(sources(sourceText));
+describe('decorator-annotator', () => {
+  function translate(sourceText: string, allowErrors = false) {
+    const {host, program} = createProgramAndHost(sources(sourceText), compilerOptions);
+    if (!allowErrors) {
+      const diagnostics = ts.getPreEmitDiagnostics(program);
+      expect(diagnostics, tsickle.formatDiagnostics(ts.getPreEmitDiagnostics(program))).to.be.empty;
+    }
+
+    const transformerHost: tsickle.TsickleHost = {
+      shouldSkipTsickleProcessing: (filePath) => !sources(sourceText).has(filePath),
+      pathToModuleName: cliSupport.pathToModuleName,
+      shouldIgnoreWarningsForPath: (filePath) => false,
+      fileNameToModuleId: (filePath) => filePath,
+      transformDecorators: true,
+      googmodule: true,
+      es5Mode: false,
+      untyped: false,
+    };
+
+    const files = new Map<string, string>();
+    const {diagnostics} = tsickle.emitWithTsickle(
+        program, transformerHost, host, compilerOptions, undefined, (path, contents) => {},
+        undefined, undefined, {beforeTs: [createAstPrintingTransform(files)]});
+
+    if (!allowErrors) {
+      // tslint:disable-next-line:no-unused-expression
+      expect(diagnostics, tsickle.formatDiagnostics(diagnostics)).to.be.empty;
+    }
+
+    return {output: files.get(testCaseFileName)!, diagnostics};
+  }
+
+  function expectUnchanged(sourceText: string) {
+    expectTranslated(sourceText).to.equal(sourceText);
+  }
+
+  function expectTranslated(sourceText: string) {
+    return expect(translate(sourceText).output);
+  }
+
+  describe('class decorator rewriter', () => {
+    it('leaves plain classes alone', () => {
+      expectUnchanged(`class Foo {
 }
+`);
+    });
 
-describe(
-    'decorator-annotator', () => {
-      function translate(sourceText: string, allowErrors = false) {
-        const program = testSupport.createProgram(sources(sourceText));
-        const sourceMapper = new DefaultSourceMapper(testCaseFileName);
-        const {output, diagnostics} = convertDecorators(
-            program.getTypeChecker(), program.getSourceFile(testCaseFileName), sourceMapper);
-        if (!allowErrors) expect(diagnostics).to.be.empty;
-        verifyCompiles(output);
-        return {output, diagnostics, sourceMap: sourceMapper.sourceMap};
-      }
-
-      function expectUnchanged(sourceText: string) {
-        expect(translate(sourceText).output).to.equal(sourceText);
-      }
-
-      it('generates a source map', () => {
-        const {output, sourceMap} = translate(`
-/** @Annotation */ let Test1: Function;
-@Test1
-export class Foo {
+    it('leaves un-marked decorators alone', () => {
+      expectUnchanged(`let Decor: any;
+@Decor
+class Foo {
+    constructor(
+        @Decor
+        p: number) { }
+    @Decor
+    m(): void { }
 }
-let X = 'a string';`);
-        const rawMap = sourceMap.toJSON();
-        const consumer = new SourceMapConsumer(rawMap);
-        const lines = output.split('\n');
-        const stringXLine = lines.findIndex(l => l.indexOf('a string') !== -1) + 1;
-        expect(consumer.originalPositionFor({line: stringXLine, column: 10}).line)
-            .to.equal(6, 'string X definition');
-      });
+`);
+    });
 
-      describe('class decorator rewriter', () => {
-        it('leaves plain classes alone', () => {
-          expectUnchanged(`class Foo {}`);
-        });
-
-        it('leaves un-marked decorators alone', () => {
-          expectUnchanged(`
-          let Decor: Function;
-          @Decor class Foo {
-            constructor(@Decor p: number) {}
-            @Decor m(): void {}
-          }`);
-        });
-
-        it('transforms decorated classes', () => {
-          expect(translate(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
+    it('transforms decorated classes', () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
 let param: any;
 @Test1
 @Test2(param)
 class Foo {
   field: string;
-}`).output).to.equal(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
 let param: any;
-
-
 class Foo {
-  field: string;
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test1 },
-{ type: Test2, args: [param, ] },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
+    field: string;
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1 },
+        { type: Test2, args: [param,] },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
+}
+`);
+    });
 
-        it('transforms decorated classes with function expression annotation declaration', () => {
-          expect(translate(`
-/** @Annotation */ function Test() {};
+    it('transforms decorated classes with function expression annotation declaration', () => {
+      expectTranslated(`
+/** @Annotation */ function Test(t: any) {};
 @Test
 class Foo {
   field: string;
-}`).output).to.equal(`
-/** @Annotation */ function Test() {};
-
+}`).to.equal(`/** @Annotation */ function Test(t: any) { }
+;
 class Foo {
-  field: string;
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
+    field: string;
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
+}
+`);
+    });
 
-        it('transforms decorated classes with an exported annotation declaration', () => {
-          expect(translate(`
-/** @Annotation */ export let Test: Function;
+    it('transforms decorated classes with an exported annotation declaration', () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ export let Test: FakeDecorator;
 @Test
 class Foo {
   field: string;
-}`).output).to.equal(`
-/** @Annotation */ export let Test: Function;
-
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ export let Test: FakeDecorator;
 class Foo {
-  field: string;
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
+    field: string;
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
+}
+`);
+    });
 
-        it('accepts various complicated decorators', () => {
-          expect(translate(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
-/** @Annotation */ let Test3: Function;
-/** @Annotation */ function Test4<T>(param: any): ClassDecorator { return null; }
+    it('accepts various complicated decorators', () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
+/** @Annotation */ let Test3: FakeDecorator;
+/** @Annotation */ function Test4<T>(param: any): ClassDecorator { return null as any; }
 let param: any;
 @Test1({name: 'percentPipe'}, class ZZZ {})
 @Test2
 @Test3()
 @Test4<string>(param)
 class Foo {
-}`).output).to.equal(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
-/** @Annotation */ let Test3: Function;
-/** @Annotation */ function Test4<T>(param: any): ClassDecorator { return null; }
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
+/** @Annotation */ let Test3: FakeDecorator;
+/** @Annotation */ function Test4<T>(param: any): ClassDecorator { return null as any; }
 let param: any;
-
-
-
-
 class Foo {
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test1, args: [{name: 'percentPipe'}, class ZZZ {}, ] },
-{ type: Test2 },
-{ type: Test3 },
-{ type: Test4, args: [param, ] },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1, args: [{ name: 'percentPipe' }, class ZZZ {
+                },] },
+        { type: Test2 },
+        { type: Test3 },
+        { type: Test4, args: [param,] },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
+}
+`);
+    });
 
-        it(`doesn't eat 'export'`, () => {
-          expect(translate(`
-/** @Annotation */ let Test1: Function;
+    it(`doesn't eat 'export'`, () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
 @Test1
 export class Foo {
-}`).output).to.equal(`
-/** @Annotation */ let Test1: Function;
-
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
 export class Foo {
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test1 },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1 },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
+}
+`);
+    });
 
-        it(`handles nested classes`, () => {
-          expect(translate(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
+    it(`handles nested classes`, () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
 @Test1
 export class Foo {
   foo() {
@@ -209,199 +270,265 @@ export class Foo {
     class Bar {
     }
   }
-}`).output).to.equal(`
-/** @Annotation */ let Test1: Function;
-/** @Annotation */ let Test2: Function;
-
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+/** @Annotation */ let Test2: FakeDecorator;
 export class Foo {
-  foo() {
-    \n    class Bar {
-    static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test2 },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
+    foo() {
+        class Bar {
+            static decorators: {
+                type: Function;
+                args?: any[];
+            }[] = [
+                { type: Test2 },
+            ];
+            /** @nocollapse */
+            static ctorParameters: () => ({
+                type: any;
+                decorators?: {
+                    type: Function;
+                    args?: any[];
+                }[];
+            } | null)[] = () => [];
+        }
+    }
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1 },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [];
 }
-  }
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test1 },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-];
-}`);
-        });
-      });
+`);
+    });
+  });
 
-      describe('ctor decorator rewriter', () => {
-        it('ignores ctors that have no applicable injects', () => {
-          expectUnchanged(`
-import {BarService} from 'bar';
+  describe('ctor decorator rewriter', () => {
+    it('ignores ctors that have no applicable injects', () => {
+      expectUnchanged(`import { BarService } from 'bar';
 class Foo {
-  constructor(bar: BarService, num: number) {
-  }
-}`);
-        });
+    constructor(bar: BarService, num: number) {
+    }
+}
+`);
+    });
 
-        it('transforms injected ctors', () => {
-          expect(translate(`
+    it('transforms injected ctors', () => {
+      expectTranslated(`
 /** @Annotation */ let Inject: Function;
 enum AnEnum { ONE, TWO, };
 abstract class AbstractService {}
 class Foo {
   constructor(@Inject bar: AbstractService, @Inject('enum') num: AnEnum) {
   }
-}`).output).to.equal(`
-/** @Annotation */ let Inject: Function;
-enum AnEnum { ONE, TWO, };
-abstract class AbstractService {}
+}`).to.equal(`/** @Annotation */ let Inject: Function;
+enum AnEnum {
+    ONE,
+    TWO
+}
+;
+abstract class AbstractService {
+}
 class Foo {
-  constructor( bar: AbstractService,  num: AnEnum) {
-  }
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: AbstractService, decorators: [{ type: Inject }, ]},
-{type: AnEnum, decorators: [{ type: Inject, args: ['enum', ] }, ]},
-];
-}`);
-        });
+    constructor(bar: AbstractService, num: AnEnum) {
+    }
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: AbstractService, decorators: [{ type: Inject },] },
+        { type: AnEnum, decorators: [{ type: Inject, args: ['enum',] },] },
+    ];
+}
+`);
+    });
 
-        it('stores non annotated parameters if the class has at least one decorator', () => {
-          expect(translate(`
-import {BarService} from 'bar';
-/** @Annotation */ let Test1: Function;
+    it('stores non annotated parameters if the class has at least one decorator', () => {
+      expectTranslated(`
+import {BarService, FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
 @Test1()
 class Foo {
   constructor(bar: BarService, num: number) {
   }
-}`).output).to.equal(`
-import {BarService} from 'bar';
-/** @Annotation */ let Test1: Function;
-
+}`).to.equal(`import { BarService, FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
 class Foo {
-  constructor(bar: BarService, num: number) {
-  }
-static decorators: {type: Function, args?: any[]}[] = [
-{ type: Test1 },
-];
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: BarService, },
-null,
-];
-}`);
-        });
+    constructor(bar: BarService, num: number) {
+    }
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1 },
+    ];
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: BarService, },
+        null,
+    ];
+}
+`);
+    });
 
-        it('handles complex ctor parameters', () => {
-          expect(translate(`
+    it('handles complex ctor parameters', () => {
+      expectTranslated(`
 import * as bar from 'bar';
 /** @Annotation */ let Inject: Function;
 let param: any;
 class Foo {
   constructor(@Inject(param) x: bar.BarService, {a, b}, defArg = 3, optional?: bar.BarService) {
   }
-}`).output).to.equal(`
-import * as bar from 'bar';
+}`).to.equal(`import * as bar from 'bar';
 /** @Annotation */ let Inject: Function;
 let param: any;
 class Foo {
-  constructor( x: bar.BarService, {a, b}, defArg = 3, optional?: bar.BarService) {
-  }
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: bar.BarService, decorators: [{ type: Inject, args: [param, ] }, ]},
-null,
-null,
-{type: bar.BarService, },
-];
-}`);
-        });
+    constructor(x: bar.BarService, { a, b }, defArg = 3, optional?: bar.BarService) {
+    }
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: bar.BarService, decorators: [{ type: Inject, args: [param,] },] },
+        null,
+        null,
+        { type: bar.BarService, },
+    ];
+}
+`);
+    });
 
-        it('includes decorators for primitive type ctor parameters', () => {
-          expect(translate(`
+    it('includes decorators for primitive type ctor parameters', () => {
+      expectTranslated(`
 /** @Annotation */ let Inject: Function;
 let APP_ID: any;
 class ViewUtils {
   constructor(@Inject(APP_ID) private _appId: string) {}
-}`).output).to.equal(`
-/** @Annotation */ let Inject: Function;
+}`).to.equal(`/** @Annotation */ let Inject: Function;
 let APP_ID: any;
 class ViewUtils {
-  constructor( private _appId: string) {}
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: undefined, decorators: [{ type: Inject, args: [APP_ID, ] }, ]},
-];
-}`);
-        });
+    constructor(private _appId: string) { }
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: undefined, decorators: [{ type: Inject, args: [APP_ID,] },] },
+    ];
+}
+`);
+    });
 
-        it('strips generic type arguments', () => {
-          expect(translate(`
+    it('strips generic type arguments', () => {
+      expectTranslated(`
 /** @Annotation */ let Inject: Function;
 class Foo {
   constructor(@Inject typed: Promise<string>) {
   }
-}`).output).to.equal(`
-/** @Annotation */ let Inject: Function;
+}`).to.equal(`/** @Annotation */ let Inject: Function;
 class Foo {
-  constructor( typed: Promise<string>) {
-  }
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: Promise, decorators: [{ type: Inject }, ]},
-];
-}`);
-        });
+    constructor(typed: Promise<string>) {
+    }
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: Promise, decorators: [{ type: Inject },] },
+    ];
+}
+`);
+    });
 
-        it('avoids using interfaces as values', () => {
-          expect(translate(`
-/** @Annotation */ let Inject: Function = null;
+    it('avoids using interfaces as values', () => {
+      expectTranslated(`
+/** @Annotation */ let Inject: Function = (null as any);
 class Class {}
 interface Iface {}
 class Foo {
   constructor(@Inject aClass: Class, @Inject aIface: Iface) {}
-}`).output).to.equal(`
-/** @Annotation */ let Inject: Function = null;
-class Class {}
-interface Iface {}
+}`).to.equal(`/** @Annotation */ let Inject: Function = (null as any);
+class Class {
+}
+interface Iface {
+}
 class Foo {
-  constructor( aClass: Class,  aIface: Iface) {}
-/** @nocollapse */
-static ctorParameters: () => ({type: any, decorators?: {type: Function, args?: any[]}[]}|null)[] = () => [
-{type: Class, decorators: [{ type: Inject }, ]},
-{type: undefined, decorators: [{ type: Inject }, ]},
-];
-}`);
-        });
-      });
+    constructor(aClass: Class, aIface: Iface) { }
+    /** @nocollapse */
+    static ctorParameters: () => ({
+        type: any;
+        decorators?: {
+            type: Function;
+            args?: any[];
+        }[];
+    } | null)[] = () => [
+        { type: Class, decorators: [{ type: Inject },] },
+        { type: undefined, decorators: [{ type: Inject },] },
+    ];
+}
+`);
+    });
+  });
 
-      describe('method decorator rewriter', () => {
-        it('leaves ordinary methods alone', () => {
-          expectUnchanged(`
-class Foo {
-  bar() {}
-}`);
-        });
+  describe('method decorator rewriter', () => {
+    it('leaves ordinary methods alone', () => {
+      expectUnchanged(`class Foo {
+    bar() { }
+}
+`);
+    });
 
-        it('gathers decorators from methods', () => {
-          expect(translate(`
+    it('gathers decorators from methods', () => {
+      expectTranslated(`
 /** @Annotation */ let Test1: Function;
 class Foo {
   @Test1('somename')
   bar() {}
-}`).output).to.equal(`
-/** @Annotation */ let Test1: Function;
+}`).to.equal(`/** @Annotation */ let Test1: Function;
 class Foo {
-  \n  bar() {}
-static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
-"bar": [{ type: Test1, args: ['somename', ] },],
-};
-}`);
-        });
+    bar() { }
+    static propDecorators: {
+        [key: string]: {
+            type: Function;
+            args?: any[];
+        }[];
+    } = {
+        "bar": [{ type: Test1, args: ['somename',] },],
+    };
+}
+`);
+    });
 
-        it('gathers decorators from fields and setters', () => {
-          expect(translate(`
+    it('gathers decorators from fields and setters', () => {
+      expectTranslated(`
 /** @Annotation */ let PropDecorator: Function;
 class ClassWithDecorators {
   @PropDecorator("p1") @PropDecorator("p2") a;
@@ -409,22 +536,26 @@ class ClassWithDecorators {
 
   @PropDecorator("p3")
   set c(value) {}
-}`).output).to.equal(`
-/** @Annotation */ let PropDecorator: Function;
+}`).to.equal(`/** @Annotation */ let PropDecorator: Function;
 class ClassWithDecorators {
     a;
-  b;
+    b;
+    set c(value) { }
+    static propDecorators: {
+        [key: string]: {
+            type: Function;
+            args?: any[];
+        }[];
+    } = {
+        "a": [{ type: PropDecorator, args: ["p1",] }, { type: PropDecorator, args: ["p2",] },],
+        "c": [{ type: PropDecorator, args: ["p3",] },],
+    };
+}
+`);
+    });
 
-  \n  set c(value) {}
-static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
-"a": [{ type: PropDecorator, args: ["p1", ] },{ type: PropDecorator, args: ["p2", ] },],
-"c": [{ type: PropDecorator, args: ["p3", ] },],
-};
-}`);
-        });
-
-        it('errors on weird class members', () => {
-          const {diagnostics} = translate(`
+    it('errors on weird class members', () => {
+      const {diagnostics} = translate(`
 /** @Annotation */ let Test1: Function;
 let param: any;
 class Foo {
@@ -432,26 +563,31 @@ class Foo {
   [param]() {}
 }`, true /* allow errors */);
 
-          expect(tsickle.formatDiagnostics(diagnostics))
-              .to.equal(
-                  'Error at testcase.ts:5:3: cannot process decorators on strangely named method');
-        });
-        it('avoids mangling code relying on ASI', () => {
-          expect(translate(`
+      expect(tsickle.formatDiagnostics(diagnostics))
+          .to.equal(
+              'Error at testcase.ts:5:3: cannot process decorators on strangely named method');
+    });
+    it('avoids mangling code relying on ASI', () => {
+      expectTranslated(`
 /** @Annotation */ let PropDecorator: Function;
 class Foo {
   missingSemi = () => {}
   @PropDecorator other: number;
-}`).output).to.equal(`
-/** @Annotation */ let PropDecorator: Function;
+}`).to.equal(`/** @Annotation */ let PropDecorator: Function;
 class Foo {
-  missingSemi = () => {}
-   other: number;
-static propDecorators: {[key: string]: {type: Function, args?: any[]}[]} = {
-"other": [{ type: PropDecorator },],
-};
-}`);
+    missingSemi = () => { };
+    other: number;
+    static propDecorators: {
+        [key: string]: {
+            type: Function;
+            args?: any[];
+        }[];
+    } = {
+        "other": [{ type: PropDecorator },],
+    };
+}
+`);
 
-        });
-      });
     });
+  });
+});

--- a/test/transformer_util_test.ts
+++ b/test/transformer_util_test.ts
@@ -9,7 +9,7 @@
 import {expect} from 'chai';
 import * as ts from 'typescript';
 
-import {createCustomTransformers, visitEachChildIgnoringTypes, visitNodeWithSynthesizedComments} from '../src/transformer_util';
+import {createCustomTransformers, visitNodeWithSynthesizedComments} from '../src/transformer_util';
 import * as tsickle from '../src/tsickle';
 import {normalizeLineEndings} from '../src/util';
 
@@ -49,7 +49,7 @@ describe('transformer util', () => {
         function visitNodeImpl<T extends ts.Node>(node: T): T {
           visitComments(node, ts.getSyntheticLeadingComments(node));
           visitComments(node, ts.getSyntheticTrailingComments(node));
-          return visitEachChildIgnoringTypes(node, visitNode, context);
+          return ts.visitEachChild(node, visitNode, context);
         }
 
         function visitComments(node: ts.Node, comments: ts.SynthesizedComment[]|undefined) {
@@ -362,7 +362,7 @@ describe('transformer util', () => {
             ts.setTextRange(synthNode, node);
             node = synthNode as ts.Node as T;
           }
-          return visitEachChildIgnoringTypes(node, visitNode, context);
+          return ts.visitEachChild(node, visitNode, context);
         }
       };
     }
@@ -421,7 +421,7 @@ describe('transformer util', () => {
                          ed, undefined, undefined, namedExports, ed.moduleSpecifier) as ts.Node as
                   T;
             }
-            return visitEachChildIgnoringTypes(node, visitNode, context);
+            return ts.visitEachChild(node, visitNode, context);
           }
         };
       }


### PR DESCRIPTION
Reworks the decorator-annotator unit tests to run in transformer mode so that we can migrate code out of the psuedo-tranformer into a proper transformer and be assured that the behavior hasn't changed.  Incidentally removes the function `visitEachChildIgnoringTypes`, which was used to work around a TypeScript bug that was fixed in 2.4, and made it impossible to properly pretty print the AST after all our transforms ran.