### PR TITLE
Add license blocks.

### DIFF
--- a/src/class_decorator_downlevel_transformer.ts
+++ b/src/class_decorator_downlevel_transformer.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 import {shouldLower} from './decorator-annotator';

--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 import * as jsdoc from './jsdoc';


### PR DESCRIPTION
g3 third_party requires code we check in to have license blocks, so this adds license blocks to the two new transformer files we've added.