### PR TITLE
Turn on the lint rule checking for the Google copyright license block.

### DIFF
--- a/test/ast_printing_transform.ts
+++ b/test/ast_printing_transform.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 /**

--- a/tslint.json
+++ b/tslint.json
@@ -51,6 +51,7 @@
       "ban-keywords",
       "allow-leading-underscore",
       "allow-trailing-underscore"
-    ]
+    ],
+    "file-header": [true, "Copyright Google Inc\\."]
   }
 }


### PR DESCRIPTION
I was surprised when I tried to sync tsickle that I need license blocks - this lint rule will catch that issue much earlier.