### PR TITLE
Handle @fileoverview in all initial comments.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1922,6 +1922,7 @@ export function emitWithTsickle(
   let tsickleDiagnostics: ts.Diagnostic[] = [];
   const typeChecker = program.getTypeChecker();
   const tsickleSourceTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
+  const tsickleJsTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
   if (host.transformTypesToClosure) {
     // Note: tsickle.annotate can also lower decorators in the same run.
     tsickleSourceTransformers.push(createTransformerFromSourceMap((sourceFile, sourceMapper) => {
@@ -1931,7 +1932,7 @@ export function emitWithTsickle(
       return output;
     }));
     // Only add @suppress {checkTypes} comments when also adding type annotations.
-    tsickleSourceTransformers.push(transformFileoverviewComment);
+    tsickleJsTransformers.push(transformFileoverviewComment);
     tsickleSourceTransformers.push(
         classDecoratorDownlevelTransformer(typeChecker, tsickleDiagnostics));
   } else if (host.transformDecorators) {
@@ -1949,7 +1950,8 @@ export function emitWithTsickle(
   //   sourceMapper.addMapping(sourceFile, {position: 0, line: 0, column: 0}, {position: 0, line: 0,
   //   column: 0}, sourceFile.text.length); return sourceFile.text;
   // }));
-  const tsickleTransformers = createCustomTransformers({before: tsickleSourceTransformers});
+  const tsickleTransformers =
+      createCustomTransformers({before: tsickleSourceTransformers, after: tsickleJsTransformers});
   const tsTransformers: ts.CustomTransformers = {
     before: [
       ...(customTransformers.beforeTsickle || []),

--- a/test_files/file_comment/comment_with_no_newline.js
+++ b/test_files/file_comment/comment_with_no_newline.js
@@ -1,0 +1,14 @@
+goog.module('test_files.file_comment.comment_with_no_newline');var module = module || {id: 'test_files/file_comment/comment_with_no_newline.js'};/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/**
+ *
+ * @fileoverview
+ * @suppress {missingRequire,checkTypes}
+ *
+ */
+console.log('hello');

--- a/test_files/file_comment/comment_with_no_newline.ts
+++ b/test_files/file_comment/comment_with_no_newline.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/**
+ * @fileoverview
+ * @suppress {missingRequire}
+ */
+console.log('hello');

--- a/test_files/file_comment/multicomment_with_empty_lines.js
+++ b/test_files/file_comment/multicomment_with_empty_lines.js
@@ -1,0 +1,11 @@
+goog.module('test_files.file_comment.multicomment_with_empty_lines');var module = module || {id: 'test_files/file_comment/multicomment_with_empty_lines.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */

--- a/test_files/file_comment/multicomment_with_empty_lines.ts
+++ b/test_files/file_comment/multicomment_with_empty_lines.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/*
+ * Stuff ffuts
+ * @fileoverview
+ * @suppress {undefinedVars} because we don't like them errors
+ */
+
+/**
+ * This is a jsdoc comment.
+ */
+interface foo {}


### PR DESCRIPTION
The fileoverview comment transformer handled @fileoverview comments that weren't attached to any
node, but @fileoverview comments just have to be before any js, so they can be in leading comments on the first statement in the file.  Thus, we need to look for @fileoverview in a leading NotEmittedStatement's comments as well as in the leading comments on the first emitted statement.  To avoid handling comments that were on a node that isn't emitted (ie an interface), move the fileoverview transformer to run after tsc runs its compile.