### PR TITLE
Enable writing new goldens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ Example:
   `clang-format`,
 - `yarn test` runs unit tests, e2e tests and checks the source code formatting.
 
-### Environment variables
+### Updating Goldens
 
-Export the environment variable `UPDATE_GOLDENS=1` and run `bazel run test:golden_test`
-to have the test suite update the goldens in `test_files/...`.
+Run `UPDATE_GOLDENS=y bazel run test:golden_test` to have the test suite update 
+the goldens in `test_files/...`.
+
+### Environment variables
 
 Pass the flag `--action_env=TEST_FILTER=<REGEX>` to bazel test to limit the
 end-to-end test (found in `test_files/...`) run tests with a name matching the

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -173,6 +173,22 @@ export class GoldenFileTest {
         .map(f => path.join(this.path, GoldenFileTest.tsPathToJs(f)));
   }
 
+  /**
+   * Find the absolute path to the tsickle root directory by reading the
+   * symlink bazel puts into bazel-bin back into the test_files directory
+   * and chopping off the test_files portion.
+   */
+  getWorkspaceRoot(): string {
+    if (!this.tsFiles.length || !this.tsFiles[0]) {
+      throw new Error(
+          'The workspace root was requested, but there were no source files to follow symlinks for.');
+    }
+    const resolvedFileSymLink = fs.readlinkSync(path.join(this.path, this.tsFiles[0]));
+    const resolvedPathParts = resolvedFileSymLink.split(path.delimiter);
+    const testFilesSegmentIndex = resolvedPathParts.findIndex(s => s === 'test_files');
+    return path.join(...resolvedPathParts.slice(0, testFilesSegmentIndex));
+  }
+
   public static tsPathToJs(tsPath: string): string {
     return tsPath.replace(/\.tsx?$/, '.js');
   }


### PR DESCRIPTION
Previously, updating goldens worked because the runfiles directory contains symlinks back to the original file.  However, if we needed to create a new golden file, there wasn't a symlink, so we'd create the new golden in the bazel runfiles directory, not in the test_files directory.  By parsing the symlink to the source ts files for the test, we can find the absolute path to the tsickle workspace root, which allows us to construct the path to the actual file we want to update.

This commit also changes the semantics of requesting a goldens update, by only requiring you to bazel run test:golden_test, instead of having to run the target as well as setting an environment variable.