### PR TITLE
Upgrade tsickle to TS2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "source-map-support": "^0.4.2"
   },
   "peerDependencies": {
-    "typescript": "2.4.2"
+    "typescript": "2.5.3"
   },
   "devDependencies": {
     "@bazel/typescript": "0.1.0",
@@ -48,7 +48,7 @@
     "mocha": "^3.2.0",
     "temp": "^0.8.1",
     "tslint": "^5.4.2",
-    "typescript": "~2.4.2"
+    "typescript": "~2.5.3"
   },
   "scripts": {
     "prepublish": "bazel build ...",

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -288,7 +288,8 @@ export function visitNodeWithSynthesizedComments<T extends ts.Node>(
  * @param node
  */
 function resetNodeTextRangeToPreventDuplicateComments<T extends ts.Node>(node: T): T {
-  ts.setEmitFlags(node, (ts.getEmitFlags(node) || 0) | ts.EmitFlags.NoComments);
+  // tslint:disable-next-line:no-any TS 2.5 typescript.d.ts does not expose getEmitFlags.
+  ts.setEmitFlags(node, ((ts as any).getEmitFlags(node) || 0) | ts.EmitFlags.NoComments);
   // See also addSyntheticCommentsAfterTsTransformer.
   // Note: Don't reset the textRange for ts.ExportDeclaration / ts.ImportDeclaration
   // until after the TypeScript transformer as we need the source location
@@ -301,11 +302,9 @@ function resetNodeTextRangeToPreventDuplicateComments<T extends ts.Node>(node: T
   if (node.kind === ts.SyntaxKind.PropertyDeclaration) {
     allowTextRange = false;
     const pd = node as ts.Node as ts.PropertyDeclaration;
-    // TODO(tbosch): Using pd.initializer! as the typescript typings before 2.4.0
-    // are incorrect. Remove this once we upgrade to TypeScript 2.4.0.
     node = ts.updateProperty(
-               pd, pd.decorators, pd.modifiers, resetTextRange(pd.name) as ts.PropertyName, pd.type,
-               pd.initializer!) as ts.Node as T;
+               pd, pd.decorators, pd.modifiers, resetTextRange(pd.name) as ts.PropertyName,
+               pd.questionToken, pd.type, pd.initializer) as ts.Node as T;
   }
   if (!allowTextRange) {
     node = resetTextRange(node);
@@ -375,6 +374,10 @@ function synthesizeTrailingComments(sourceFile: ts.SourceFile, node: ts.Node): n
   return -1;
 }
 
+function arrayOf<T>(value: T|undefined|null): T[] {
+  return value ? [value] : [];
+}
+
 /**
  * Convert leading/trailing detached comment ranges of statement arrays
  * (e.g. the statements of a ts.SourceFile or ts.Block) into
@@ -392,13 +395,32 @@ function visitNodeStatementsWithSynthesizedComments<T extends ts.Node>(
   const leading = synthesizeDetachedLeadingComments(sourceFile, node, statements);
   const trailing = synthesizeDetachedTrailingComments(sourceFile, node, statements);
   if (leading.commentStmt || trailing.commentStmt) {
-    statements = ts.setTextRange(ts.createNodeArray(statements), {pos: -1, end: -1});
-    if (leading.commentStmt) {
-      statements.unshift(leading.commentStmt);
-    }
-    if (trailing.commentStmt) {
-      statements.push(trailing.commentStmt);
-    }
+    const newStatements: ts.Statement[] =
+        [...arrayOf(leading.commentStmt), ...statements, ...arrayOf(trailing.commentStmt)];
+    statements = ts.setTextRange(ts.createNodeArray(newStatements), {pos: -1, end: -1});
+
+    /**
+     * The visitor creates a new node with the new statements. However, doing so
+     * reveals a TypeScript bug.
+     * To reproduce comment out the line below and compile:
+     *
+     * // ......
+     *
+     * abstract class A {
+     * }
+     * abstract class B extends A {
+     *   // ......
+     * }
+     *
+     * Note that newlines are significant. This would result in the following:
+     * runtime error "TypeError: Cannot read property 'members' of undefined".
+     *
+     * The line below is a workaround that ensures that updateSourceFileNode and
+     * updateBlock never create new Nodes.
+     * TODO(#634): file a bug with TS team.
+     */
+    (node as ts.Node as ts.SourceFile).statements = statements;
+
     const fileContext = assertFileContext(context, sourceFile);
     if (leading.lastCommentEnd !== -1) {
       fileContext.lastCommentEnd = leading.lastCommentEnd;
@@ -604,6 +626,7 @@ export function visitEachChild(
  * This is a version of `ts.updateSourceFileNode` that works
  * well with property decorators.
  * See https://github.com/Microsoft/TypeScript/issues/17384
+ * TODO(#634): This has been fixed in TS 2.5. Investigate removal.
  *
  * @param sf
  * @param statements

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -106,8 +106,6 @@ export function symbolToDebugString(sym: ts.Symbol): string {
     ts.SymbolFlags.TypeParameter,
     ts.SymbolFlags.TypeAlias,
     ts.SymbolFlags.ExportValue,
-    ts.SymbolFlags.ExportType,
-    ts.SymbolFlags.ExportNamespace,
     ts.SymbolFlags.Alias,
     ts.SymbolFlags.Prototype,
     ts.SymbolFlags.ExportStar,

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -13,7 +13,6 @@ import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import * as cliSupport from '../src/cli_support';
-import {convertDecorators} from '../src/decorator-annotator';
 import {DefaultSourceMapper} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,11 +36,7 @@
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.6.0.tgz#997b41a27752b4850af2683bc4a8d8222c25bd02"
 
-"@types/minimatch@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
-
-"@types/minimatch@^2.0.28":
+"@types/minimatch@*", "@types/minimatch@^2.0.28":
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
 
@@ -56,11 +52,7 @@
   version "2.2.43"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"
 
-"@types/node@*":
-  version "8.0.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.31.tgz#d9af61093cf4bfc9f066ca34de0175012cfb0ce9"
-
-"@types/node@7.0.18":
+"@types/node@*", "@types/node@7.0.18":
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
@@ -249,15 +241,11 @@ colour@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
 
-commander@2.9.0:
+commander@2.9.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1781,9 +1769,13 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@2.4.x, typescript@~2.4.2:
+typescript@2.4.x:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+
+typescript@~2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
The major change is that NodeArray is now readonly, but we still
want to modify it in a number of places.