### PR TITLE
    handle tslib-style export * rewriting

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,12 +1,13 @@
-package(default_visibility=["//visibility:public"])
+package(default_visibility = ["//visibility:public"])
+
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_support",
     srcs = ["test_support.ts"],
-    deps = ["//src"],
     tsconfig = "//:tsconfig.json",
+    deps = ["//src"],
 )
 
 ts_library(
@@ -22,11 +23,11 @@ ts_library(
         "tsickle_test.ts",
         "type-translator_test.ts",
     ],
-    deps = [
-        "//src",
-        ":test_support",
-    ],
     tsconfig = "//:tsconfig.json",
+    deps = [
+        ":test_support",
+        "//src",
+    ],
 )
 
 jasmine_node_test(
@@ -43,11 +44,11 @@ ts_library(
         "e2e_source_map_test.ts",
         "e2e_test.ts",
     ],
-    deps = [
-        "//src",
-        ":test_support",
-    ],
     tsconfig = "//:tsconfig.json",
+    deps = [
+        ":test_support",
+        "//src",
+    ],
 )
 
 jasmine_node_test(
@@ -61,11 +62,11 @@ ts_library(
     srcs = [
         "golden_tsickle_test.ts",
     ],
-    deps = [
-        "//src",
-        ":test_support",
-    ],
     tsconfig = "//:tsconfig.json",
+    deps = [
+        ":test_support",
+        "//src",
+    ],
 )
 
 jasmine_node_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -14,6 +14,7 @@ ts_library(
     srcs = [
         "ast_printing_transform.ts",
         "decorator-annotator_test.ts",
+        "es5processor_test.ts",
         "jsdoc_test.ts",
         "source_map_test.ts",
         "source_map_utils_test.ts",

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -113,6 +113,12 @@ __export(require('req/mod'));`)
               `goog.module('a');var module = module || {id: 'a.js'};var mod = goog.require('req.mod');
 __export(mod);`);
     });
+
+    it('converts tslib exportStar usage', () => {
+      expectCommonJs('a.js', `tslib_1.__exportStar(require("./decorators"), exports);`)
+          .to.equal(
+              `goog.module('a');var module = module || {id: 'a.js'};var tsickle_module_0_ = goog.require('decorators');tslib_1.__exportStar(tsickle_module_0_, exports);`);
+    });
   });
 
   it('resolves relative module URIs', () => {


### PR DESCRIPTION
    
    If code is built using tsc's importHelpers flag, "export *" expressions
    produce code like:
      var tslib_1 = require('tslib');
      tslib_1.__exportStar(require('foo'), exports);
    
    Adjust the code that rewrites "require" into "goog.require" to also
    match this specific pattern, by looking for use of the special name
    __exportStar().
