### PR TITLE
Upgrade bazel nodejs and typescript rules to TS 2.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.1.8",
+    tag = "0.2.1",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "2.5.3"
   },
   "devDependencies": {
-    "@bazel/typescript": "0.1.0",
+    "@bazel/typescript": "^0.3.1",
     "@types/chai": "^3.4.32",
     "@types/diff": "^3.2.0",
     "@types/glob": "^5.0.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,15 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.1.0.tgz#14a0a74d06e0acf7cf60295963adbcc5d3f41217"
+"@bazel/typescript@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.3.1.tgz#54367df8f30fa0fb25e41106eb7aa558534c36dd"
   dependencies:
     "@types/node" "7.0.18"
+    "@types/source-map" "^0.5.1"
     protobufjs "5.0.0"
-    tsickle "0.24.x"
-    typescript "2.4.x"
+    tsickle "0.25.x"
+    typescript "2.5.x"
 
 "@types/chai@^3.4.32":
   version "3.5.2"
@@ -52,13 +53,13 @@
   version "2.2.43"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"
 
-"@types/node@*", "@types/node@7.0.18":
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
-
-"@types/node@^6.0.38":
+"@types/node@*", "@types/node@^6.0.38":
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
+
+"@types/node@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
 "@types/source-map-support@^0.2.27":
   version "0.2.28"
@@ -1727,9 +1728,9 @@ to-absolute-glob@^0.1.1:
   dependencies:
     extend-shallow "^2.0.1"
 
-tsickle@0.24.x:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.24.1.tgz#039343b205bf517a333b0703978892f80a7d848e"
+tsickle@0.25.x:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.25.0.tgz#4ba51e79e9333ab7baec6f374c789b0bc1dba36c"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -1769,11 +1770,7 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@2.4.x:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
-
-typescript@~2.5.3:
+typescript@2.5.x, typescript@~2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 


### PR DESCRIPTION
Note that we no longer have TS 2.4 in the yarn.lock file.