### PR TITLE
Fix path handling in tsickle tests a bit

### DIFF
--- a/src/cli_support.ts
+++ b/src/cli_support.ts
@@ -8,7 +8,11 @@
 
 import * as path from 'path';
 
-// Postprocess generated JS.
+/**
+ * Converts a path in the given context to a Closure module name.
+ * Both context and fileName must be logical paths, i.e. they must have rootDir
+ * and outDir, respectively, stripped.
+ */
 export function pathToModuleName(context: string, fileName: string): string {
   fileName = fileName.replace(/\.js$/, '');
 

--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -270,6 +270,7 @@ class ES5Processor extends Rewriter {
       modName = nsImport;
       isNamespaceImport = true;
     } else {
+      // TODO(martinprobst): why doesn't this need stripping "rootDir"?
       modName = this.host.pathToModuleName(this.file.fileName, tsImport);
     }
 
@@ -383,7 +384,8 @@ class ES5Processor extends Rewriter {
  * Converts TypeScript's JS+CommonJS output to Closure goog.module etc.
  * For use as a postprocessing step *after* TypeScript emits JavaScript.
  *
- * @param fileName The source file name.
+ * @param fileName The logical JavaScript source file name, i.e. with any
+ *     outDir prefix removed.
  * @param moduleId The "module id", a module-identifying string that is
  *     the value module.id in the scope of the module.
  * @param pathToModuleName A function that maps a filesystem .ts path to a

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1179,7 +1179,7 @@ class Annotator extends ClosureRewriter {
     // Convert the source fileName to a logical fileName.
     const rootDir = (this.tsOpts && this.tsOpts.rootDir) || '';
     const logicalFileName = this.file.fileName.startsWith(rootDir) ?
-        this.file.fileName.substring(rootDir.length) :
+        path.relative(rootDir, this.file.fileName) :
         this.file.fileName;
     const moduleNamespace =
         nsImport !== null ? nsImport : this.host.pathToModuleName(logicalFileName, importPath);
@@ -2013,7 +2013,7 @@ export function emitWithTsickle(
           }
           const outDir = program.getCompilerOptions().outDir || '';
           const logicalFileName =
-              fileName.startsWith(outDir) ? fileName.substring(outDir.length) : fileName;
+              fileName.startsWith(outDir) ? path.relative(outDir, fileName) : fileName;
           content = es5processor.convertCommonJsToGoogModuleIfNeeded(
               host, modulesManifest, logicalFileName, content);
         } else {

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -32,6 +32,10 @@ export interface AnnotatorHost {
    * by default.
    */
   logWarning?: (warning: ts.Diagnostic) => void;
+  /**
+   * Convert an import path in the given context into a Closure module name.
+   * context and import path must have rootDir or outDir prefixes stripped.
+   */
   pathToModuleName: (context: string, importPath: string) => string;
   /**
    * If true, convert every type to the Closure {?} type, which means
@@ -1163,8 +1167,7 @@ class Annotator extends ClosureRewriter {
     const importPath = this.resolveModuleSpecifier(specifier);
     const nsImport = es5processor.extractGoogNamespaceImport(importPath);
     const forwardDeclarePrefix = `tsickle_forward_declare_${++this.forwardDeclareCounter}`;
-    const moduleNamespace =
-        nsImport !== null ? nsImport : this.host.pathToModuleName(this.file.fileName, importPath);
+
     const moduleSymbol = this.typeChecker.getSymbolAtLocation(specifier);
     // Scripts do not have a symbol. Scripts can still be imported, either as side effect imports or
     // with an empty import set ("{}"). TypeScript does not emit a runtime load for an import with
@@ -1172,13 +1175,22 @@ class Annotator extends ClosureRewriter {
     // be visible, which is what users use this for. No symbols from the script need forward
     // declaration, so just return.
     if (!moduleSymbol) return;
-    const exports = this.typeChecker.getExportsOfModule(moduleSymbol);
+
+    // Convert the source fileName to a logical fileName.
+    const rootDir = (this.tsOpts && this.tsOpts.rootDir) || '';
+    const logicalFileName = this.file.fileName.startsWith(rootDir) ?
+        this.file.fileName.substring(rootDir.length) :
+        this.file.fileName;
+    const moduleNamespace =
+        nsImport !== null ? nsImport : this.host.pathToModuleName(logicalFileName, importPath);
+
     // In TypeScript, importing a module for use in a type annotation does not cause a runtime load.
     // In Closure Compiler, goog.require'ing a module causes a runtime load, so emitting requires
     // here would cause a change in load order, which is observable (and can lead to errors).
     // Instead, goog.forwardDeclare types, which allows using them in type annotations without
     // causing a load. See below for the exception to the rule.
     this.emit(`\nconst ${forwardDeclarePrefix} = goog.forwardDeclare("${moduleNamespace}");`);
+    const exports = this.typeChecker.getExportsOfModule(moduleSymbol);
     const hasValues = exports.some(e => (e.flags & ts.SymbolFlags.Value) !== 0);
     if (!hasValues) {
       // Closure Compiler's toolchain will drop files that are never goog.require'd *before* type
@@ -1999,8 +2011,11 @@ export function emitWithTsickle(
           } else {
             content = removeInlineSourceMap(content);
           }
+          const outDir = program.getCompilerOptions().outDir || '';
+          const logicalFileName =
+              fileName.startsWith(outDir) ? fileName.substring(outDir.length) : fileName;
           content = es5processor.convertCommonJsToGoogModuleIfNeeded(
-              host, modulesManifest, fileName, content);
+              host, modulesManifest, logicalFileName, content);
         } else {
           content = combineSourceMaps(program, fileName, content);
         }

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -19,12 +19,13 @@ describe('toClosureJS', () => {
 
     const filePaths =
         ['test_files/underscore/export_underscore.ts', 'test_files/underscore/underscore.ts'];
-    const compilerOptionsWithRoot = {...compilerOptions, rootDir: 'test_files'};
+    const compilerOptionsWithRoot = {...compilerOptions, rootDir: 'test_files/', outDir: 'out/'};
     const sources = readSources(filePaths);
 
     const files = new Map<string, string>();
+    // NB: the code below only passes underscore.ts, and then resolves export_underscore.
     const result = toClosureJS(
-        compilerOptionsWithRoot, filePaths, {isTyped: true},
+        compilerOptionsWithRoot, ['test_files/underscore/underscore.ts'], {isTyped: true},
         (filePath: string, contents: string) => {
           files.set(filePath, contents);
         });
@@ -40,11 +41,13 @@ var __NS = {};
 __NS.__ns1;
 `);
 
-    const underscoreDotJs = files.get('./underscore/underscore.js');
+    const underscoreDotJs = files.get('out/underscore/underscore.js');
     expect(underscoreDotJs).to.contain(`goog.module('underscore.underscore')`);
+    expect(underscoreDotJs).to.contain(`goog.require('underscore.export_underscore')`);
+    expect(underscoreDotJs).to.contain(`goog.forwardDeclare("underscore.export_underscore")`);
     expect(underscoreDotJs).to.contain(`/** @type {string} */`);
 
-    const exportUnderscoreDotJs = files.get('./underscore/export_underscore.js');
+    const exportUnderscoreDotJs = files.get('out/underscore/export_underscore.js');
     expect(exportUnderscoreDotJs).to.contain(`goog.module('underscore.export_underscore')`);
   });
 });

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -6,24 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import * as ts from 'typescript';
 
 import {toClosureJS} from '../src/main';
 import * as tsickle from '../src/tsickle';
 
-import {compilerOptions, createSourceCachingHost, findFileContentsByName, readSources} from './test_support';
+import {compilerOptions, createHostWithSources, findFileContentsByName, readSources} from './test_support';
 
 describe('toClosureJS', () => {
   it('creates externs, adds type comments and rewrites imports', () => {
 
     const filePaths =
         ['test_files/underscore/export_underscore.ts', 'test_files/underscore/underscore.ts'];
+    const compilerOptionsWithRoot = {...compilerOptions, rootDir: 'test_files'};
     const sources = readSources(filePaths);
 
     const files = new Map<string, string>();
     const result = toClosureJS(
-        compilerOptions, filePaths, {isTyped: true}, (filePath: string, contents: string) => {
+        compilerOptionsWithRoot, filePaths, {isTyped: true},
+        (filePath: string, contents: string) => {
           files.set(filePath, contents);
         });
 
@@ -38,12 +40,11 @@ var __NS = {};
 __NS.__ns1;
 `);
 
-    const underscoreDotJs = files.get('./test_files/underscore/underscore.js');
-    expect(underscoreDotJs).to.contain(`goog.module('test_files.underscore.underscore')`);
+    const underscoreDotJs = files.get('./underscore/underscore.js');
+    expect(underscoreDotJs).to.contain(`goog.module('underscore.underscore')`);
     expect(underscoreDotJs).to.contain(`/** @type {string} */`);
 
-    const exportUnderscoreDotJs = files.get('./test_files/underscore/export_underscore.js');
-    expect(exportUnderscoreDotJs)
-        .to.contain(`goog.module('test_files.underscore.export_underscore')`);
+    const exportUnderscoreDotJs = files.get('./underscore/export_underscore.js');
+    expect(exportUnderscoreDotJs).to.contain(`goog.module('underscore.export_underscore')`);
   });
 });

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -53,18 +53,6 @@ export const compilerOptions: ts.CompilerOptions = {
   emitDecoratorMetadata: true,
   noEmitHelpers: true,
   jsx: ts.JsxEmit.React,
-  /**
-   * The 'conceptual path' of source files in TypeScript is their path relative to the current
-   * directory, or relative to rootDir if set.
-   *
-   * This path ends up in sourceFile.fileName, which tsickle converts to the goog.module name and
-   * also uses for source map contents. Together with outDir, this causes file writes to happen with
-   * the same path as their original .ts file, which is what tests expect. Setting it here
-   * explicitly makes sure files end up with the right path in both places.
-   */
-  rootDir: '',
-  /**  */
-  outDir: '.',
 };
 
 /**
@@ -122,9 +110,10 @@ export function createProgram(
 /**
  * Creates a ts.CompilerHost that only resolves the given source files.
  *
- * Map keys in sources should be relative paths. The host simulates an environment where the sources exist immediately underneath the current directory
+ * Map keys in sources should be relative paths. The host simulates an environment where the sources
+ * exist immediately underneath the current directory, which is BASE_PATH.
  *
- * Additionally, this host caches
+ * Additionally, this host caches `lib.d.ts` to speed up tests.
  */
 export function createHostWithSources(
     sources: Map<string, string>,
@@ -136,7 +125,7 @@ export function createHostWithSources(
     return path.relative(BASE_PATH, p);
   }
 
-  // host.getCurrentDirectory = () => BASE_PATH;
+  host.getCurrentDirectory = () => BASE_PATH;
   host.getSourceFile = (fileName: string, languageVersion: ts.ScriptTarget,
                         onError?: (msg: string) => void): ts.SourceFile => {
     // Normalize path to fix wrong directory separators on Windows which

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -172,7 +172,10 @@ export function emit(program: ts.Program): {[fileName: string]: string} {
       es5Mode: true,
       prelude: '',
     };
-    transformed[fileName] = es5processor.processES5(host, fileName, data).output;
+    const outDir = program.getCompilerOptions().outDir || '';
+    const logicalFileName =
+        fileName.startsWith(outDir) ? fileName.substring(outDir.length) : fileName;
+    transformed[fileName] = es5processor.processES5(host, logicalFileName, data).output;
   });
   if (diagnostics.length > 0) {
     throw new Error(tsickle.formatDiagnostics(diagnostics));

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -28,8 +28,7 @@ import * as tsickle from '../src/tsickle';
  */
 const BASE_PATH = (() => {
   const runfiles = process.env['RUNFILES'];
-  const candidate =
-      path.join(runfiles, 'google3', 'third_party', 'javascript', 'node_modules', 'tsickle');
+  const candidate = path.join(runfiles, 'google3/third_party/javascript/node_modules/tsickle');
   if (fs.existsSync(candidate)) return candidate;
   return path.join(runfiles, 'io_angular_tsickle');
 })();

--- a/test/transformer_util_test.ts
+++ b/test/transformer_util_test.ts
@@ -70,6 +70,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
+      console.error('sources ended up being', Array.from(Object.keys(jsSources)));
       expect(jsSources['./a.js']).to.eq([
         `/*<${ts.SyntaxKind.NotEmittedStatement}>fc*/`,
         `/*<${ts.SyntaxKind.VariableStatement}>sc*/`,

--- a/test/transformer_util_test.ts
+++ b/test/transformer_util_test.ts
@@ -70,8 +70,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      console.error('sources ended up being', Array.from(Object.keys(jsSources)));
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `/*<${ts.SyntaxKind.NotEmittedStatement}>fc*/`,
         `/*<${ts.SyntaxKind.VariableStatement}>sc*/`,
         `const x = 1;`,
@@ -87,7 +86,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
         `/*<${ts.SyntaxKind.NotEmittedStatement}>fc*/ `,
         ``,
@@ -106,7 +105,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `{`,
         `    /*<${ts.SyntaxKind.NotEmittedStatement}>bc*/`,
         `    /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
@@ -128,7 +127,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `{`,
         `    /*<${ts.SyntaxKind.VariableStatement}>a*/`,
         `    const a = 1;`,
@@ -150,7 +149,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `{`,
         `    const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
         `    /*<${ts.SyntaxKind.NotEmittedStatement}>bc*/`,
@@ -171,7 +170,7 @@ describe('transformer util', () => {
       const jsSources = emitWithTransform(tsSources, transformComments);
       // Note: tripple line comments contain typescript specific information
       // and are removed.
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `/*<${ts.SyntaxKind.VariableStatement}>mlc*/`,
         `//<${ts.SyntaxKind.VariableStatement}>slc`,
         `const x = 1;`,
@@ -188,7 +187,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `/*<${ts.SyntaxKind.VariableStatement}>sc1*/`,
         `/*<${ts.SyntaxKind.VariableStatement}>sc2*/`,
         `const x = 1;`,
@@ -203,7 +202,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `const x = 1; /*<${ts.SyntaxKind.VariableStatement}>sc*/`,
         ``,
       ].join('\n'));
@@ -217,7 +216,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `/*<${ts.SyntaxKind.VariableStatement}>lc1*/ const x = 1; /*<${
             ts.SyntaxKind.VariableStatement}>tc1*/`,
         `/*<${ts.SyntaxKind.VariableStatement}>lc2*/ const y = 1; /*<${
@@ -229,7 +228,7 @@ describe('transformer util', () => {
     it('should synthesize comments on variables', () => {
       const tsSources = {'a.ts': `/*c*/ const /*x*/ x = 1, /*y*/ y = 1;`};
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js'])
+      expect(jsSources['a.js'])
           .to.eq(
               `/*<${ts.SyntaxKind.VariableStatement}>c*/ const ` +
               `/*<${ts.SyntaxKind.VariableDeclaration}>x*/ x = 1, ` +
@@ -239,7 +238,7 @@ describe('transformer util', () => {
     it('should synthesize comments on exported variables', () => {
       const tsSources = {'a.ts': `/*c*/export const x = 1;`};
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         MODULE_HEADER,
         `/*<${ts.SyntaxKind.VariableStatement}>c*/ exports.x = 1;`,
         ``,
@@ -249,7 +248,7 @@ describe('transformer util', () => {
     it('should synthesize comments on reexport stmts', () => {
       const tsSources = {'a.ts': 'export const x = 1', 'b.ts': `/*c*/export {x} from './a';`};
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./b.js']).to.eq([
+      expect(jsSources['b.js']).to.eq([
         MODULE_HEADER,
         `/*<${ts.SyntaxKind.ExportDeclaration}>c*/ var a_1 = require("./a");`,
         `exports.x = a_1.x;`,
@@ -263,7 +262,7 @@ describe('transformer util', () => {
         'b.ts': `/*c*/import {x} from './a';console.log(x);`
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./b.js']).to.eq([
+      expect(jsSources['b.js']).to.eq([
         MODULE_HEADER,
         `/*<${ts.SyntaxKind.ImportDeclaration}>c*/ const a_1 = require("./a");`,
         `console.log(a_1.x);`,
@@ -282,7 +281,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./c.js']).to.eq([
+      expect(jsSources['c.js']).to.eq([
         MODULE_HEADER,
         `/*<${ts.SyntaxKind.ImportDeclaration}>x*/ const b_1 = require("./b");`,
         `console.log(b_1.x);`,
@@ -300,7 +299,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./c.js']).to.eq([
+      expect(jsSources['c.js']).to.eq([
         MODULE_HEADER,
         `/*<${ts.SyntaxKind.ExportDeclaration}>x*/ var b_1 = require("./b");`,
         `exports.x = b_1.x;`,
@@ -318,7 +317,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `class C {`,
         `    constructor() {`,
         `        /*<${ts.SyntaxKind.PropertyDeclaration}>c2*/ this.p2 = true;`,
@@ -339,7 +338,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, transformComments);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `/*<${ts.SyntaxKind.ClassDeclaration}>c*/`,
         `class C {`,
         `    constructor() {`,
@@ -379,7 +378,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, synthesizeTransform);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `let decorator;`,
         `class X {`,
         `}`,
@@ -400,7 +399,7 @@ describe('transformer util', () => {
         ].join('\n')
       };
       const jsSources = emitWithTransform(tsSources, synthesizeTransform);
-      expect(jsSources['./a.js']).to.eq([
+      expect(jsSources['a.js']).to.eq([
         `var Reflect;`,
         `(function (Reflect) {`,
         `    const x = 1;`,
@@ -429,7 +428,7 @@ describe('transformer util', () => {
 
       const tsSources = {'a.ts': `export const x = 1;`, 'b.ts': `export * from './a';`};
       const jsSources = emitWithTransform(tsSources, expandExportStar);
-      expect(jsSources['./b.js']).to.eq([
+      expect(jsSources['b.js']).to.eq([
         MODULE_HEADER,
         `var a_1 = require("./a");`,
         `exports.x = a_1.x;`,

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -78,7 +78,7 @@ describe('emitWithTsickle', () => {
         },
         {beforeTs: [transformValue]});
 
-    expect(jsSources['./a.js']).to.contain('exports.x = 2;');
+    expect(jsSources['a.js']).to.contain('exports.x = 2;');
   });
 
 
@@ -93,7 +93,7 @@ describe('emitWithTsickle', () => {
              },
              {es5Mode: false, googmodule: false});
 
-         expect(jsSources['./b.d.ts']).to.eq(`export * from './a';\n`);
+         expect(jsSources['b.d.ts']).to.eq(`export * from './a';\n`);
        });
 
   });


### PR DESCRIPTION
This is a prequisite to run the test suite in other environments (g3), but also just a general cleanup of messy code.

Additionally I think I discovered the cause for #481 and #490. Internally and when using bazel, we never run into this, because we emulate one consistent path hierarchy for tsc, i.e. we never use `rootDir` or `outDir` due to clever bazel file layout.

However if you do have `rootDir` or `outDir` set, then we're calling `pathToModuleName` with inconsistent paths, causing inconsistent `goog.require` and `goog.module` calls. This PR fixes that issue, though in a somewhat incomplete way. Ideally, we should not strip `rootDir` but rather call into some TypeScript API to obtain the logical file name. I don't know which or whether it is exposed though.