### PR TITLE
Break cyclic dependencies in tsickle.ts

### DIFF
--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {ModulesManifest} from './modules_manifest';
 import {getIdentifierText, Rewriter} from './rewriter';
-import {isDtsFileName} from './tsickle';
+import {isDtsFileName} from './util';
 
 export interface Es5ProcessorHost {
   /**

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ts from 'typescript';
-import * as tsickle from './tsickle';
+import {hasModifierFlag} from './util';
 
 /**
  * Adjusts the given CustomTransformers with additional transformers
@@ -171,7 +171,7 @@ function emitMissingSyntheticCommentsAfterTypescriptTransform(context: ts.Transf
           }
         } else if (
             parent3 && parent3.kind === ts.SyntaxKind.VariableStatement &&
-            tsickle.hasModifierFlag(parent3, ts.ModifierFlags.Export)) {
+            hasModifierFlag(parent3, ts.ModifierFlags.Export)) {
           // TypeScript ignores synthetic comments on exported variables.
           // find the parent ExpressionStatement like exports.foo = ...
           const expressionStmt =
@@ -298,7 +298,7 @@ function resetNodeTextRangeToPreventDuplicateComments<T extends ts.Node>(node: T
   let allowTextRange = node.kind !== ts.SyntaxKind.ClassDeclaration &&
       node.kind !== ts.SyntaxKind.VariableDeclaration &&
       !(node.kind === ts.SyntaxKind.VariableStatement &&
-        tsickle.hasModifierFlag(node, ts.ModifierFlags.Export));
+        hasModifierFlag(node, ts.ModifierFlags.Export));
   if (node.kind === ts.SyntaxKind.PropertyDeclaration) {
     allowTextRange = false;
     const pd = node as ts.Node as ts.PropertyDeclaration;

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -22,6 +22,7 @@ import {containsInlineSourceMap, extractInlineSourceMap, parseSourceMap, removeI
 import {createTransformerFromSourceMap} from './transformer_sourcemap';
 import {createCustomTransformers} from './transformer_util';
 import * as typeTranslator from './type-translator';
+import {hasModifierFlag, isDtsFileName} from './util';
 
 export {FileMap, ModulesManifest} from './modules_manifest';
 
@@ -97,11 +98,6 @@ export function formatDiagnostics(diags: ts.Diagnostic[]): string {
 }
 
 /** @return true if node has the specified modifier flag set. */
-export function hasModifierFlag(node: ts.Node, flag: ts.ModifierFlags): boolean {
-  return (ts.getCombinedModifierFlags(node) & flag) !== 0;
-}
-
-/** @return true if node has the specified modifier flag set. */
 function isAmbient(node: ts.Node): boolean {
   let current: ts.Node|undefined = node;
   while (current) {
@@ -128,10 +124,6 @@ function isValidClosurePropertyName(name: string): boolean {
   // In local experimentation, it appears that reserved words like 'var' and
   // 'if' are legal JS and still accepted by Closure.
   return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name);
-}
-
-export function isDtsFileName(fileName: string): boolean {
-  return /\.d\.ts$/.test(fileName);
 }
 
 /** Returns the Closure name of a function parameter, special-casing destructuring. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -53,3 +53,12 @@ export function createSourceReplacingCompilerHost(
 export function normalizeLineEndings(input: string): string {
   return input.replace(/\r\n/g, '\n');
 }
+
+/** @return true if node has the specified modifier flag set. */
+export function hasModifierFlag(node: ts.Node, flag: ts.ModifierFlags): boolean {
+  return (ts.getCombinedModifierFlags(node) & flag) !== 0;
+}
+
+export function isDtsFileName(fileName: string): boolean {
+  return /\.d\.ts$/.test(fileName);
+}


### PR DESCRIPTION
This commit fixes the cyclic dependencies caused by `hasModifierFlag`
and `isDtsFileName` methods in `tsickle` by moving them to `util`.