### PR TITLE
Fix support for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "source-map-support": "^0.4.2",
     "typescript": "~2.5.3"
   },
+  "peerDependencies": {
+    "typescript": "~2.5.3"
+  },
   "devDependencies": {
     "@bazel/typescript": "^0.3.1",
     "@types/chai": "^3.4.32",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "merge2": "^1.0.2",
     "mocha": "^3.2.0",
     "temp": "^0.8.1",
-    "tslint": "^5.4.2",
-    "typescript": "~2.5.3"
+    "tslint": "^5.4.2"
   },
   "scripts": {
     "prepublish": "bazel build ...",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,8 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "source-map": "^0.5.6",
-    "source-map-support": "^0.4.2"
-  },
-  "peerDependencies": {
-    "typescript": "2.5.3"
+    "source-map-support": "^0.4.2",
+    "typescript": "~2.5.3"
   },
   "devDependencies": {
     "@bazel/typescript": "^0.3.1",


### PR DESCRIPTION
With npm 3+ deps in peerDependencies are not installed automatically and installing tsickle is complaining with

npm WARN tsickle@0.23.6 requires a peer of typescript@2.3.4 but none is installed. You must install peer dependencies yourself.

I think this may be causing https://bugs.chromium.org/p/gerrit/issues/detail?id=7630

By putting it in dependencies and peerDependencies it will not complain any more.