### PR TITLE
Fix e2e tests and support PromiseLike

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/minimatch": "^2.0.28",
     "@types/minimist": "^1.1.28",
     "@types/mkdirp": "^0.3.28",
-    "@types/mocha": "^2.2.31",
     "@types/node": "^6.0.38",
     "@types/source-map": "^0.5.1",
     "@types/source-map-support": "^0.2.27",
@@ -46,7 +45,6 @@
     "gulp-typescript": "^3.0.0",
     "jasmine": "~2.8.0",
     "merge2": "^1.0.2",
-    "mocha": "^3.2.0",
     "temp": "^0.8.1",
     "tslint": "^5.4.2",
     "typescript": "~2.5.3"

--- a/src/BUILD
+++ b/src/BUILD
@@ -22,5 +22,6 @@ ts_library(
         "util.ts",
     ],
     deps = [],
+    data = ["closure_externs.js"],
     tsconfig = "//:tsconfig.json",
 )

--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -29,21 +29,35 @@ var HTMLTableHeaderCellElement;
 
 /**
  * Closure's NodeList is parameterized itself, there is no NodeListOf.
- * @typedef {!NodeList}
+ * @constructor
+ * @template T
+ * @extends {NodeList<T>}
  */
 var NodeListOf;
 
 /**
  * Closure models this as a plain Array.
- * @typedef {Array<string>|null}
+ * @typedef {!IArrayLike<string>|null}
  */
 var RegExpExecArray;
 
-/** @typedef {!Array} */
-var ReadonlyArray;
+/**
+ * @record
+ * @template T
+ * @extends {IArrayLike<T>}
+ */
+function ReadonlyArray() {}
 
-/** @typedef {!Map} */
-var ReadonlyMap;
+/**
+ * @constructor
+ * @template K, V
+ * @extends {Map<K, V>}
+ */
+function ReadonlyMap() {}
 
-/** @typedef {!Set} */
-var ReadonlySet;
+/**
+ * @constructor
+ * @template T
+ * @extends {Set<T>}
+ */
+function ReadonlySet() {}

--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -61,3 +61,14 @@ function ReadonlyMap() {}
  * @extends {Set<T>}
  */
 function ReadonlySet() {}
+
+/**
+ * @record
+ * @template T
+ * @extends {IThenable<T>}
+ */
+function PromiseLike() {};
+
+/** @typedef {function(new:Promise)} */
+var PromiseConstructor;
+

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1437,7 +1437,7 @@ class Annotator extends ClosureRewriter {
       }
     }
     if (hasNumber && hasString) {
-      return 'number|string';
+      return '?';  // Closure's new type inference doesn't support enums of unions.
     } else if (hasNumber) {
       return 'number';
     } else if (hasString) {

--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -141,8 +141,8 @@ export class TypeTranslator {
    * @param pathBlackList is a set of paths that should never get typed;
    *     any reference to symbols defined in these paths should by typed
    *     as {?}.
-   * @param symbolsToPrefix a mapping from symbols (`Foo`) to a prefix they should be emitted with
-   *     (`tsickle_import.Foo`).
+   * @param symbolsToAliasedNames a mapping from symbols (`Foo`) to a name in scope they should be
+   *     emitted as (e.g. `tsickle_forward_declare_1.Foo`).
    */
   constructor(
       private readonly typeChecker: ts.TypeChecker, private readonly node: ts.Node,

--- a/test/e2e_clutz_dts_test.ts
+++ b/test/e2e_clutz_dts_test.ts
@@ -19,7 +19,7 @@ import {compileWithTransfromer, createProgram, goldenTests} from './test_support
 
 describe('clutz dts', () => {
   it('produces a valid .d.ts', () => {
-    const tests = goldenTests().filter(t => /\.declaration\b/.test(t.name));
+    const tests = goldenTests().filter(t => t.isDeclarationTest);
 
     const dtsSources = new Map<string, string>();
 

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -20,8 +20,8 @@ export function checkClosureCompile(
   const CLOSURE_COMPILER_OPTS: closure.CompileOptions = {
     'checks_only': true,
     'jscomp_error': 'checkTypes',
-    // TODO(martinprobst): enable when NTI is ready. Currently doesn't support enum union types.
-    // 'new_type_inf': true,
+    // NTI enabled mostly to get more precise errors on template type instantiation.
+    'new_type_inf': true,
     'warning_level': 'VERBOSE',
     'js': jsFiles,
     'externs': externsFiles,

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -49,5 +49,5 @@ describe('golden file tests', () => {
     goldenJs.push('test_files/import_from_goog/closure_OtherModule.js');
     const externs = tests.map(t => t.externsPath).filter(fs.existsSync);
     checkClosureCompile(goldenJs, externs, done);
-  });
+  }, 15000 /* ms timeout */);
 });

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -11,8 +11,7 @@ import * as closure from 'google-closure-compiler';
 
 import {goldenTests} from './test_support';
 
-export function checkClosureCompile(
-    jsFiles: string[], externsFiles: string[], done: DoneFn) {
+export function checkClosureCompile(jsFiles: string[], externsFiles: string[], done: DoneFn) {
   const startTime = Date.now();
   const total = jsFiles.length;
   if (!total) throw new Error('No JS files in ' + JSON.stringify(jsFiles));
@@ -32,8 +31,8 @@ export function checkClosureCompile(
   const compiler = new closure.compiler(CLOSURE_COMPILER_OPTS);
   compiler.run((exitCode, stdout, stderr) => {
     console.log('Closure compilation:', total, 'done after', Date.now() - startTime, 'ms');
-      expect(exitCode).toBe(0, stderr);
-      done();
+    expect(exitCode).toBe(0, stderr);
+    done();
   });
 }
 

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -152,8 +152,8 @@ testFn('golden tests with transformer', () => {
         convertIndexImportShorthand: true,
         transformDecorators: true,
         transformTypesToClosure: true,
-        addDtsClutzAliases: /\.declaration\b/.test(test.name),
-        untyped: /\.untyped\b/.test(test.name),
+        addDtsClutzAliases: test.isDeclarationTest,
+        untyped: test.isUntypedTest,
         logWarning: (diag: ts.Diagnostic) => {
           let diags = diagnosticsByFile.get(diag.file!.fileName);
           if (!diags) {
@@ -187,11 +187,10 @@ testFn('golden tests with transformer', () => {
               Array.from(tsSources.keys())}`);
         }
       }
-      const isDeclarationTest = /\.declaration\b/.test(test.name);
       const {diagnostics, externs} = tsickle.emitWithTsickle(
           program, transformerHost, tsHost, tsCompilerOptions, targetSource,
           (fileName: string, data: string) => {
-            if (isDeclarationTest) {
+            if (test.isDeclarationTest) {
               // Only compare .d.ts files for declaration tests.
               if (!fileName.endsWith('.d.ts')) return;
             } else {
@@ -203,7 +202,7 @@ testFn('golden tests with transformer', () => {
             // we only care about the .d.ts files
             tscOutput[fileName] = data;
           });
-      if (!isDeclarationTest) {
+      if (!test.isDeclarationTest) {
         const sortedPaths = test.jsPaths.sort();
         const actualPaths = Object.keys(tscOutput).map(p => p.replace(/^\.\//, '')).sort();
         expect(sortedPaths).to.eql(actualPaths, `${test.jsPaths} vs ${actualPaths}`);

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -173,6 +173,14 @@ export class GoldenFileTest {
         .map(f => path.join(this.path, GoldenFileTest.tsPathToJs(f)));
   }
 
+  get isDeclarationTest(): boolean {
+    return /\.declaration\b/.test(this.name);
+  }
+
+  get isUntypedTest(): boolean {
+    return /\.untyped\b/.test(this.name);
+  }
+
   /**
    * Find the absolute path to the tsickle root directory by reading the
    * symlink bazel puts into bazel-bin back into the test_files directory

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -76,7 +76,7 @@ const StringEnum = {
     STR: 'abc',
     OTHER_STR: 'xyz',
 };
-/** @enum {number|string} */
+/** @enum {?} */
 const MixedEnum = {
     STR: 'abc',
     NUM: 3,

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,0 +1,11 @@
+goog.module('test_files.promiseconstructor.promiseconstructor');var module = module || {id: 'test_files/promiseconstructor/promiseconstructor.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+/**
+ * @param {(undefined|!PromiseConstructor)=} promiseCtor
+ * @return {!Promise<void>}
+ */
+function f(promiseCtor) {
+    return promiseCtor ? new promiseCtor((res, rej) => res()) : Promise.resolve();
+}

--- a/test_files/promiseconstructor/promiseconstructor.ts
+++ b/test_files/promiseconstructor/promiseconstructor.ts
@@ -1,0 +1,6 @@
+// typeof Promise actually resolves to "PromiseConstructor" in TypeScript, which
+// is a type that doesn't exist in Closure's type world. This code passes the
+// e2e test because closure_externs.js declares PromiseConstructor.
+function f(promiseCtor?: typeof Promise): Promise<void> {
+  return promiseCtor ? new promiseCtor((res, rej) => res()) : Promise.resolve();
+}

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,0 +1,5 @@
+goog.module('test_files.promiselike.promiselike');var module = module || {id: 'test_files/promiselike/promiselike.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+let /** @type {!PromiseLike<string>} */ promiseLikeOfString;

--- a/test_files/promiselike/promiselike.ts
+++ b/test_files/promiselike/promiselike.ts
@@ -1,0 +1,1 @@
+let promiseLikeOfString: PromiseLike<string>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "lib": ["es5", "es6", "es2015.collection", "es2015.iterable", "dom"],
     "jsx": "react",
-    "types": ["node", "mocha", "jasmine"],
+    "types": ["node", "jasmine"],
     "downlevelIteration": true,
 
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,6 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
-"@types/mocha@^2.2.31":
-  version "2.2.43"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"
-
 "@types/node@*", "@types/node@^6.0.38":
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
@@ -159,10 +155,6 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-
 bytebuffer@~5:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
@@ -248,7 +240,7 @@ colour@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
 
-commander@2.9.0, commander@^2.9.0:
+commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -276,12 +268,6 @@ dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -307,10 +293,6 @@ detect-file@^0.1.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
   dependencies:
     fs-exists-sync "^0.1.0"
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^2.0.2, diff@^2.2.1:
   version "2.2.3"
@@ -388,7 +370,7 @@ es6-weak-map@^2.0.2:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -601,17 +583,6 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^4.3.1:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
@@ -705,10 +676,6 @@ graceful-fs@~1.2.0:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 gulp-clang-format@^1.0.22:
   version "1.0.23"
@@ -812,19 +779,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
   dependencies:
     sparkles "^1.0.0"
-
-he@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -1012,10 +971,6 @@ json-stable-stringify@^1.0.0:
   dependencies:
     jsonify "~0.0.0"
 
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -1058,20 +1013,9 @@ liftoff@^2.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
 lodash._basetostring@^3.0.0:
   version "3.0.1"
@@ -1104,14 +1048,6 @@ lodash._reinterpolate@^3.0.0:
 lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.escape@^3.0.0:
   version "3.2.0"
@@ -1247,7 +1183,7 @@ micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1274,32 +1210,11 @@ minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-mocha@^3.2.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
-    he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
-    mkdirp "0.5.1"
-    supports-color "3.1.2"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 multipipe@^0.1.2:
   version "0.1.2"
@@ -1668,12 +1583,6 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We accidentally disabled error checking of our E2E tests in #623. This restores the test case, and fixes a number of issues that have crept in.

Some of those problems were in the code even before accidentally disabling the tests, but only exposed when running with `--new_type_inf` (Closure's New Type Inference). The recurring pattern here is that Closure does not actually allow `typedef` aliases of types with generic type arguments.

This also adds support for PromiseLike and PromiseConstructor in our `closure_externs.js`.