### PR TITLE
Avoid emitting unsupported template parameters 

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1391,6 +1391,8 @@ class Annotator extends ClosureRewriter {
     // TypeScript drops exports that are never assigned to (and Closure
     // requires us to not assign to typedef exports).  Instead, emit the
     // "exports.foo;" line directly in that case.
+    this.newTypeTranslator(node).blacklistTypeParameters(node.typeParameters);
+
     this.emit(`\n/** @typedef {${this.typeToClosure(node)}} */\n`);
     if (hasModifierFlag(node, ts.ModifierFlags.Export)) {
       this.emit('exports.');

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -750,7 +750,8 @@ class Annotator extends ClosureRewriter {
         }
 
         this.emitFunctionType([fnDecl], tags);
-        this.newTypeTranslator(fnDecl).blacklistTypeParameters(fnDecl.typeParameters);
+        this.newTypeTranslator(fnDecl).blacklistTypeParameters(
+            this.symbolsToAliasedNames, fnDecl.typeParameters);
         this.writeNodeFrom(fnDecl, fnDecl.getStart());
         return true;
       case ts.SyntaxKind.TypeAliasDeclaration:
@@ -1392,7 +1393,8 @@ class Annotator extends ClosureRewriter {
     // TypeScript drops exports that are never assigned to (and Closure
     // requires us to not assign to typedef exports).  Instead, emit the
     // "exports.foo;" line directly in that case.
-    this.newTypeTranslator(node).blacklistTypeParameters(node.typeParameters);
+    this.newTypeTranslator(node).blacklistTypeParameters(
+        this.symbolsToAliasedNames, node.typeParameters);
 
     this.emit(`\n/** @typedef {${this.typeToClosure(node)}} */\n`);
     if (hasModifierFlag(node, ts.ModifierFlags.Export)) {

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -750,6 +750,7 @@ class Annotator extends ClosureRewriter {
         }
 
         this.emitFunctionType([fnDecl], tags);
+        this.newTypeTranslator(fnDecl).blacklistTypeParameters(fnDecl.typeParameters);
         this.writeNodeFrom(fnDecl, fnDecl.getStart());
         return true;
       case ts.SyntaxKind.TypeAliasDeclaration:

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -12,6 +12,8 @@ import * as closure from 'google-closure-compiler';
 import {goldenTests} from './test_support';
 
 export function checkClosureCompile(useNewTypeInferece: boolean, done: DoneFn) {
+  const ntiOtiMsg = useNewTypeInferece ? '(New Type Inference)' : '(Old Type Inference)';
+
   // Declaration tests do not produce .js files.
   const tests = goldenTests().filter(t => !t.isDeclarationTest);
   const goldenJs = ([] as string[]).concat(...tests.map(t => t.jsPaths));
@@ -40,17 +42,17 @@ export function checkClosureCompile(useNewTypeInferece: boolean, done: DoneFn) {
 
   const compiler = new closure.compiler(CLOSURE_COMPILER_OPTS);
   compiler.run((exitCode, stdout, stderr) => {
-    console.log('Closure compilation:', total, 'done after', Date.now() - startTime, 'ms');
+    const durationMs = Date.now() - startTime;
+    console.error(
+        'Closure compilation', ntiOtiMsg, 'of', total, 'files done after', durationMs, 'ms');
     expect(exitCode).toBe(0, stderr);
     done();
   });
 }
 
 describe('golden file tests', () => {
-  it('compile with Closure (New Type Inference)', (done) => {
+  it('compile with Closure', (done) => {
     checkClosureCompile(true /* NTI */, done);
-  }, 30000 /* ms timeout */);
-  it('compile with Closure (Old Type Inference)', (done) => {
     checkClosureCompile(false /* OTI */, done);
   }, 30000 /* ms timeout */);
 });

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -49,8 +49,8 @@ export function checkClosureCompile(useNewTypeInferece: boolean, done: DoneFn) {
 describe('golden file tests', () => {
   it('compile with Closure (New Type Inference)', (done) => {
     checkClosureCompile(true /* NTI */, done);
-  }, 15000 /* ms timeout */);
+  }, 30000 /* ms timeout */);
   it('compile with Closure (Old Type Inference)', (done) => {
     checkClosureCompile(false /* OTI */, done);
-  }, 15000 /* ms timeout */);
+  }, 30000 /* ms timeout */);
 });

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,0 +1,9 @@
+goog.module('test_files.generic_fn_type.generic_fn_type');var module = module || {id: 'test_files/generic_fn_type/generic_fn_type.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+/**
+ * A function type that includes a generic type argument. Unsupported by
+ * Closure, so tsickle should emit ?.
+ */
+let /** @type {function(?): ?} */ genericFnType = (x) => x;

--- a/test_files/generic_fn_type/generic_fn_type.ts
+++ b/test_files/generic_fn_type/generic_fn_type.ts
@@ -1,0 +1,5 @@
+/**
+ * A function type that includes a generic type argument. Unsupported by
+ * Closure, so tsickle should emit ?.
+ */
+let genericFnType: <T>(t: T)=> T = (x) => x;

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,0 +1,31 @@
+goog.module('test_files.generic_local_var.generic_local_var');var module = module || {id: 'test_files/generic_local_var/generic_local_var.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+/**
+ * @template T
+ */
+class Container {
+    /**
+     * @param {T} tField
+     */
+    constructor(tField) {
+        this.tField = tField;
+    }
+    /**
+     * @template U
+     * @param {U} u
+     * @return {void}
+     */
+    method(u) {
+        const /** @type {T} */ myT = this.tField;
+        // Closure Compiler's Old Type Inference does not support using generic
+        // method parameters as local symbols, so myU must be emitted as ?.
+        const /** @type {?} */ myU = u;
+        console.log(myT, myU);
+    }
+}
+function Container_tsickle_Closure_declarations() {
+    /** @type {T} */
+    Container.prototype.tField;
+}

--- a/test_files/generic_local_var/generic_local_var.ts
+++ b/test_files/generic_local_var/generic_local_var.ts
@@ -1,0 +1,11 @@
+
+class Container<T> {
+  constructor(private tField: T) {}
+  method<U>(u: U) {
+    const myT: T = this.tField;
+    // Closure Compiler's Old Type Inference does not support using generic
+    // method parameters as local symbols, so myU must be emitted as ?.
+    const myU: U = u;
+    console.log(myT, myU);
+  }
+}

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,0 +1,6 @@
+goog.module('test_files.generic_type_alias.generic_type_alias');var module = module || {id: 'test_files/generic_type_alias/generic_type_alias.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+/** @typedef {!Array<?>} */
+var MyList;

--- a/test_files/generic_type_alias/generic_type_alias.ts
+++ b/test_files/generic_type_alias/generic_type_alias.ts
@@ -1,0 +1,5 @@
+/**
+ * A type alias including a generic type parameter. Unsupported by Closure, so
+ * tsickle emits <?>.
+ */
+type MyList<T> = T[];


### PR DESCRIPTION
Closure restricts the locations where template parameters can be used. Curiously this also depends on the version of the type checker in use, so we have to run our test suite for both.