### PR TITLE
Only resolve aliases when emitting typedefs.

### DIFF
--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -32,6 +32,13 @@ function isClosureProvidedType(symbol: ts.Symbol): boolean {
 export function typeToDebugString(type: ts.Type): string {
   let debugString = `flags:0x${type.flags.toString(16)}`;
 
+  if (type.aliasSymbol) {
+    debugString += ` alias:${symbolToDebugString(type.aliasSymbol)}`;
+  }
+  if (type.aliasTypeArguments) {
+    debugString += ` aliasArgs:<${type.aliasTypeArguments.map(typeToDebugString).join(',')}>`;
+  }
+
   // Just the unique flags (powers of two). Declared in src/compiler/types.ts.
   const basicTypes: ts.TypeFlags[] = [
     ts.TypeFlags.Any,           ts.TypeFlags.String,         ts.TypeFlags.Number,

--- a/test_files/export/export_helper_2.ts
+++ b/test_files/export/export_helper_2.ts
@@ -13,7 +13,7 @@ export const enum ConstEnum {
 
 export declare type DeclaredType = {
   a: number
-}
+};
 
 export declare interface DeclaredInterface {
   a: number;

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,0 +1,8 @@
+goog.module('test_files.import_prefixed.exporter');var module = module || {id: 'test_files/import_prefixed/exporter.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+
+exports.valueExport = 1;
+/** @typedef {(string|number)} */
+exports.TypeExport;

--- a/test_files/import_prefixed/exporter.ts
+++ b/test_files/import_prefixed/exporter.ts
@@ -1,0 +1,2 @@
+export const valueExport = 1;
+export type TypeExport = string|number;

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,0 +1,11 @@
+goog.module('test_files.import_prefixed.import_prefixed_mixed');var module = module || {id: 'test_files/import_prefixed/import_prefixed_mixed.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+// This file imports exporter with a prefix import (* as ...), and then uses the
+// import in a type and in a value position.
+
+var exporter = goog.require('test_files.import_prefixed.exporter');
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
+let /** @type {tsickle_forward_declare_1.TypeExport} */ someVar;
+console.log(exporter.valueExport);

--- a/test_files/import_prefixed/import_prefixed_mixed.ts
+++ b/test_files/import_prefixed/import_prefixed_mixed.ts
@@ -1,0 +1,7 @@
+// This file imports exporter with a prefix import (* as ...), and then uses the
+// import in a type and in a value position.
+
+import * as exporter from './exporter';
+
+let someVar: exporter.TypeExport;
+console.log(exporter.valueExport);

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,0 +1,12 @@
+goog.module('test_files.import_prefixed.import_prefixed_types');var module = module || {id: 'test_files/import_prefixed/import_prefixed_types.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+// This file imports exporter with a prefix import (* as ...), and then only
+// uses the import in a type position.
+// tsickle emits a goog.forwardDeclare for the type and uses it to refer to the
+// type TypeExport.
+
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
+const /** @type {tsickle_forward_declare_1.TypeExport} */ someVar = 1;
+console.log(someVar);

--- a/test_files/import_prefixed/import_prefixed_types.ts
+++ b/test_files/import_prefixed/import_prefixed_types.ts
@@ -1,0 +1,9 @@
+// This file imports exporter with a prefix import (* as ...), and then only
+// uses the import in a type position.
+// tsickle emits a goog.forwardDeclare for the type and uses it to refer to the
+// type TypeExport.
+
+import * as exporter from './exporter';
+
+const someVar: exporter.TypeExport = 1;
+console.log(someVar);

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -1,4 +1,23 @@
 // Warning at test_files/jsdoc/jsdoc.ts:44:3: unhandled anonymous type
+// Warning at test_files/jsdoc/jsdoc.ts:16:1: the type annotation on @param is redundant with its TypeScript type, remove the {...} part
+// Warning at test_files/jsdoc/jsdoc.ts:35:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
+// Warning at test_files/jsdoc/jsdoc.ts:40:3: @type annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:43:3: @enum annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:46:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+// Warning at test_files/jsdoc/jsdoc.ts:49:3: @typedef annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:35:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
+// Warning at test_files/jsdoc/jsdoc.ts:40:3: @type annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:43:3: @enum annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:46:3: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
+// Warning at test_files/jsdoc/jsdoc.ts:49:3: @typedef annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:53:1: @template annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:56:1: use index signatures (`[k: string]: type`) instead of @dict
+// Warning at test_files/jsdoc/jsdoc.ts:59:1: @lends annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:65:1: @this annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:68:1: @interface annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:77:1: @extends annotations are redundant with TypeScript equivalents
+// @implements annotations are redundant with TypeScript equivalents
+// Warning at test_files/jsdoc/jsdoc.ts:84:3: @constructor annotations are redundant with TypeScript equivalents
 goog.module('test_files.jsdoc.jsdoc');var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -8,28 +8,29 @@ goog.module('test_files.jsdoc_types.jsdoc_types');var module = module || {id: 't
  */
 
 var module1 = goog.require('test_files.jsdoc_types.module1');
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module1");
 var module2_1 = goog.require('test_files.jsdoc_types.module2');
-const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module2");
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.module2");
 var default_1 = goog.require('test_files.jsdoc_types.default');
-const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.default");
-const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
+const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.default");
+const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
 goog.require("test_files.jsdoc_types.nevertyped"); // force type-only module to be loaded
 // Check that imported types get the proper names in JSDoc.
-let /** @type {!module1.Class} */ useNamespacedClass = new module1.Class();
-let /** @type {!module1.Class} */ useNamespacedClassAsType;
-let /** @type {!module1.Interface} */ useNamespacedType;
+let /** @type {!tsickle_forward_declare_1.Class} */ useNamespacedClass = new module1.Class();
+let /** @type {!tsickle_forward_declare_1.Class} */ useNamespacedClassAsType;
+let /** @type {!tsickle_forward_declare_1.Interface} */ useNamespacedType;
 // Should be references to the symbols in module2, perhaps via locals.
-let /** @type {!tsickle_forward_declare_1.ClassOne} */ useLocalClass = new module2_1.ClassOne();
-let /** @type {!tsickle_forward_declare_1.ClassOne} */ useLocalClassRenamed = new module2_1.ClassOne();
-let /** @type {!tsickle_forward_declare_1.ClassTwo} */ useLocalClassRenamedTwo = new module2_1.ClassTwo();
-let /** @type {!tsickle_forward_declare_1.ClassOne} */ useLocalClassAsTypeRenamed;
-let /** @type {!tsickle_forward_declare_1.Interface} */ useLocalInterface;
-let /** @type {!tsickle_forward_declare_1.ClassWithParams<number>} */ useClassWithParams;
+let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClass = new module2_1.ClassOne();
+let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClassRenamed = new module2_1.ClassOne();
+let /** @type {!tsickle_forward_declare_2.ClassTwo} */ useLocalClassRenamedTwo = new module2_1.ClassTwo();
+let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClassAsTypeRenamed;
+let /** @type {!tsickle_forward_declare_2.Interface} */ useLocalInterface;
+let /** @type {!tsickle_forward_declare_2.ClassWithParams<number>} */ useClassWithParams;
 // This is purely a value; it doesn't need renaming.
 let /** @type {number} */ useLocalValue = module2_1.value;
 // Check a default import.
-let /** @type {!tsickle_forward_declare_2.default} */ useDefaultClass = new default_1.default();
-let /** @type {!tsickle_forward_declare_2.default} */ useDefaultClassAsType;
+let /** @type {!tsickle_forward_declare_3.default} */ useDefaultClass = new default_1.default();
+let /** @type {!tsickle_forward_declare_3.default} */ useDefaultClassAsType;
 // NeverTyped should be {?}, even in typed mode.
 let /** @type {?} */ useNeverTyped;
 let /** @type {(string|?)} */ useNeverTyped2;

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,0 +1,21 @@
+goog.module('test_files.type_alias_imported.type_alias_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_exporter.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+
+class X {
+}
+exports.X = X;
+function X_tsickle_Closure_declarations() {
+    /** @type {string} */
+    X.prototype.x;
+}
+class Y {
+}
+exports.Y = Y;
+function Y_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Y.prototype.x;
+}
+/** @typedef {(!X|!Y)} */
+exports.XY;

--- a/test_files/type_alias_imported/type_alias_exporter.ts
+++ b/test_files/type_alias_imported/type_alias_exporter.ts
@@ -1,0 +1,7 @@
+export class X { private x: string; }
+export class Y { private x: string; }
+// Export a type alias that references types from this file that, in turn, are
+// not imported at the use site in type_alias_imported. This is a regression
+// test for a bug where tsickle would accidentally inline the union type "X|Y"
+// instead of emitting the alias "XY" at the use site.
+export type XY = X|Y;

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,0 +1,7 @@
+goog.module('test_files.type_alias_imported.type_alias_imported');var module = module || {id: 'test_files/type_alias_imported/type_alias_imported.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
+let /** @type {tsickle_forward_declare_1.XY} */ xy;

--- a/test_files/type_alias_imported/type_alias_imported.ts
+++ b/test_files/type_alias_imported/type_alias_imported.ts
@@ -1,0 +1,3 @@
+import {XY} from './type_alias_exporter';
+
+let xy: XY;

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -7,13 +7,14 @@ goog.module('test_files.type_and_value.type_and_value');var module = module || {
  */
 
 var conflict = goog.require('test_files.type_and_value.module');
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_and_value.module");
 // This test deals with symbols that are simultaneously types and values.
 // Use a browser built-in as both a type and a value.
 let /** @type {function(new: (!Document)): ?} */ useBuiltInAsValue = Document;
 let /** @type {!Document} */ useBuiltInAsType;
 // Use a user-defined class as both a type and a value.
 let /** @type {?} */ useUserClassAsValue = conflict.Class;
-let /** @type {!conflict.Class} */ useUserClassAsType;
+let /** @type {!tsickle_forward_declare_1.Class} */ useUserClassAsType;
 // Use a user-defined interface/value pair as both a type and a value.
 let /** @type {number} */ useAsValue = conflict.TypeAndValue;
 // Note: because of the conflict, we currently just use the type {?} here.


### PR DESCRIPTION
This is based on PR #654, please only review the last commit.