### PR TITLE
forward declare symbols not in the local scope.

### DIFF
--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -349,7 +349,7 @@ class DecoratorRewriter extends Rewriter {
   private importedNames: Array<{name: ts.Identifier, declarationNames: ts.Identifier[]}> = [];
 
   constructor(
-      private typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile, sourceMapper?: SourceMapper) {
+      private typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile, sourceMapper: SourceMapper) {
     super(sourceFile, sourceMapper);
   }
 
@@ -464,6 +464,6 @@ export function visitClassContentIncludingDecorators(
 
 export function convertDecorators(
     typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile,
-    sourceMapper?: SourceMapper): {output: string, diagnostics: ts.Diagnostic[]} {
+    sourceMapper: SourceMapper): {output: string, diagnostics: ts.Diagnostic[]} {
   return new DecoratorRewriter(typeChecker, sourceFile, sourceMapper).process();
 }

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -40,7 +40,9 @@ export abstract class Rewriter {
     }
     let out = this.output.join('');
     if (prefix) {
-      out = prefix + out;
+      // Insert prefix after any leading trivia so that @fileoverview comments do not get broken.
+      const firstCode = this.file.getStart();
+      out = out.substring(0, firstCode) + prefix + out.substring(firstCode);
       this.sourceMapper.shiftByOffset(prefix.length);
     }
     return {
@@ -184,7 +186,7 @@ export abstract class Rewriter {
 
   error(node: ts.Node, messageText: string) {
     this.diagnostics.push({
-      file: this.file,
+      file: node.getSourceFile(),
       start: node.getStart(),
       length: node.getEnd() - node.getStart(),
       messageText,

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -34,12 +34,17 @@ export abstract class Rewriter {
   constructor(public file: ts.SourceFile, private sourceMapper: SourceMapper = NOOP_SOURCE_MAPPER) {
   }
 
-  getOutput(): {output: string, diagnostics: ts.Diagnostic[]} {
+  getOutput(prefix?: string): {output: string, diagnostics: ts.Diagnostic[]} {
     if (this.indent !== 0) {
       throw new Error('visit() failed to track nesting');
     }
+    let out = this.output.join('');
+    if (prefix) {
+      out = prefix + out;
+      this.sourceMapper.shiftByOffset(prefix.length);
+    }
     return {
-      output: this.output.join(''),
+      output: out,
       diagnostics: this.diagnostics,
     };
   }

--- a/src/transformer_sourcemap.ts
+++ b/src/transformer_sourcemap.ts
@@ -11,17 +11,25 @@ import {isTypeNodeKind, updateSourceFileNode, visitNodeWithSynthesizedComments} 
 import * as ts from './typescript';
 
 /**
- * @fileoverview Creates a TypeScript transformer that parses code into a new `ts.SourceFile`,
- * marks the nodes as synthetic and where possible maps the new nodes back to the original nodes
- * via sourcemap information.
+ * Creates a TypeScript transformer based on a source->text transformation.
+ *
+ * TypeScript transformers operate on AST nodes. Newly created nodes must be marked as replacing an
+ * older AST node. This shim allows running a transformation step that's based on emitting new text
+ * as a node based transformer. It achieves that by running the transformation, collecting a source
+ * mapping in the process, and then afterwards parsing the source text into a new AST and marking
+ * the new nodes as representations of the old nodes based on their source map positions.
+ *
+ * The process marks all nodes as synthesized except for a handful of special cases (identifiers
+ * etc).
  */
 export function createTransformerFromSourceMap(
-    operator: (sourceFile: ts.SourceFile, sourceMapper: SourceMapper) =>
+    sourceBasedTransformer: (sourceFile: ts.SourceFile, sourceMapper: SourceMapper) =>
         string): ts.TransformerFactory<ts.SourceFile> {
   return (context) => (sourceFile) => {
     const sourceMapper = new NodeSourceMapper();
+    const transformedSourceText = sourceBasedTransformer(sourceFile, sourceMapper);
     const newFile = ts.createSourceFile(
-        sourceFile.fileName, operator(sourceFile, sourceMapper), ts.ScriptTarget.Latest, true);
+        sourceFile.fileName, transformedSourceText, ts.ScriptTarget.Latest, true);
     const mappedFile = visitNode(newFile);
     return updateSourceFileNode(sourceFile, mappedFile.statements);
 
@@ -92,6 +100,8 @@ export function createTransformerFromSourceMap(
 class NodeSourceMapper implements SourceMapper {
   private originalNodeByGeneratedRange = new Map<string, ts.Node>();
   private genStartPositions = new Map<ts.Node, number>();
+  /** Conceptual offset for all nodes in this mapping. */
+  private offset = 0;
 
   private addFullNodeRange(node: ts.Node, genStartPos: number) {
     this.originalNodeByGeneratedRange.set(
@@ -99,6 +109,10 @@ class NodeSourceMapper implements SourceMapper {
         node);
     node.forEachChild(
         child => this.addFullNodeRange(child, genStartPos + (child.getStart() - node.getStart())));
+  }
+
+  shiftByOffset(offset: number) {
+    this.offset += offset;
   }
 
   addMapping(
@@ -128,9 +142,24 @@ class NodeSourceMapper implements SourceMapper {
     });
   }
 
+  /** For the newly parsed `node`, find what node corresponded to it in the original source text. */
   getOriginalNode(node: ts.Node): ts.Node|undefined {
-    return this.originalNodeByGeneratedRange.get(
-        this.nodeCacheKey(node.kind, node.getStart(), node.getEnd()));
+    // Apply the offset: if there is an offset > 0, all nodes are conceptually shifted by so many
+    // characters from the start of the file.
+    let start = node.getStart() - this.offset;
+    if (start < 0) {
+      // Special case: the source file conceptually spans all of the file, including any added
+      // prefix added that causes offset to be set.
+      if (node.kind !== ts.SyntaxKind.SourceFile) {
+        // Nodes within [0, offset] of the new file (start < 0) is the additional prefix that has no
+        // corresponding nodes in the original source, so return undefined.
+        return undefined;
+      }
+      start = 0;
+    }
+    const end = node.getEnd() - this.offset;
+    const key = this.nodeCacheKey(node.kind, start, end);
+    return this.originalNodeByGeneratedRange.get(key);
   }
 
   private nodeCacheKey(kind: ts.SyntaxKind, start: number, end: number): string {

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -13,7 +13,6 @@ import {SourceMapConsumer} from 'source-map';
 import * as ts from 'typescript';
 
 import * as cliSupport from '../src/cli_support';
-import {DefaultSourceMapper} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
 
 import {createAstPrintingTransform} from './ast_printing_transform';

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -9,5 +9,5 @@ const tsickle_forward_declare_2 = goog.forwardDeclare("some.other");
 goog.require("some.other"); // force type-only module to be loaded
 let /** @type {!tsickle_forward_declare_1.ClutzedClass} */ clutzedClass = new goog_some_name_space_1.ClutzedClass();
 console.log(clutzedClass);
-let /** @type {!some.other.ClutzedInterface} */ typeAliased = clutzedClass.field;
+let /** @type {!tsickle_forward_declare_2.ClutzedInterface} */ typeAliased = clutzedClass.field;
 goog_some_name_space_1.clutzedFn(typeAliased);

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -1,0 +1,6 @@
+goog.module('test_files.type_alias_imported.export_constant');var module = module || {id: 'test_files/type_alias_imported/export_constant.js'};/**
+ * @fileoverview See comments in type_alias_imported.
+ * @suppress {checkTypes} checked by tsc
+ */
+
+exports.SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/export_constant.ts
+++ b/test_files/type_alias_imported/export_constant.ts
@@ -1,0 +1,3 @@
+/** @fileoverview See comments in type_alias_imported. */
+
+export const SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -1,0 +1,15 @@
+goog.module('test_files.type_alias_imported.type_alias_declare');var module = module || {id: 'test_files/type_alias_imported/type_alias_declare.js'};/**
+ *
+ * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
+ * must ultimately be imported by type_alias_imported.
+ *
+ * @suppress {checkTypes} checked by tsc
+ */
+
+class X {
+}
+exports.X = X;
+function X_tsickle_Closure_declarations() {
+    /** @type {string} */
+    X.prototype.x;
+}

--- a/test_files/type_alias_imported/type_alias_declare.ts
+++ b/test_files/type_alias_imported/type_alias_declare.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
+ * must ultimately be imported by type_alias_imported.
+ */
+
+export class X { private x: string; }

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -1,0 +1,14 @@
+goog.module('test_files.type_alias_imported.type_alias_default_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_default_exporter.js'};/**
+ *
+ * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
+ * type reference is created (no .default property).
+ *
+ * @suppress {checkTypes} checked by tsc
+ */
+
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
+class Z {
+}
+exports.Z = Z;
+/** @typedef {(!tsickle_forward_declare_1.X|!Z)} */
+var DefaultExport;

--- a/test_files/type_alias_imported/type_alias_default_exporter.ts
+++ b/test_files/type_alias_imported/type_alias_default_exporter.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
+ * type reference is created (no .default property).
+ */
+
+import {X} from './type_alias_declare';
+
+export class Z {}
+
+type DefaultExport = X|Z;
+export default DefaultExport;

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -3,19 +3,9 @@ goog.module('test_files.type_alias_imported.type_alias_exporter');var module = m
  * @suppress {checkTypes} checked by tsc
  */
 
-class X {
-}
-exports.X = X;
-function X_tsickle_Closure_declarations() {
-    /** @type {string} */
-    X.prototype.x;
-}
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 class Y {
 }
 exports.Y = Y;
-function Y_tsickle_Closure_declarations() {
-    /** @type {string} */
-    Y.prototype.x;
-}
-/** @typedef {(!X|!Y)} */
+/** @typedef {(!tsickle_forward_declare_1.X|!Y)} */
 exports.XY;

--- a/test_files/type_alias_imported/type_alias_exporter.ts
+++ b/test_files/type_alias_imported/type_alias_exporter.ts
@@ -1,7 +1,8 @@
-export class X { private x: string; }
-export class Y { private x: string; }
+import {X} from './type_alias_declare';
 // Export a type alias that references types from this file that, in turn, are
 // not imported at the use site in type_alias_imported. This is a regression
 // test for a bug where tsickle would accidentally inline the union type "X|Y"
 // instead of emitting the alias "XY" at the use site.
+
+export class Y {}
 export type XY = X|Y;

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,7 +1,21 @@
 goog.module('test_files.type_alias_imported.type_alias_imported');var module = module || {id: 'test_files/type_alias_imported/type_alias_imported.js'};/**
- * @fileoverview added by tsickle
+ * @fileoverview Make sure imports are inserted *after* the fileoverview.
  * @suppress {checkTypes} checked by tsc
  */
 
+const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
-let /** @type {tsickle_forward_declare_1.XY} */ xy;
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_default_exporter");
+var export_constant_1 = goog.require('test_files.type_alias_imported.export_constant');
+const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");
+// The union types below use members from the exporting files that are not
+// explicitly imported into this file. tsickle must emit extra forwardDeclare
+// statements for them.
+let /** @type {tsickle_forward_declare_1.XY} */ usingTypeAlias;
+let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_1.Y)} */ usingTypeAliasInUnion;
+let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_2.Z)} */ usingDefaultExportAlias;
+// The code below reproduces an issue where tsickle would break source maps if it just post-hoc
+// prepended imports to its emit, which in turn would break the references to imported symbols, as
+// tsc would no longer understand these symbols are imported and need to be prefixed with the module
+// type.
+console.log(export_constant_1.SOME_CONSTANT);

--- a/test_files/type_alias_imported/type_alias_imported.ts
+++ b/test_files/type_alias_imported/type_alias_imported.ts
@@ -1,3 +1,20 @@
-import {XY} from './type_alias_exporter';
+/** @fileoverview Make sure imports are inserted *after* the fileoverview. */
 
-let xy: XY;
+import {XY} from './type_alias_exporter';
+import ImportedDefaultExport from './type_alias_default_exporter';
+import {SOME_CONSTANT} from './export_constant';
+
+// The union types below use members from the exporting files that are not
+// explicitly imported into this file. tsickle must emit extra forwardDeclare
+// statements for them.
+
+let usingTypeAlias: XY;
+let usingTypeAliasInUnion: XY|boolean;
+let usingDefaultExportAlias: ImportedDefaultExport|boolean;
+
+// The code below reproduces an issue where tsickle would break source maps if it just post-hoc
+// prepended imports to its emit, which in turn would break the references to imported symbols, as
+// tsc would no longer understand these symbols are imported and need to be prefixed with the module
+// type.
+
+console.log(SOME_CONSTANT);


### PR DESCRIPTION
TypeScript's type checker expands aliases in union types as they are
constructed. This is apparently a design limitation and hard to change
for reasons including performance.

In tsickle, the expanded symbols might however not be available at the
use site, e.g. if a union type is declared in `fileA.ts`, contains
symbols available locally, but then imported in `fileB.ts` where its
constituent types are not available:

    // fileA
    export class LocalType {}
    export type TypeDef = LocalType|number;

    // fileB
    import {TypeDef} from './fileA';
    let useTypeDef: TypeDef|string;

Tsickle would emit `LocalType|number|string` as the type for
`useTypeDef`. This change fixes the issue by ensuring all symbols that
are used have an appropriate forward declare. This turns out to be
easier than mapping back into the original type or trying to emit the
syntactical type.