### PR TITLE
Handle `this: ...` parameters in function types.

### DIFF
--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,0 +1,12 @@
+goog.module('test_files.this_type.this_type');var module = module || {id: 'test_files/this_type/this_type.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+
+class SomeClass {
+}
+function SomeClass_tsickle_Closure_declarations() {
+    /** @type {number} */
+    SomeClass.prototype.x;
+}
+const /** @type {function(this: (!SomeClass), string): number} */ variableWithFunctionTypeUsingThis = () => 1;

--- a/test_files/this_type/this_type.ts
+++ b/test_files/this_type/this_type.ts
@@ -1,0 +1,7 @@
+export {};
+
+class SomeClass {
+  private x: number;
+}
+
+const variableWithFunctionTypeUsingThis: (this: SomeClass, a: string) => number = () => 1;


### PR DESCRIPTION
This is already covered for function declarations (which are handled
separately in tsickle.ts), but wasn't supported yet for declarations of
function types.