### PR TITLE
Separate forward declares with a line break.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1230,7 +1230,7 @@ class Annotator extends ClosureRewriter {
     // here would cause a change in load order, which is observable (and can lead to errors).
     // Instead, goog.forwardDeclare types, which allows using them in type annotations without
     // causing a load. See below for the exception to the rule.
-    let emitText = `\nconst ${forwardDeclarePrefix} = goog.forwardDeclare("${moduleNamespace}");`;
+    let emitText = `const ${forwardDeclarePrefix} = goog.forwardDeclare("${moduleNamespace}");\n`;
 
     // Scripts do not have a symbol. Scripts can still be imported, either as side effect imports or
     // with an empty import set ("{}"). TypeScript does not emit a runtime load for an import with
@@ -1252,7 +1252,7 @@ class Annotator extends ClosureRewriter {
       // This is a heuristic - if the module exports some values, but those are never imported,
       // the file will still end up not being imported. Hopefully modules that export values are
       // imported for their value in some place.
-      emitText += `\ngoog.require("${moduleNamespace}"); // force type-only module to be loaded`;
+      emitText += `goog.require("${moduleNamespace}"); // force type-only module to be loaded\n`;
     }
     for (let sym of exports) {
       if (sym.flags & ts.SymbolFlags.Alias) {

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -6,8 +6,10 @@ goog.module('test_files.type_alias_imported.type_alias_declare');var module = mo
  * @suppress {checkTypes} checked by tsc
  */
 
-class X {
-}
+/**
+ * @record
+ */
+function X() { }
 exports.X = X;
 function X_tsickle_Closure_declarations() {
     /** @type {string} */

--- a/test_files/type_alias_imported/type_alias_declare.ts
+++ b/test_files/type_alias_imported/type_alias_declare.ts
@@ -3,4 +3,4 @@
  * must ultimately be imported by type_alias_imported.
  */
 
-export class X { private x: string; }
+export interface X { x: string; }

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -7,6 +7,7 @@ goog.module('test_files.type_alias_imported.type_alias_default_exporter');var mo
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
+goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Z {
 }
 exports.Z = Z;

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -4,6 +4,7 @@ goog.module('test_files.type_alias_imported.type_alias_exporter');var module = m
  */
 
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
+goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Y {
 }
 exports.Y = Y;

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -4,16 +4,17 @@ goog.module('test_files.type_alias_imported.type_alias_imported');var module = m
  */
 
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
-const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
-const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_default_exporter");
+goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 var export_constant_1 = goog.require('test_files.type_alias_imported.export_constant');
-const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
+const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_default_exporter");
 // The union types below use members from the exporting files that are not
 // explicitly imported into this file. tsickle must emit extra forwardDeclare
 // statements for them.
-let /** @type {tsickle_forward_declare_1.XY} */ usingTypeAlias;
-let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_1.Y)} */ usingTypeAliasInUnion;
-let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_2.Z)} */ usingDefaultExportAlias;
+let /** @type {tsickle_forward_declare_2.XY} */ usingTypeAlias;
+let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_2.Y)} */ usingTypeAliasInUnion;
+let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_3.Z)} */ usingDefaultExportAlias;
 // The code below reproduces an issue where tsickle would break source maps if it just post-hoc
 // prepended imports to its emit, which in turn would break the references to imported symbols, as
 // tsc would no longer understand these symbols are imported and need to be prefixed with the module

--- a/test_files/type_alias_imported/type_alias_imported.ts
+++ b/test_files/type_alias_imported/type_alias_imported.ts
@@ -1,8 +1,8 @@
 /** @fileoverview Make sure imports are inserted *after* the fileoverview. */
 
+import {SOME_CONSTANT} from './export_constant';
 import {XY} from './type_alias_exporter';
 import ImportedDefaultExport from './type_alias_default_exporter';
-import {SOME_CONSTANT} from './export_constant';
 
 // The union types below use members from the exporting files that are not
 // explicitly imported into this file. tsickle must emit extra forwardDeclare


### PR DESCRIPTION
Previously, if a list of imports would end in a trailing force-load of a
type only module, the line comment would effectively strip the next line
of code. This is very rare (people separate their imports and code), but
gets triggered when forward declaring a symbol from a type only module
which gets prepended before all other imports.