### PR TITLE
Treat const enums like types for imports.

### DIFF
--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -5,5 +5,8 @@ goog.module('test_files.import_only_types.import_only_types');var module = modul
 
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_only_types.types_only");
 goog.require("test_files.import_only_types.types_only"); // force type-only module to be loaded
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.import_only_types.types_and_constenum");
+goog.require("test_files.import_only_types.types_and_constenum"); // force type-only module to be loaded
 let /** @type {!tsickle_forward_declare_1.Foo} */ x = { x: 'x' };
-console.log(x);
+let /** @type {!tsickle_forward_declare_2.SomeInterface} */ y = x;
+console.log(y);

--- a/test_files/import_only_types/import_only_types.ts
+++ b/test_files/import_only_types/import_only_types.ts
@@ -1,4 +1,7 @@
 import {Foo} from './types_only';
+// const enums count as types for the purpose of importing.
+import {SomeInterface} from './types_and_constenum';
 
 let x: Foo = {x: 'x'};
-console.log(x);
+let y: SomeInterface = x;
+console.log(y);

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,0 +1,21 @@
+goog.module('test_files.import_only_types.types_and_constenum');var module = module || {id: 'test_files/import_only_types/types_and_constenum.js'};/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+// const enum values are inlined, so even though const enums are values,
+// TypeScript might not generate any imports for them, which means modules
+// containing only types and const enums must be "force loaded".
+
+/** @enum {number} */
+const ConstEnum = {
+    BAR: 0,
+    BAZ: 1,
+};
+exports.ConstEnum = ConstEnum;
+/**
+ * @record
+ */
+function SomeInterface() { }
+exports.SomeInterface = SomeInterface;
+function SomeInterface_tsickle_Closure_declarations() {
+}

--- a/test_files/import_only_types/types_and_constenum.ts
+++ b/test_files/import_only_types/types_and_constenum.ts
@@ -1,0 +1,10 @@
+// const enum values are inlined, so even though const enums are values,
+// TypeScript might not generate any imports for them, which means modules
+// containing only types and const enums must be "force loaded".
+
+export const enum ConstEnum {
+  BAR,
+  BAZ
+}
+
+export interface SomeInterface {}


### PR DESCRIPTION
TypeScript inlines all values of a `const enum` during compilation (if
`preserveConstEnums` is `false`), so that there will never be runtime
imports of the symbol. To avoid the same problems as with modules
defining only types, `const enum`s must therefore be treated like types.

This only affects the import situation, other judgements based on
whether a symbol is a value (such as generating an export) still hold.