### PR TITLE
 Emit goog.module & co after @fileoverview.

### DIFF
--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -18,6 +18,17 @@ const FILEOVERVIEW_COMMENT_MARKERS: ReadonlySet<string> =
     new Set(['fileoverview', 'externs', 'modName', 'mods', 'pintomodule']);
 
 /**
+ * Returns true if the given comment is a \@fileoverview style comment in the Closure sense, i.e. a
+ * comment that has JSDoc tags marking it as a fileoverview comment.
+ * Note that this is different from TypeScript's understanding of the concept, where a file comment
+ * is a comment separated from the rest of the file by a double newline.
+ */
+export function isClosureFileoverviewComment(text: string) {
+  const current = jsdoc.parseContents(text);
+  return current !== null && current.tags.some(t => FILEOVERVIEW_COMMENT_MARKERS.has(t.tagName));
+}
+
+/**
  * A transformer that ensures the emitted JS file has an \@fileoverview comment that contains an
  * \@suppress {checkTypes} annotation by either adding or updating an existing comment.
  */

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -113,8 +113,14 @@ export abstract class Rewriter {
     this.skipCommentsUpToOffset = oldSkipCommentsUpToOffset;
   }
 
-  writeLeadingTrivia(node: ts.Node) {
-    this.writeRange(node, node.getFullStart(), node.getStart());
+  /**
+   * Writes all leading trivia (whitespace or comments) on node, or all trivia up to the given
+   * position. Also marks those trivia as "already emitted" by shifting the skipCommentsUpTo marker.
+   */
+  writeLeadingTrivia(node: ts.Node, upTo = 0) {
+    const upToOffset = upTo || node.getStart();
+    this.writeRange(node, node.getFullStart(), upTo || node.getStart());
+    this.skipCommentsUpToOffset = upToOffset;
   }
 
   addSourceMapping(node: ts.Node) {

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -156,19 +156,31 @@ console.log(this.default);
 console.log(foo.bar.default);`);
   });
 
-  it('inserts the module after "use strict"', () => {
+  it('strips "use strict" (implied by goog.module)', () => {
     expectCommonJs(
         'a/b.js',
         `/**
-* docstring here
-*/
+ * docstring here
+ */
 "use strict";
 var foo = bar;
 `).to.equal(`goog.module('a.b');var module = module || {id: 'a/b.js'};/**
-* docstring here
-*/
+ * docstring here
+ */
 
 var foo = bar;
+`);
+  });
+
+  it('inserts goog.module after fileoverview comments', () => {
+    expectCommonJs('a/b.js', `/**
+ * @fileoverview comment here.
+ */
+var foo = bar;
+`).to.equal(`/**
+ * @fileoverview comment here.
+ */
+goog.module('a.b');var module = module || {id: 'a/b.js'};var foo = bar;
 `);
   });
 

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,8 +1,8 @@
-goog.module('test_files.abstract.abstract');var module = module || {id: 'test_files/abstract/abstract.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.abstract.abstract');var module = module || {id: 'test_files/abstract/abstract.js'};/**
  * @abstract
  */
 class Base {

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,5 +1,5 @@
-goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');var module = module || {id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-var /** @type {?} */ fn3 = (a) => 12;
+goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');var module = module || {id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.js'};var /** @type {?} */ fn3 = (a) => 12;

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,8 +1,8 @@
-goog.module('test_files.arrow_fn.arrow_fn');var module = module || {id: 'test_files/arrow_fn/arrow_fn.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.arrow_fn.arrow_fn');var module = module || {id: 'test_files/arrow_fn/arrow_fn.js'};
 var /** @type {function(number): number} */ fn3 = (a) => 12;
 var /** @type {function(?): ?} */ fn4 = (a) => a + 12;
 exports.fn5 = (a = 10) => a;

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,8 +1,8 @@
-goog.module('test_files.basic.untyped.basic.untyped');var module = module || {id: 'test_files/basic.untyped/basic.untyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.basic.untyped.basic.untyped');var module = module || {id: 'test_files/basic.untyped/basic.untyped.js'};/**
  * @param {?} arg1
  * @return {?}
  */

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,8 +1,8 @@
-goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.class.untyped.class');var module = module || {id: 'test_files/class.untyped/class.js'};/**
  * @record
  */
 function Interface() { }

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,9 +1,9 @@
 // Warning at test_files/class/class.ts:129:1: type/symbol conflict for Zone, using {?} for now
-goog.module('test_files.class.class');var module = module || {id: 'test_files/class/class.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// This test exercises the various ways classes and interfaces can interact.
+goog.module('test_files.class.class');var module = module || {id: 'test_files/class/class.js'};// This test exercises the various ways classes and interfaces can interact.
 // There are three types of classy things:
 //   interface, class, abstract class
 // And there are two keywords for relating them:

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,8 +1,8 @@
-goog.module('test_files.clutz.no_externs.strip_clutz_type');var module = module || {id: 'test_files/clutz.no_externs/strip_clutz_type.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.clutz.no_externs.strip_clutz_type');var module = module || {id: 'test_files/clutz.no_externs/strip_clutz_type.js'};
 var goog_some_name_space_1 = goog.require('some.name.space');
 const tsickle_forward_declare_1 = goog.forwardDeclare("some.name.space");
 const tsickle_forward_declare_2 = goog.forwardDeclare("some.other");

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,8 +1,8 @@
-goog.module('test_files.coerce.coerce');var module = module || {id: 'test_files/coerce/coerce.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.coerce.coerce');var module = module || {id: 'test_files/coerce/coerce.js'};/**
  * @param {string} arg
  * @return {string}
  */

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,8 +1,8 @@
-goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class Comments {
+goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};class Comments {
 }
 function Comments_tsickle_Closure_declarations() {
     /**

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,8 +1,8 @@
-goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {function(new: (!Document)): ?} */ x = Document;
+goog.module('test_files.ctors.ctors');var module = module || {id: 'test_files/ctors/ctors.js'};let /** @type {function(new: (!Document)): ?} */ x = Document;
 class X {
     /**
      * @param {number} a

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -1,6 +1,6 @@
-goog.module('test_files.declare.user');var module = module || {id: 'test_files/declare/user.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {!GlobalClass} */ x;
+goog.module('test_files.declare.user');var module = module || {id: 'test_files/declare/user.js'};let /** @type {!GlobalClass} */ x;
 let /** @type {!globalNamespace.GlobalNamespaced} */ y;

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,4 +1,5 @@
-goog.module('test_files.declare_class_ns.declare_class_ns');var module = module || {id: 'test_files/declare_class_ns/declare_class_ns.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+goog.module('test_files.declare_class_ns.declare_class_ns');var module = module || {id: 'test_files/declare_class_ns/declare_class_ns.js'};

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,4 +1,5 @@
-goog.module('test_files.declare_class_overloads.declare_class_overloads');var module = module || {id: 'test_files/declare_class_overloads/declare_class_overloads.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+goog.module('test_files.declare_class_overloads.declare_class_overloads');var module = module || {id: 'test_files/declare_class_overloads/declare_class_overloads.js'};

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,6 +1,6 @@
-goog.module('test_files.declare_export.untyped.declare_export');var module = module || {id: 'test_files/declare_export.untyped/declare_export.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.declare_export.untyped.declare_export');var module = module || {id: 'test_files/declare_export.untyped/declare_export.js'};
 ;

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,8 +1,8 @@
-goog.module('test_files.declare_export.declare_export');var module = module || {id: 'test_files/declare_export/declare_export.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.declare_export.declare_export');var module = module || {id: 'test_files/declare_export/declare_export.js'};
 /** @typedef {ExportDeclaredIf} */
 exports.ExportDeclaredIf;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,8 +1,8 @@
-goog.module('test_files.decorator.decorator');var module = module || {id: 'test_files/decorator/decorator.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.decorator.decorator');var module = module || {id: 'test_files/decorator/decorator.js'};
 // OtherClass is reachable via the imports for './external' and './external2'.
 // Test that were using it from the right import, and not just the first
 // that allows access to the value. That is important when imports are elided.

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -1,8 +1,8 @@
-goog.module('test_files.decorator.external');var module = module || {id: 'test_files/decorator/external.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.decorator.external');var module = module || {id: 'test_files/decorator/external.js'};
 var external2_1 = goog.require('test_files.decorator.external2');
 exports.ReexportedOtherClass = external2_1.OtherClass;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.decorator.external2");

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -1,8 +1,8 @@
-goog.module('test_files.decorator.external2');var module = module || {id: 'test_files/decorator/external2.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.decorator.external2');var module = module || {id: 'test_files/decorator/external2.js'};
 class OtherClass {
 }
 exports.OtherClass = OtherClass;

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -1,8 +1,8 @@
-goog.module('test_files.decorator_nested_scope.decorator_nested_scope');var module = module || {id: 'test_files/decorator_nested_scope/decorator_nested_scope.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.decorator_nested_scope.decorator_nested_scope');var module = module || {id: 'test_files/decorator_nested_scope/decorator_nested_scope.js'};
 class SomeService {
 }
 /**

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,8 +1,8 @@
-goog.module('test_files.default.default');var module = module || {id: 'test_files/default/default.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.default.default');var module = module || {id: 'test_files/default/default.js'};/**
  * @param {number} x
  * @param {string=} y
  * @return {void}

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -1,8 +1,8 @@
-goog.module('test_files.doc_params.doc_params');var module = module || {id: 'test_files/doc_params/doc_params.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class Foo {
+goog.module('test_files.doc_params.doc_params');var module = module || {id: 'test_files/doc_params/doc_params.js'};class Foo {
     /**
      * @ngInject
      * @param {string} a

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,8 +1,8 @@
-goog.module('test_files.enum.untyped.enum.untyped');var module = module || {id: 'test_files/enum.untyped/enum.untyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.enum.untyped.enum.untyped');var module = module || {id: 'test_files/enum.untyped/enum.untyped.js'};
 /** @enum {number} */
 const EnumUntypedTest1 = { XYZ: 0, PI: 3.14159, };
 EnumUntypedTest1[EnumUntypedTest1.XYZ] = "XYZ";

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,11 +1,11 @@
 // Warning at test_files/enum/enum.ts:2:7: should not emit a 'never' type
 // Warning at test_files/enum/enum.ts:8:33: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 // Warning at test_files/enum/enum.ts:15:22: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
-goog.module('test_files.enum.enum');var module = module || {id: 'test_files/enum/enum.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.enum.enum');var module = module || {id: 'test_files/enum/enum.js'};
 // Line with a missing semicolon should not break the following enum.
 const /** @type {!Array<?>} */ EnumTestMissingSemi = [];
 /** @enum {number} */

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -1,8 +1,8 @@
-goog.module('test_files.enum.enum_user');var module = module || {id: 'test_files/enum/enum_user.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.enum.enum_user');var module = module || {id: 'test_files/enum/enum_user.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.enum.enum");
 /**
  * @record

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -1,8 +1,8 @@
-goog.module('test_files.enum_value_literal_type.enum_value_literal_type');var module = module || {id: 'test_files/enum_value_literal_type/enum_value_literal_type.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// Note: if you only have one value in the enum, then the type of "x" below
+goog.module('test_files.enum_value_literal_type.enum_value_literal_type');var module = module || {id: 'test_files/enum_value_literal_type/enum_value_literal_type.js'};// Note: if you only have one value in the enum, then the type of "x" below
 // is just ExportedEnum, regardless of the annotation.  This might be a bug
 // in TypeScript but this test is just trying to verify the behavior of
 // exporting an enum's value, not that.

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export.export');var module = module || {id: 'test_files/export/export.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export.export');var module = module || {id: 'test_files/export/export.js'};
 var export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export2 = export_helper_1.export2;
 exports.export5 = export_helper_1.export5;

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export.export_helper');var module = module || {id: 'test_files/export/export_helper.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export.export_helper');var module = module || {id: 'test_files/export/export_helper.js'};
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.
 var export_helper_2_1 = goog.require('test_files.export.export_helper_2');

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export.export_helper_2');var module = module || {id: 'test_files/export/export_helper_2.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export.export_helper_2');var module = module || {id: 'test_files/export/export_helper_2.js'};
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.
 exports.export2 = 3;

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export.export_star_imported');var module = module || {id: 'test_files/export/export_star_imported.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export.export_star_imported');var module = module || {id: 'test_files/export/export_star_imported.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
 var export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export1 = export_helper_1.export1;

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,6 +1,6 @@
-goog.module('test_files.export.type_and_value');var module = module || {id: 'test_files/export/type_and_value.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export.type_and_value');var module = module || {id: 'test_files/export/type_and_value.js'};
 exports.TypeAndValue = 1;

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export_declare_namespace.export_declare_namespace');var module = module || {id: 'test_files/export_declare_namespace/export_declare_namespace.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export_declare_namespace.export_declare_namespace');var module = module || {id: 'test_files/export_declare_namespace/export_declare_namespace.js'};
 class ModuleType {
 }
 exports.ModuleType = ModuleType;

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export_declare_namespace.user');var module = module || {id: 'test_files/export_declare_namespace/user.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export_declare_namespace.user');var module = module || {id: 'test_files/export_declare_namespace/user.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export_declare_namespace.export_declare_namespace");
 let /** @type {!exportedDeclaredNamespace.Used} */ x;
 let /** @type {!nested.exportedNamespace.User} */ y;

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,7 +1,7 @@
-goog.module('test_files.export_types_values.untyped.importer');var module = module || {id: 'test_files/export_types_values.untyped/importer.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export_types_values.untyped.importer');var module = module || {id: 'test_files/export_types_values.untyped/importer.js'};
 var value_exporter_1 = goog.require('test_files.export_types_values.untyped.value_exporter');
 exports.Clazz = value_exporter_1.Clazz;

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,5 +1,5 @@
-goog.module('test_files.export_types_values.untyped.type_exporter');var module = module || {id: 'test_files/export_types_values.untyped/type_exporter.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export_types_values.untyped.type_exporter');var module = module || {id: 'test_files/export_types_values.untyped/type_exporter.js'};

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,8 +1,8 @@
-goog.module('test_files.export_types_values.untyped.value_exporter');var module = module || {id: 'test_files/export_types_values.untyped/value_exporter.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.export_types_values.untyped.value_exporter');var module = module || {id: 'test_files/export_types_values.untyped/value_exporter.js'};
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,8 +1,8 @@
-goog.module('test_files.exporting_decorator.exporting');var module = module || {id: 'test_files/exporting_decorator/exporting.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.exporting_decorator.exporting');var module = module || {id: 'test_files/exporting_decorator/exporting.js'};/**
  * \@ExportDecoratedItems
  * @return {function(?, (string|symbol)): void}
  */

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,9 +1,9 @@
 // Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
-goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class FieldsTest {
+goog.module('test_files.fields.fields');var module = module || {id: 'test_files/fields/fields.js'};class FieldsTest {
     /**
      * @param {number} field3
      */

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,8 +1,8 @@
-goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class NoCtor {
+goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
 }
 function NoCtor_tsickle_Closure_declarations() {
     /** @type {number} */

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -1,4 +1,4 @@
-goog.module('test_files.file_comment.comment_before_class');var module = module || {id: 'test_files/file_comment/comment_before_class.js'};/**
+/**
  *
  * @fileoverview Class handling code does not special cases comments preceding
  * it before its JSDoc block. This comment would not get emitted if detached
@@ -6,7 +6,7 @@ goog.module('test_files.file_comment.comment_before_class');var module = module 
  *
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.file_comment.comment_before_class');var module = module || {id: 'test_files/file_comment/comment_before_class.js'};
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -1,4 +1,4 @@
-goog.module('test_files.file_comment.comment_before_var');var module = module || {id: 'test_files/file_comment/comment_before_var.js'};/**
+/**
  *
  * @fileoverview This comment must not be emitted twice.
  * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
@@ -6,5 +6,5 @@ goog.module('test_files.file_comment.comment_before_var');var module = module ||
  *
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.file_comment.comment_before_var');var module = module || {id: 'test_files/file_comment/comment_before_var.js'};
 exports.y = 3;

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,8 +1,8 @@
-goog.module('test_files.file_comment.comment_no_tag');var module = module || {id: 'test_files/file_comment/comment_no_tag.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/** A comment without any tags. */
+goog.module('test_files.file_comment.comment_no_tag');var module = module || {id: 'test_files/file_comment/comment_no_tag.js'};/** A comment without any tags. */
 
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,7 +1,7 @@
-goog.module('test_files.file_comment.comment_with_text');var module = module || {id: 'test_files/file_comment/comment_with_text.js'};/**
+/**
  *
  * @fileoverview
  * @suppress {undefinedVars,checkTypes}  because we don't like them errors
  *
  */
-console.log('hello');
+goog.module('test_files.file_comment.comment_with_text');var module = module || {id: 'test_files/file_comment/comment_with_text.js'};console.log('hello');

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,8 +1,8 @@
-goog.module('test_files.file_comment.file_comment');var module = module || {id: 'test_files/file_comment/file_comment.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.file_comment.file_comment');var module = module || {id: 'test_files/file_comment/file_comment.js'};/**
  * @return {string}
  */
 function foo() {

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,8 +1,8 @@
-goog.module('test_files.file_comment.fileoverview_and_jsdoc');var module = module || {id: 'test_files/file_comment/fileoverview_and_jsdoc.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.file_comment.fileoverview_and_jsdoc');var module = module || {id: 'test_files/file_comment/fileoverview_and_jsdoc.js'};/**
  * @noalias
  */
 const /** @type {number} */ aVariable = 1;

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -1,7 +1,7 @@
-goog.module('test_files.file_comment.fileoverview_comment_add_suppress');var module = module || {id: 'test_files/file_comment/fileoverview_comment_add_suppress.js'};/**
+/**
  * @fileoverview a comment without a suppress tag.
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.file_comment.fileoverview_comment_add_suppress');var module = module || {id: 'test_files/file_comment/fileoverview_comment_add_suppress.js'};
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -1,8 +1,8 @@
-goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');var module = module || {id: 'test_files/file_comment/fileoverview_comment_merge_suppress.js'};/**
+/**
  *
  * @fileoverview Tests merging JSDoc tags in fileoverview comments.
  * @suppress {extraRequire,checkTypes}
  *
  */
-/** second comment here */
+goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');var module = module || {id: 'test_files/file_comment/fileoverview_comment_merge_suppress.js'};/** second comment here */
 console.log('code');

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+goog.module('test_files.file_comment.jsdoc_comment');var module = module || {id: 'test_files/file_comment/jsdoc_comment.js'};/**
+ * This comment belongs to the class below.
+ */
+class ClassWithComment {
+}

--- a/test_files/file_comment/jsdoc_comment.ts
+++ b/test_files/file_comment/jsdoc_comment.ts
@@ -1,0 +1,4 @@
+/**
+ * This comment belongs to the class below.
+ */
+class ClassWithComment {}

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -1,4 +1,4 @@
-goog.module('test_files.file_comment.multiple_comments');var module = module || {id: 'test_files/file_comment/multiple_comments.js'};/**
+/**
  * @license
  * Copyright Google Inc. All Rights Reserved.
  *
@@ -9,7 +9,7 @@ goog.module('test_files.file_comment.multiple_comments');var module = module || 
  * @fileoverview This comment is ignore by Closure compiler.
  * @suppress {undefinedVars}
  */
-/**
+goog.module('test_files.file_comment.multiple_comments');var module = module || {id: 'test_files/file_comment/multiple_comments.js'};/**
  *
  * @fileoverview The last fileoverview actually takes effect.
  * @suppress {globalThis,checkTypes}

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,6 +1,6 @@
-goog.module('test_files.file_comment.other_fileoverview_comments');var module = module || {id: 'test_files/file_comment/other_fileoverview_comments.js'};/**
+/**
  * @modName {some_mod}
  * @suppress {checkTypes} checked by tsc
  */
-// @modName also belongs in a fileoverview comment, so must be merged.
+goog.module('test_files.file_comment.other_fileoverview_comments');var module = module || {id: 'test_files/file_comment/other_fileoverview_comments.js'};// @modName also belongs in a fileoverview comment, so must be merged.
 console.log('hello');

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,8 +1,8 @@
-goog.module('test_files.functions.untyped.functions');var module = module || {id: 'test_files/functions.untyped/functions.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.functions.untyped.functions');var module = module || {id: 'test_files/functions.untyped/functions.js'};/**
  * @param {?} a
  * @return {?}
  */

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,8 +1,8 @@
-goog.module('test_files.functions.functions');var module = module || {id: 'test_files/functions/functions.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.functions.functions');var module = module || {id: 'test_files/functions/functions.js'};/**
  * @param {number} a
  * @return {number}
  */

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -1,10 +1,10 @@
-goog.module('test_files.functions.two_jsdoc_blocks');var module = module || {id: 'test_files/functions/two_jsdoc_blocks.js'};/**
+/**
  *
  * @fileoverview This text here matches the     text below in length.
  *
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.functions.two_jsdoc_blocks');var module = module || {id: 'test_files/functions/two_jsdoc_blocks.js'};
 /**
  * A comment.
  * @return {boolean}

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,8 +1,8 @@
-goog.module('test_files.generic_fn_type.generic_fn_type');var module = module || {id: 'test_files/generic_fn_type/generic_fn_type.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.generic_fn_type.generic_fn_type');var module = module || {id: 'test_files/generic_fn_type/generic_fn_type.js'};/**
  * A function type that includes a generic type argument. Unsupported by
  * Closure, so tsickle should emit ?.
  */

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,8 +1,8 @@
-goog.module('test_files.generic_local_var.generic_local_var');var module = module || {id: 'test_files/generic_local_var/generic_local_var.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.generic_local_var.generic_local_var');var module = module || {id: 'test_files/generic_local_var/generic_local_var.js'};/**
  * @template T
  */
 class Container {

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,6 +1,6 @@
-goog.module('test_files.generic_type_alias.generic_type_alias');var module = module || {id: 'test_files/generic_type_alias/generic_type_alias.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/** @typedef {!Array<?>} */
+goog.module('test_files.generic_type_alias.generic_type_alias');var module = module || {id: 'test_files/generic_type_alias/generic_type_alias.js'};/** @typedef {!Array<?>} */
 var MyList;

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -1,6 +1,6 @@
-goog.module('test_files.import_empty.import_empty');var module = module || {id: 'test_files/import_empty/import_empty.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.import_empty.import_empty');var module = module || {id: 'test_files/import_empty/import_empty.js'};
 console.log('hello');

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -1,4 +1,5 @@
-goog.module('test_files.import_empty.imported');var module = module || {id: 'test_files/import_empty/imported.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+goog.module('test_files.import_empty.imported');var module = module || {id: 'test_files/import_empty/imported.js'};

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_from_goog.import_from_goog');var module = module || {id: 'test_files/import_from_goog/import_from_goog.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.import_from_goog.import_from_goog');var module = module || {id: 'test_files/import_from_goog/import_from_goog.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("closure.Module");
 goog.require("closure.Module"); // force type-only module to be loaded
 const tsickle_forward_declare_2 = goog.forwardDeclare("closure.OtherModule");

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_only_types.import_only_types');var module = module || {id: 'test_files/import_only_types/import_only_types.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.import_only_types.import_only_types');var module = module || {id: 'test_files/import_only_types/import_only_types.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_only_types.types_only");
 goog.require("test_files.import_only_types.types_only"); // force type-only module to be loaded
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.import_only_types.types_and_constenum");

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_only_types.types_and_constenum');var module = module || {id: 'test_files/import_only_types/types_and_constenum.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// const enum values are inlined, so even though const enums are values,
+goog.module('test_files.import_only_types.types_and_constenum');var module = module || {id: 'test_files/import_only_types/types_and_constenum.js'};// const enum values are inlined, so even though const enums are values,
 // TypeScript might not generate any imports for them, which means modules
 // containing only types and const enums must be "force loaded".
 

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_only_types.types_only');var module = module || {id: 'test_files/import_only_types/types_only.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// Exports only types, but must still be goog.require'd for Closure Compiler.
+goog.module('test_files.import_only_types.types_only');var module = module || {id: 'test_files/import_only_types/types_only.js'};// Exports only types, but must still be goog.require'd for Closure Compiler.
 
 /**
  * @record

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_prefixed.exporter');var module = module || {id: 'test_files/import_prefixed/exporter.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.import_prefixed.exporter');var module = module || {id: 'test_files/import_prefixed/exporter.js'};
 exports.valueExport = 1;
 /** @typedef {(string|number)} */
 exports.TypeExport;

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_prefixed.import_prefixed_mixed');var module = module || {id: 'test_files/import_prefixed/import_prefixed_mixed.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// This file imports exporter with a prefix import (* as ...), and then uses the
+goog.module('test_files.import_prefixed.import_prefixed_mixed');var module = module || {id: 'test_files/import_prefixed/import_prefixed_mixed.js'};// This file imports exporter with a prefix import (* as ...), and then uses the
 // import in a type and in a value position.
 
 var exporter = goog.require('test_files.import_prefixed.exporter');

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,8 +1,8 @@
-goog.module('test_files.import_prefixed.import_prefixed_types');var module = module || {id: 'test_files/import_prefixed/import_prefixed_types.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// This file imports exporter with a prefix import (* as ...), and then only
+goog.module('test_files.import_prefixed.import_prefixed_types');var module = module || {id: 'test_files/import_prefixed/import_prefixed_types.js'};// This file imports exporter with a prefix import (* as ...), and then only
 // uses the import in a type position.
 // tsickle emits a goog.forwardDeclare for the type and uses it to refer to the
 // type TypeExport.

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,6 +1,6 @@
-goog.module('test_files.index_import.has_index.index');var module = module || {id: 'test_files/index_import/has_index/index.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.index_import.has_index.index');var module = module || {id: 'test_files/index_import/has_index/index.js'};
 exports.a = 1;

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,7 +1,7 @@
-goog.module('test_files.index_import.has_index.relative');var module = module || {id: 'test_files/index_import/has_index/relative.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.index_import.has_index.relative');var module = module || {id: 'test_files/index_import/has_index/relative.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.index_import.has_index.index");
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.index_import.has_index.index");

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,6 +1,6 @@
-goog.module('test_files.index_import.lib');var module = module || {id: 'test_files/index_import/lib.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.index_import.lib');var module = module || {id: 'test_files/index_import/lib.js'};
 exports.b = 2;

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,8 +1,8 @@
-goog.module('test_files.index_import.user');var module = module || {id: 'test_files/index_import/user.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.index_import.user');var module = module || {id: 'test_files/index_import/user.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.index_import.has_index.index");
 var has_index_1 = goog.require('test_files.index_import.has_index.index');
 exports.a = has_index_1.a;

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,8 +1,8 @@
-goog.module('test_files.interface.implement_import');var module = module || {id: 'test_files/interface/implement_import.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.interface.implement_import');var module = module || {id: 'test_files/interface/implement_import.js'};
 var interface_1 = goog.require('test_files.interface.interface');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.interface.interface");
 /**

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,8 +1,8 @@
-goog.module('test_files.interface.interface');var module = module || {id: 'test_files/interface/interface.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.interface.interface');var module = module || {id: 'test_files/interface/interface.js'};
 /**
  * Used by implement_import.ts
  * @record

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,8 +1,8 @@
-goog.module('test_files.interface.interface_extends');var module = module || {id: 'test_files/interface/interface_extends.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.interface.interface_extends');var module = module || {id: 'test_files/interface/interface_extends.js'};/**
  * @record
  */
 function ParentInterface() { }

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,8 +1,8 @@
-goog.module('test_files.interface.interface_type_params');var module = module || {id: 'test_files/interface/interface_type_params.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.interface.interface_type_params');var module = module || {id: 'test_files/interface/interface_type_params.js'};/**
  * @record
  */
 function UpperBound() { }

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -18,11 +18,11 @@
 // Warning at test_files/jsdoc/jsdoc.ts:77:1: @extends annotations are redundant with TypeScript equivalents
 // @implements annotations are redundant with TypeScript equivalents
 // Warning at test_files/jsdoc/jsdoc.ts:84:3: @constructor annotations are redundant with TypeScript equivalents
-goog.module('test_files.jsdoc.jsdoc');var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.jsdoc.jsdoc');var module = module || {id: 'test_files/jsdoc/jsdoc.js'};/**
  * @param {string} foo a string.
  * @param {string} baz
  * @return {string} return comment.

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.default');var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.untyped.default');var module = module || {id: 'test_files/jsdoc_types.untyped/default.js'};
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types.untyped/jsdoc_types.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.jsdoc_types.untyped.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types.untyped/jsdoc_types.js'};/**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.
  */

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.untyped.module1');var module = module || {id: 'test_files/jsdoc_types.untyped/module1.js'};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.module2');var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.untyped.module2');var module = module || {id: 'test_files/jsdoc_types.untyped/module2.js'};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/* This filename is specially marked in the tsickle test
+goog.module('test_files.jsdoc_types.untyped.nevertyped');var module = module || {id: 'test_files/jsdoc_types.untyped/nevertyped.js'};/* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 
 /**

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.default');var module = module || {id: 'test_files/jsdoc_types/default.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.default');var module = module || {id: 'test_files/jsdoc_types/default.js'};
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types/jsdoc_types.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.jsdoc_types.jsdoc_types');var module = module || {id: 'test_files/jsdoc_types/jsdoc_types.js'};/**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.
  */

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.module1');var module = module || {id: 'test_files/jsdoc_types/module1.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.module1');var module = module || {id: 'test_files/jsdoc_types/module1.js'};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.module2');var module = module || {id: 'test_files/jsdoc_types/module2.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.jsdoc_types.module2');var module = module || {id: 'test_files/jsdoc_types/module2.js'};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsdoc_types.nevertyped');var module = module || {id: 'test_files/jsdoc_types/nevertyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/* This filename is specially marked in the tsickle test
+goog.module('test_files.jsdoc_types.nevertyped');var module = module || {id: 'test_files/jsdoc_types/nevertyped.js'};/* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
 
 /**

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,8 +1,8 @@
-goog.module('test_files.jsx.jsx');var module = module || {id: 'test_files/jsx/jsx.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {!JSX.Element} */ simple = React.createElement("div", null);
+goog.module('test_files.jsx.jsx');var module = module || {id: 'test_files/jsx/jsx.js'};let /** @type {!JSX.Element} */ simple = React.createElement("div", null);
 let /** @type {string} */ hello = 'hello';
 let /** @type {!JSX.Element} */ helloDiv = React.createElement("div", null,
     hello,

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,8 +1,8 @@
-goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class HasMethods {
+goog.module('test_files.methods.methods');var module = module || {id: 'test_files/methods/methods.js'};class HasMethods {
     /**
      * @return {void}
      */

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -1,8 +1,8 @@
-goog.module('test_files.module.module');var module = module || {id: 'test_files/module/module.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-var Reflect;
+goog.module('test_files.module.module');var module = module || {id: 'test_files/module/module.js'};var Reflect;
 (function (Reflect) {
     const /** @type {number} */ x = 1;
 })(Reflect || (Reflect = {}));

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,5 +1,5 @@
-goog.module('test_files.namespaced.ambient_namespaced');var module = module || {id: 'test_files/namespaced/ambient_namespaced.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {!decl.ns.one.NamespacedClass} */ user;
+goog.module('test_files.namespaced.ambient_namespaced');var module = module || {id: 'test_files/namespaced/ambient_namespaced.js'};let /** @type {!decl.ns.one.NamespacedClass} */ user;

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -1,8 +1,8 @@
-goog.module('test_files.namespaced.export_namespace');var module = module || {id: 'test_files/namespaced/export_namespace.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.namespaced.export_namespace');var module = module || {id: 'test_files/namespaced/export_namespace.js'};
 var valueNamespace;
 (function (valueNamespace) {
     class ValueClass {

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -1,8 +1,8 @@
-goog.module('test_files.namespaced.local_namespace');var module = module || {id: 'test_files/namespaced/local_namespace.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.namespaced.local_namespace');var module = module || {id: 'test_files/namespaced/local_namespace.js'};
 var unexported;
 (function (unexported) {
     class Unexported {

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -1,8 +1,8 @@
-goog.module('test_files.namespaced.user');var module = module || {id: 'test_files/namespaced/user.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.namespaced.user');var module = module || {id: 'test_files/namespaced/user.js'};
 var export_namespace_1 = goog.require('test_files.namespaced.export_namespace');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.namespaced.export_namespace");
 const /** @type {?} */ x = new export_namespace_1.valueNamespace.ValueClass();

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,8 +1,8 @@
-goog.module('test_files.nullable.nullable');var module = module || {id: 'test_files/nullable/nullable.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class Primitives {
+goog.module('test_files.nullable.nullable');var module = module || {id: 'test_files/nullable/nullable.js'};class Primitives {
 }
 function Primitives_tsickle_Closure_declarations() {
     /** @type {(null|string)} */

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,8 +1,8 @@
-goog.module('test_files.optional.optional');var module = module || {id: 'test_files/optional/optional.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.optional.optional');var module = module || {id: 'test_files/optional/optional.js'};/**
  * @param {number} x
  * @param {(undefined|string)=} y
  * @return {void}

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,8 +1,8 @@
-goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class ParamProps {
+goog.module('test_files.parameter_properties.parameter_properties');var module = module || {id: 'test_files/parameter_properties/parameter_properties.js'};class ParamProps {
     /**
      * @param {string} publicExportedP
      * @param {string} publicP

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,8 +1,8 @@
-goog.module('test_files.promiseconstructor.promiseconstructor');var module = module || {id: 'test_files/promiseconstructor/promiseconstructor.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-/**
+goog.module('test_files.promiseconstructor.promiseconstructor');var module = module || {id: 'test_files/promiseconstructor/promiseconstructor.js'};/**
  * @param {(undefined|!PromiseConstructor)=} promiseCtor
  * @return {!Promise<void>}
  */

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,5 +1,5 @@
-goog.module('test_files.promiselike.promiselike');var module = module || {id: 'test_files/promiselike/promiselike.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {!PromiseLike<string>} */ promiseLikeOfString;
+goog.module('test_files.promiselike.promiselike');var module = module || {id: 'test_files/promiselike/promiselike.js'};let /** @type {!PromiseLike<string>} */ promiseLikeOfString;

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -2,11 +2,11 @@
 // Warning at test_files/quote_props/quote.ts:10:1: Quoted has a string index type but is accessed using dotted access. Quoting the access.
 // Warning at test_files/quote_props/quote.ts:13:1: Quoted has a string index type but is accessed using dotted access. Quoting the access.
 // Warning at test_files/quote_props/quote.ts:29:1: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
-goog.module('test_files.quote_props.quote');var module = module || {id: 'test_files/quote_props/quote.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.quote_props.quote');var module = module || {id: 'test_files/quote_props/quote.js'};
 /**
  * @record
  */

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,8 +1,8 @@
-goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class Static {
+goog.module('test_files.static.static');var module = module || {id: 'test_files/static/static.js'};class Static {
 }
 // This should not become a stub declaration.
 Static.bar = 3;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,8 +1,8 @@
-goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class StructuralTest {
+goog.module('test_files.structural.untyped.structural.untyped');var module = module || {id: 'test_files/structural.untyped/structural.untyped.js'};class StructuralTest {
     /**
      * @return {?}
      */

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,8 +1,8 @@
-goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-class SuperTestBaseNoArg {
+goog.module('test_files.super.super');var module = module || {id: 'test_files/super/super.js'};class SuperTestBaseNoArg {
     constructor() { }
 }
 class SuperTestBaseOneArg {

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,8 +1,8 @@
-goog.module('test_files.this_type.this_type');var module = module || {id: 'test_files/this_type/this_type.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.this_type.this_type');var module = module || {id: 'test_files/this_type/this_type.js'};
 class SomeClass {
 }
 function SomeClass_tsickle_Closure_declarations() {

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,9 +1,9 @@
 // Warning at test_files/type/type.ts:14:5: unhandled type literal
-goog.module('test_files.type.type');var module = module || {id: 'test_files/type/type.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-let /** @type {?} */ typeAny;
+goog.module('test_files.type.type');var module = module || {id: 'test_files/type/type.js'};let /** @type {?} */ typeAny;
 let /** @type {!Array<?>} */ typeArr;
 let /** @type {!Array<?>} */ typeArr2;
 let /** @type {!Array<!Array<{a: ?}>>} */ typeNestedArr;

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -1,6 +1,6 @@
-goog.module('test_files.type_alias_imported.export_constant');var module = module || {id: 'test_files/type_alias_imported/export_constant.js'};/**
+/**
  * @fileoverview See comments in type_alias_imported.
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_alias_imported.export_constant');var module = module || {id: 'test_files/type_alias_imported/export_constant.js'};
 exports.SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -1,11 +1,11 @@
-goog.module('test_files.type_alias_imported.type_alias_declare');var module = module || {id: 'test_files/type_alias_imported/type_alias_declare.js'};/**
+/**
  *
  * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
  * must ultimately be imported by type_alias_imported.
  *
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_alias_imported.type_alias_declare');var module = module || {id: 'test_files/type_alias_imported/type_alias_declare.js'};
 /**
  * @record
  */

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -1,11 +1,11 @@
-goog.module('test_files.type_alias_imported.type_alias_default_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_default_exporter.js'};/**
+/**
  *
  * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
  * type reference is created (no .default property).
  *
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_alias_imported.type_alias_default_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_default_exporter.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Z {

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,8 +1,8 @@
-goog.module('test_files.type_alias_imported.type_alias_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_exporter.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_alias_imported.type_alias_exporter');var module = module || {id: 'test_files/type_alias_imported/type_alias_exporter.js'};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Y {

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,8 +1,8 @@
-goog.module('test_files.type_alias_imported.type_alias_imported');var module = module || {id: 'test_files/type_alias_imported/type_alias_imported.js'};/**
+/**
  * @fileoverview Make sure imports are inserted *after* the fileoverview.
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_alias_imported.type_alias_imported');var module = module || {id: 'test_files/type_alias_imported/type_alias_imported.js'};
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 var export_constant_1 = goog.require('test_files.type_alias_imported.export_constant');

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,8 +1,8 @@
-goog.module('test_files.type_and_value.module');var module = module || {id: 'test_files/type_and_value/module.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_and_value.module');var module = module || {id: 'test_files/type_and_value/module.js'};
 exports.TypeAndValue = 3;
 exports.TemplatizedTypeAndValue = 1;
 class Class {

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -1,11 +1,11 @@
 // Warning at test_files/type_and_value/type_and_value.ts:10:5: unhandled anonymous type
 // Warning at test_files/type_and_value/type_and_value.ts:16:5: type/symbol conflict for TypeAndValue, using {?} for now
 // Warning at test_files/type_and_value/type_and_value.ts:19:5: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
-goog.module('test_files.type_and_value.type_and_value');var module = module || {id: 'test_files/type_and_value/type_and_value.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_and_value.type_and_value');var module = module || {id: 'test_files/type_and_value/type_and_value.js'};
 var conflict = goog.require('test_files.type_and_value.module');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_and_value.module");
 // This test deals with symbols that are simultaneously types and values.

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -1,8 +1,8 @@
-goog.module('test_files.type_guard_fn.type_guard_fn');var module = module || {id: 'test_files/type_guard_fn/type_guard_fn.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.type_guard_fn.type_guard_fn');var module = module || {id: 'test_files/type_guard_fn/type_guard_fn.js'};
 /**
  * @param {!Object} a
  * @return {boolean}

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,6 +1,6 @@
-goog.module('test_files.typedef.untyped.typedef');var module = module || {id: 'test_files/typedef.untyped/typedef.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.typedef.untyped.typedef');var module = module || {id: 'test_files/typedef.untyped/typedef.js'};
 var /** @type {?} */ y = 3;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,8 +1,8 @@
-goog.module('test_files.typedef.typedef');var module = module || {id: 'test_files/typedef/typedef.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.typedef.typedef');var module = module || {id: 'test_files/typedef/typedef.js'};
 /** @typedef {number} */
 var MyType;
 var /** @type {number} */ y = 3;

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,6 +1,6 @@
-goog.module('test_files.underscore.export_underscore');var module = module || {id: 'test_files/underscore/export_underscore.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-
+goog.module('test_files.underscore.export_underscore');var module = module || {id: 'test_files/underscore/export_underscore.js'};
 exports.__test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,8 +1,8 @@
-goog.module('test_files.underscore.underscore');var module = module || {id: 'test_files/underscore/underscore.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-// Verify that double-underscored names in various places don't get corrupted.
+goog.module('test_files.underscore.underscore');var module = module || {id: 'test_files/underscore/underscore.js'};// Verify that double-underscored names in various places don't get corrupted.
 // See getIdentifierText() in tsickle.ts.
 
 var export_underscore_1 = goog.require('test_files.underscore.export_underscore');

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -1,11 +1,11 @@
-goog.module('test_files.use_closure_externs.use_closure_externs');var module = module || {id: 'test_files/use_closure_externs/use_closure_externs.js'};/**
+/**
  *
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
  *
  * @suppress {checkTypes} checked by tsc
  */
-console.log('work around TS dropping consecutive comments');
+goog.module('test_files.use_closure_externs.use_closure_externs');var module = module || {id: 'test_files/use_closure_externs/use_closure_externs.js'};console.log('work around TS dropping consecutive comments');
 let /** @type {!NodeListOf<!HTMLParagraphElement>} */ x = document.getElementsByTagName('p');
 console.log(x);
 const /** @type {(null|!RegExpExecArray)} */ res = /** @type {!RegExpExecArray} */ ((/asd/.exec('asd asd')));

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,6 +1,6 @@
-goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};/**
+/**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-var /** @type {string} */ v1;
+goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};var /** @type {string} */ v1;
 var /** @type {string} */ v2, /** @type {number} */ v3;


### PR DESCRIPTION
This fixes some oddity in our emit, and also makes it possible for
downstream tooling to find fileoverview comments more easily.