### PR TITLE
Don't emit clutz aliases for reexported symbols.

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -120,6 +120,12 @@ export function createSourceCachingHost(
     if (sources.has(fileName)) {
       return true;
     }
+    // Typescript occasionally needs to look on disk for files we don't pass into
+    // the program as a source (eg to resolve a module that's in node_modules),
+    // but only .ts files explicitly passed in should be findable
+    if (/\.ts$/.test(fileName)) {
+      return false;
+    }
     return originalFileExists.call(host, fileName);
   };
 

--- a/test_files/reexport.declaration/export.d.ts
+++ b/test_files/reexport.declaration/export.d.ts
@@ -1,0 +1,6 @@
+export declare const NUM_CONSTANT = 3;
+declare global {
+	namespace ಠ_ಠ.clutz {
+		const module$contents$test_files$reexport$declaration$export_NUM_CONSTANT: typeof NUM_CONSTANT;
+	}
+}

--- a/test_files/reexport.declaration/export.ts
+++ b/test_files/reexport.declaration/export.ts
@@ -1,0 +1,1 @@
+export const NUM_CONSTANT = 3;

--- a/test_files/reexport.declaration/reexport.d.ts
+++ b/test_files/reexport.declaration/reexport.d.ts
@@ -1,0 +1,1 @@
+export * from './export';

--- a/test_files/reexport.declaration/reexport.ts
+++ b/test_files/reexport.declaration/reexport.ts
@@ -1,0 +1,3 @@
+// reexport.ts exports symbols, but doesn't declare any of them, so its .d.ts
+// shouldn't have any clutz aliases in it.
+export * from './export';


### PR DESCRIPTION
Tsickle should only emit clutz aliases in the original exporting file, not any files that reexport.  Reexporting a symbol doesn't bring the symbol into the file, so the alias would refer to a symbol that isn't available.