### PR TITLE
Emit clutz aliases in the style that incremental clutz expects.

### DIFF
--- a/test_files/basic.declaration/basic.d.ts
+++ b/test_files/basic.declaration/basic.d.ts
@@ -5,4 +5,8 @@ declare global {
 		const module$contents$test_files$basic$declaration$basic_x: typeof x;
 		const module$contents$test_files$basic$declaration$basic_incr: typeof incr;
 	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$basic$declaration$basic {
+		const x: typeof module$contents$test_files$basic$declaration$basic_x;
+		const incr: typeof module$contents$test_files$basic$declaration$basic_incr;
+	}
 }

--- a/test_files/class.declaration/class.d.ts
+++ b/test_files/class.declaration/class.d.ts
@@ -3,8 +3,14 @@ export declare class Foo {
 declare global {
 	namespace ಠ_ಠ.clutz {
 		type module$contents$test_files$class$declaration$class_Foo = Foo;
-		const module$contents$test_files$class$declaration$class_Foo: typeof Foo;
 		type module$contents$test_files$class$declaration$class_Foo_Instance = Foo;
+		const module$contents$test_files$class$declaration$class_Foo: typeof Foo;
 		const module$contents$test_files$class$declaration$class_Foo_Instance: typeof Foo;
+	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$class$declaration$class {
+		type Foo = module$contents$test_files$class$declaration$class_Foo;
+		type Foo_Instance = module$contents$test_files$class$declaration$class_Foo;
+		const Foo: typeof module$contents$test_files$class$declaration$class_Foo;
+		const Foo_Instance: typeof module$contents$test_files$class$declaration$class_Foo;
 	}
 }

--- a/test_files/generics.declaration/generics.d.ts
+++ b/test_files/generics.declaration/generics.d.ts
@@ -24,16 +24,34 @@ declare global {
 		type module$contents$test_files$generics$declaration$generics_Lengthwise = Lengthwise;
 		const module$contents$test_files$generics$declaration$generics_loggingIdentity: typeof loggingIdentity;
 		type module$contents$test_files$generics$declaration$generics_GenericNumber<T> = GenericNumber<T>;
-		const module$contents$test_files$generics$declaration$generics_GenericNumber: typeof GenericNumber;
 		type module$contents$test_files$generics$declaration$generics_GenericNumber_Instance<T> = GenericNumber<T>;
+		const module$contents$test_files$generics$declaration$generics_GenericNumber: typeof GenericNumber;
 		const module$contents$test_files$generics$declaration$generics_GenericNumber_Instance: typeof GenericNumber;
 		type module$contents$test_files$generics$declaration$generics_LengthwiseContainer<T extends Lengthwise> = LengthwiseContainer<T>;
-		const module$contents$test_files$generics$declaration$generics_LengthwiseContainer: typeof LengthwiseContainer;
 		type module$contents$test_files$generics$declaration$generics_LengthwiseContainer_Instance<T extends Lengthwise> = LengthwiseContainer<T>;
+		const module$contents$test_files$generics$declaration$generics_LengthwiseContainer: typeof LengthwiseContainer;
 		const module$contents$test_files$generics$declaration$generics_LengthwiseContainer_Instance: typeof LengthwiseContainer;
 		type module$contents$test_files$generics$declaration$generics_DefaultGeneric<T extends {} = {}> = DefaultGeneric<T>;
-		const module$contents$test_files$generics$declaration$generics_DefaultGeneric: typeof DefaultGeneric;
 		type module$contents$test_files$generics$declaration$generics_DefaultGeneric_Instance<T extends {} = {}> = DefaultGeneric<T>;
+		const module$contents$test_files$generics$declaration$generics_DefaultGeneric: typeof DefaultGeneric;
 		const module$contents$test_files$generics$declaration$generics_DefaultGeneric_Instance: typeof DefaultGeneric;
+	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$generics$declaration$generics {
+		const identity: typeof module$contents$test_files$generics$declaration$generics_identity;
+		type HasThing<T> = module$contents$test_files$generics$declaration$generics_HasThing<T>;
+		type Lengthwise = module$contents$test_files$generics$declaration$generics_Lengthwise;
+		const loggingIdentity: typeof module$contents$test_files$generics$declaration$generics_loggingIdentity;
+		type GenericNumber<T> = module$contents$test_files$generics$declaration$generics_GenericNumber<T>;
+		type GenericNumber_Instance<T> = module$contents$test_files$generics$declaration$generics_GenericNumber<T>;
+		const GenericNumber: typeof module$contents$test_files$generics$declaration$generics_GenericNumber;
+		const GenericNumber_Instance: typeof module$contents$test_files$generics$declaration$generics_GenericNumber;
+		type LengthwiseContainer<T extends Lengthwise> = module$contents$test_files$generics$declaration$generics_LengthwiseContainer<T>;
+		type LengthwiseContainer_Instance<T extends Lengthwise> = module$contents$test_files$generics$declaration$generics_LengthwiseContainer<T>;
+		const LengthwiseContainer: typeof module$contents$test_files$generics$declaration$generics_LengthwiseContainer;
+		const LengthwiseContainer_Instance: typeof module$contents$test_files$generics$declaration$generics_LengthwiseContainer;
+		type DefaultGeneric<T extends {} = {}> = module$contents$test_files$generics$declaration$generics_DefaultGeneric<T>;
+		type DefaultGeneric_Instance<T extends {} = {}> = module$contents$test_files$generics$declaration$generics_DefaultGeneric<T>;
+		const DefaultGeneric: typeof module$contents$test_files$generics$declaration$generics_DefaultGeneric;
+		const DefaultGeneric_Instance: typeof module$contents$test_files$generics$declaration$generics_DefaultGeneric;
 	}
 }

--- a/test_files/interface_and_type.declaration/interface_and_type.d.ts
+++ b/test_files/interface_and_type.declaration/interface_and_type.d.ts
@@ -6,4 +6,8 @@ declare global {
 		type module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo = Foo;
 		type module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar = Bar;
 	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$interface_and_type$declaration$interface_and_type {
+		type Foo = module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo;
+		type Bar = module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar;
+	}
 }

--- a/test_files/nested_folder.declaration/inner_folder/nested.d.ts
+++ b/test_files/nested_folder.declaration/inner_folder/nested.d.ts
@@ -3,4 +3,7 @@ declare global {
 	namespace ಠ_ಠ.clutz {
 		const module$contents$test_files$nested_folder$declaration$inner_folder$nested_x: typeof x;
 	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$nested_folder$declaration$inner_folder$nested {
+		const x: typeof module$contents$test_files$nested_folder$declaration$inner_folder$nested_x;
+	}
 }

--- a/test_files/reexport.declaration/export.d.ts
+++ b/test_files/reexport.declaration/export.d.ts
@@ -3,4 +3,7 @@ declare global {
 	namespace ಠ_ಠ.clutz {
 		const module$contents$test_files$reexport$declaration$export_NUM_CONSTANT: typeof NUM_CONSTANT;
 	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$export {
+		const NUM_CONSTANT: typeof module$contents$test_files$reexport$declaration$export_NUM_CONSTANT;
+	}
 }


### PR DESCRIPTION
Global clutz runs allow symbols to be resolved to the name they have in their original contexts, even if they're exported under another name.  Incremental clutz is forced to use the exporting name, so tsickle needs to emit both until global clutz goes away.