### PR TITLE
emit typedefs in untyped mode

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1448,8 +1448,6 @@ class Annotator extends ClosureRewriter {
   }
 
   private visitTypeAlias(node: ts.TypeAliasDeclaration) {
-    if (this.host.untyped) return;
-
     // If the type is also defined as a value, skip emitting it. Closure collapses type & value
     // namespaces, the two emits would conflict if tsickle emitted both.
     const sym = this.mustGetSymbolAtLocation(node.name);
@@ -1459,7 +1457,8 @@ class Annotator extends ClosureRewriter {
     this.newTypeTranslator(node).blacklistTypeParameters(
         this.symbolsToAliasedNames, node.typeParameters);
 
-    const typeStr = this.typeToClosure(node, undefined, true /* resolveAlias */);
+    const typeStr =
+        this.host.untyped ? '?' : this.typeToClosure(node, undefined, true /* resolveAlias */);
     const typeName = node.name.getText();
     this.emit(`\n/** @typedef {${typeStr}} */\n`);
     this.emit(`var ${typeName};\n`);

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -34,6 +34,8 @@ class Extends extends Super {
      */
     interfaceFunc() { }
 }
+/** @typedef {?} */
+var TypeAlias;
 class ImplementsTypeAlias {
     /**
      * @return {?}
@@ -64,6 +66,8 @@ function ZoneImplementsInterface_tsickle_Closure_declarations() {
     /** @type {?} */
     ZoneImplementsInterface.prototype.zone;
 }
+/** @typedef {?} */
+var ZoneAlias;
 class ZoneImplementsAlias {
 }
 function ZoneImplementsAlias_tsickle_Closure_declarations() {

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -4,3 +4,6 @@
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };
+/** @typedef {?} */
+var TypeDef;
+exports.TypeDef = TypeDef;

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -4,5 +4,12 @@
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };
+/** @typedef {?} */
+var MyType;
 /** @type {?} */
 var y = 3;
+/** @typedef {?} */
+var Recursive;
+/** @typedef {?} */
+var ExportedType;
+exports.ExportedType = ExportedType;


### PR DESCRIPTION
Even in untyped mode, it's useful to define the typedef as {?}.
This allows downstream JS to continue to refer to the typedef.