### PR TITLE
don't emit types like "...?=" in externs, which are illegal

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -330,7 +330,12 @@ export function merge(tags: Tag[]): Tag {
   const type = types.size > 0 ? Array.from(types).join('|') : undefined;
   const text = texts.size > 0 ? Array.from(texts).join(' / ') : undefined;
   const tag: Tag = {tagName, parameterName, type, text};
-  if (optional) tag.optional = true;
-  if (restParam) tag.restParam = true;
+  // Note: a param can either be optional or a rest param; if we merged an
+  // optional and rest param together, prefer marking it as a rest param.
+  if (restParam) {
+    tag.restParam = true;
+  } else if (optional) {
+    tag.optional = true;
+  }
   return tag;
 }

--- a/test_files/declare/declare.d.ts
+++ b/test_files/declare/declare.d.ts
@@ -89,6 +89,10 @@ declare function redirect(url: string, status: number): void;
 declare function TestOverload(a: number, ...b: any[]): string;
 declare function TestOverload(a: number, b: string, c: string): string;
 
+// Test an overload with a rest param unioning with an optional param.
+declare function TestOverload2(a: number, ...b: any[]): void;
+declare function TestOverload2(a: number, b?: string): void;
+
 // An interface that is not tagged with "declare", but exists in a
 // d.ts file so it should show up in the externs anyway.
 interface BareInterface {

--- a/test_files/declare/dtsdiagnostics.txt
+++ b/test_files/declare/dtsdiagnostics.txt
@@ -1,1 +1,1 @@
-Warning at test_files/declare/declare.d.ts:102:1: anonymous type has no symbol
+Warning at test_files/declare/declare.d.ts:106:1: anonymous type has no symbol

--- a/test_files/declare/externs.js
+++ b/test_files/declare/externs.js
@@ -163,6 +163,13 @@ function redirect(url_or_status, url_or_status1) {}
  * @return {string}
  */
 function TestOverload(a, b) {}
+
+/**
+ * @param {number} a
+ * @param {...?|(undefined|string)} b
+ * @return {void}
+ */
+function TestOverload2(a, b) {}
 /**
  * @record
  * @struct


### PR DESCRIPTION
If we think a param is both a rest param and optional, prefer the
rest param (as that subsumes optional).