### PR TITLE
avoid a warning when 'module' is unused

### DIFF
--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -129,7 +129,9 @@ class ES5Processor extends Rewriter {
       // accesses exports through the module object, so mutable exports work.
       // It is only inserted in ES6 because we strip `.default` accesses in ES5 mode, which breaks
       // when assigning an `exports = {}` object and then later accessing it.
-      this.emit(` exports = {}; var module = {id: '${moduleId}'};`);
+      // The module=module bit suppresses an unused variable warning which
+      // may trigger depending on the compilation flags.
+      this.emit(` exports = {}; var module = {id: '${moduleId}'}; module = module;`);
     }
 
     let pos = 0;

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -43,7 +43,7 @@ describe('convertCommonJsToGoogModule', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`, false)
         .to.equal(
-            `goog.module('a'); exports = {}; var module = {id: 'a.js'};console.log('hello');`);
+            `goog.module('a'); exports = {}; var module = {id: 'a.js'}; module = module;console.log('hello');`);
   });
 
   it('adds a goog.module call to empty files', () => {
@@ -225,7 +225,8 @@ __export(require('./export_star');
     expectCommonJs('a.js', `console.log('hello');`, false, `goog.require('tshelpers');`)
         .to.equal(
             `goog.module('a');goog.require('tshelpers'); ` +
-            `exports = {}; var module = {id: 'a.js'};` +
+            `exports = {}; ` +
+            `var module = {id: 'a.js'}; module = module;` +
             `console.log('hello');`);
   });
 });


### PR DESCRIPTION
Depending on the user's compilation settings, not using the implied
'module' variable will cause compilation errors.  Avoid this.