### PR TITLE
Emit goog.require only for imported types.

### DIFF
--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -4,6 +4,5 @@
  */
 goog.module('test_files.type_alias_imported.elided_comment');var module = module || {id: 'test_files/type_alias_imported/elided_comment.js'};
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
-goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
 let /** @type {(null|!tsickle_forward_declare_2.X|!tsickle_forward_declare_1.Y)} */ xy = null;

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -4,7 +4,6 @@
  */
 goog.module('test_files.type_alias_imported.type_alias_imported');var module = module || {id: 'test_files/type_alias_imported/type_alias_imported.js'};
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
-goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 var export_constant_1 = goog.require('test_files.type_alias_imported.export_constant');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");


### PR DESCRIPTION
Emitting forced imports can cause circular dependency issues in Closure
Compiler. Types that are only imported because they are used in resolved
union types must have already been imported by some other file in the
compilation unit, so skipping these avoids some circularity issues
without dropping necessary files from the compilation.