### PR TITLE
Resolve all paths before determining whether or not to skip files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -133,7 +133,8 @@ export function toClosureJS(
     writeFile?: ts.WriteFileCallback): tsickle.EmitResult {
   const compilerHost = ts.createCompilerHost(options);
   const program = ts.createProgram(fileNames, options, compilerHost);
-  // Use absolute paths to determine what files to process since files may be imported using any means
+  // Use absolute paths to determine what files to process since files may be imported using
+  // relative or absolute paths
   const filesToProcess = new Set(fileNames.map(i => path.resolve(i)));
   const transformerHost: tsickle.TsickleHost = {
     shouldSkipTsickleProcessing: (fileName: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,9 +133,11 @@ export function toClosureJS(
     writeFile?: ts.WriteFileCallback): tsickle.EmitResult {
   const compilerHost = ts.createCompilerHost(options);
   const program = ts.createProgram(fileNames, options, compilerHost);
+  // Use absolute paths to determine what files to process since files may be imported using any means
+  const filesToProcess = new Set(fileNames.map(i => path.resolve(i)));
   const transformerHost: tsickle.TsickleHost = {
     shouldSkipTsickleProcessing: (fileName: string) => {
-      return fileNames.indexOf(fileName) === -1;
+      return !filesToProcess.has(path.resolve(fileName));
     },
     shouldIgnoreWarningsForPath: (fileName: string) => false,
     pathToModuleName: cliSupport.pathToModuleName,


### PR DESCRIPTION
Fixes https://github.com/angular/tsickle/issues/714

It turns out that Typescript supplies a mixture of relative and absolute paths to the `shouldSkipTsickleProcessing` function. In particular, files that are imported in TS using `../` appear using absolute paths. However, the `fileNames` array ends up being all relative paths (at least in my project).

As far as I can tell we can't guarantee any of the path formats, so this change resolves all paths to their absolute versions before checking if a file should be excluded.