### PR TITLE
feat: emit template types even in untyped mode.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1216,8 +1216,8 @@ class Annotator extends ClosureRewriter {
       docTags.push({tagName: 'abstract'});
     }
 
+    this.maybeAddTemplateClause(docTags, classDecl);
     if (!this.host.untyped) {
-      this.maybeAddTemplateClause(docTags, classDecl);
       this.maybeAddHeritageClauses(docTags, classDecl);
     }
 
@@ -1238,8 +1238,8 @@ class Annotator extends ClosureRewriter {
 
     const docTags = this.getJSDoc(iface) || [];
     docTags.push({tagName: 'record'});
+    this.maybeAddTemplateClause(docTags, iface);
     if (!this.host.untyped) {
-      this.maybeAddTemplateClause(docTags, iface);
       this.maybeAddHeritageClauses(docTags, iface);
     }
 

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -82,3 +82,11 @@ TestSplat3(1, 2);
  */
 function defaultBeforeRequired(x = 1, y, ...z) { }
 defaultBeforeRequired(undefined, 2, 'h', 3);
+/**
+ * @template T
+ * @param {?} t
+ * @return {?}
+ */
+function templated(t) {
+    return 1;
+}

--- a/test_files/functions.untyped/functions.ts
+++ b/test_files/functions.untyped/functions.ts
@@ -33,3 +33,7 @@ TestSplat3(1, 2);
 
 function defaultBeforeRequired(x = 1, y: number, ...z: any[]) {}
 defaultBeforeRequired(undefined, 2, 'h', 3);
+
+function templated<T>(t: T): number {
+  return 1;
+}

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -82,3 +82,11 @@ TestSplat3(1, 2);
  */
 function defaultBeforeRequired(x = 1, y, ...z) { }
 defaultBeforeRequired(undefined, 2, 'h', 3);
+/**
+ * @template T
+ * @param {T} t
+ * @return {number}
+ */
+function templated(t) {
+    return 1;
+}

--- a/test_files/functions/functions.ts
+++ b/test_files/functions/functions.ts
@@ -33,3 +33,7 @@ TestSplat3(1, 2);
 
 function defaultBeforeRequired(x = 1, y: number, ...z: any[]) {}
 defaultBeforeRequired(undefined, 2, 'h', 3);
+
+function templated<T>(t: T): number {
+  return 1;
+}

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -18,6 +18,9 @@ function Interface_tsickle_Closure_declarations() {
     /** @type {?} */
     Interface.prototype.x;
 }
+/**
+ * @template T
+ */
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;


### PR DESCRIPTION
For historical reasons, Closure Compiler allows specifying template
arguments even on types that do not declare any template arguments, and
just silently ignores them, including the types inside of them.

Emitting template arguments even when run in untyped mode allows Closure
Compiler to migrate to enforcing type argument's presence, and makes
sure type arguments are resolved when using templated TS types in
untyped mode from Closure code.