### PR TITLE
Configure renovate to be less noisy:

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "extends": [
     "config:base"
   ],
+  "packageRules": [
+    {
+      "extends": ["group:all"],
+      "excludePackagePatterns": ["google-closure-compiler"],
+      "groupName": "deps",
+      "schedule": ["on the first day of the month"]
+    }
+  ],
   "ignorePaths": ["test*/**"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,15 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitsDisabled"
   ],
   "packageRules": [
     {
-      "extends": ["group:all"],
-      "excludePackagePatterns": ["google-closure-compiler"],
-      "groupName": "deps",
-      "schedule": ["on the first day of the month"]
+      "excludePackageNames": ["google-closure-compiler"],
+      "extends": [
+        "group:all",
+        "schedule:monthly"
+      ]
     }
   ],
   "ignorePaths": ["test*/**"]


### PR DESCRIPTION
- For all dependencies other than Closure compiler:
- update only once a month
- combine all the updates into a single PR

/cc @rarkins to see if I'm doing this right