### PR TITLE
Tell renovate not to bother with source-map

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,6 @@
       ]
     }
   ],
-  "ignorePaths": ["test*/**"]
+  "ignorePaths": ["test*/**"],
+  "ignoreDeps": ["source-map"]
 }


### PR DESCRIPTION
The breaking change from 0.6 to 0.7 is too breaky for us.

/cc @rarkins 