### PR TITLE
build: update to latest bazel rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,10 @@
 workspace(name="tsickle")
 
-# Using a pre-release version to pick up the new npm_package rule.
-# TODO(alexeagle): switch back to released version after next release.
-RULES_NODEJS_VERSION = "55c8958ad4d3bdf5dd3320a915e8104edbe3b205"
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/%s.zip" % RULES_NODEJS_VERSION,
-    strip_prefix = "rules_nodejs-%s" % RULES_NODEJS_VERSION,
-    sha256 = "d894ef4ae852e53fb7da078f76290f131c1a37a09b0e0479aca845200a1b141d",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.5.0.zip",
+    strip_prefix = "rules_nodejs-0.5.0",
+    sha256 = "06aabb253c3867d51724386ac5622a0a238bbd82e2c70ce1d09ee3ceac4c31d6",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
@@ -30,9 +27,9 @@ node_repositories(package_json = [
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.10.1.zip",
-    strip_prefix = "rules_typescript-0.10.1",
-    sha256 = "a2c81776a4a492ff9f878f9705639f5647bef345f7f3e1da09c9eeb8dec80485",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.11.0.zip",
+    strip_prefix = "rules_typescript-0.11.0",
+    sha256 = "ce7bac7b5287d5162fcbe4f7c14ff507ae7d506ceb44626ad09f6b7e27d3260b",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")


### PR DESCRIPTION
As usual, I'm running this PR as a presubmit before releasing rules_nodejs and rules_typescript, and I'll change these commit SHAs to release tags before merging this PR