### PR TITLE
Don't forward declare if googmodule is false

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -50,6 +50,8 @@ export interface AnnotatorHost {
    * If true, do not modify quotes around property accessors.
    */
   disableAutoQuoting?: boolean;
+  /** Whether to add `goog.forwardDeclare` declarations for `goog.module` Closure imports. */
+  googmodule?: boolean;
 }
 
 /**

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1158,7 +1158,7 @@ class Annotator extends ClosureRewriter {
    * @param specifier the import specifier, i.e. module path ("from '...'").
    */
   private forwardDeclare(specifier: ts.Expression, isDefaultImport = false) {
-    if (!this.tsHost.googmodule) {
+    if (!this.host.googmodule) {
       return;
     }
     const importPath = es5processor.resolveIndexShorthand(

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1158,6 +1158,9 @@ class Annotator extends ClosureRewriter {
    * @param specifier the import specifier, i.e. module path ("from '...'").
    */
   private forwardDeclare(specifier: ts.Expression, isDefaultImport = false) {
+    if (!this.tsHost.googmodule) {
+      return;
+    }
     const importPath = es5processor.resolveIndexShorthand(
         {options: this.tsOpts, host: this.tsHost}, this.file.fileName,
         (specifier as ts.StringLiteral).text);


### PR DESCRIPTION
Don't emit `goog.forwardDeclare` if `goog.module` conversion is disabled.