### PR TITLE
Only emit `ctorParameters` when the class has a constructor

### DIFF
--- a/src/class_decorator_downlevel_transformer.ts
+++ b/src/class_decorator_downlevel_transformer.ts
@@ -100,7 +100,7 @@ function insertBeforeDecoratorProperties(
   let insertionPoint = classMembers.findIndex(
       m => isNameEqual(m, 'ctorParameters') || isNameEqual(m, 'propDecorators'));
   if (insertionPoint === -1) {
-    insertionPoint = classMembers.length - 1;
+    insertionPoint = classMembers.length;  // Insert at end of list
   }
   const members = [
     ...classMembers.slice(0, insertionPoint), decoratorMetadata,

--- a/src/decorator-annotator.ts
+++ b/src/decorator-annotator.ts
@@ -64,11 +64,11 @@ export function shouldLower(decorator: ts.Decorator, typeChecker: ts.TypeChecker
 // separately for each class we encounter.
 export class DecoratorClassVisitor {
   /** Decorators on the class itself. */
-  decorators: ts.Decorator[];
+  private decorators: ts.Decorator[];
   /** The constructor parameter list and decorators on each param. */
   private ctorParameters: ConstructorParameter[];
   /** Per-method decorators. */
-  propDecorators: Map<string, ts.Decorator[]>;
+  private propDecorators: Map<string, ts.Decorator[]>;
 
   constructor(
       private typeChecker: ts.TypeChecker, private rewriter: Rewriter,
@@ -249,8 +249,12 @@ export class DecoratorClassVisitor {
    */
   emitMetadataAsStaticProperties() {
     const decoratorInvocations = '{type: Function, args?: any[]}[]';
+
     if (this.decorators || this.ctorParameters) {
       this.rewriter.emit(`/** @nocollapse */\n`);
+    }
+
+    if (this.ctorParameters) {
       // ctorParameters may contain forward references in the type: field, so wrap in a function
       // closure
       this.rewriter.emit(

--- a/test/decorator-annotator_test.ts
+++ b/test/decorator-annotator_test.ts
@@ -120,14 +120,6 @@ class Foo {
         { type: Test1 },
         { type: Test2, args: [param,] },
     ];
-    /** @nocollapse */
-    static ctorParameters: () => ({
-        type: any;
-        decorators?: {
-            type: Function;
-            args?: any[];
-        }[];
-    } | null)[] = () => [];
 }
 `);
     });
@@ -148,14 +140,6 @@ class Foo {
     }[] = [
         { type: Test },
     ];
-    /** @nocollapse */
-    static ctorParameters: () => ({
-        type: any;
-        decorators?: {
-            type: Function;
-            args?: any[];
-        }[];
-    } | null)[] = () => [];
 }
 `);
     });
@@ -177,14 +161,6 @@ class Foo {
     }[] = [
         { type: Test },
     ];
-    /** @nocollapse */
-    static ctorParameters: () => ({
-        type: any;
-        decorators?: {
-            type: Function;
-            args?: any[];
-        }[];
-    } | null)[] = () => [];
 }
 `);
     });
@@ -219,14 +195,6 @@ class Foo {
         { type: Test3 },
         { type: Test4, args: [param,] },
     ];
-    /** @nocollapse */
-    static ctorParameters: () => ({
-        type: any;
-        decorators?: {
-            type: Function;
-            args?: any[];
-        }[];
-    } | null)[] = () => [];
 }
 `);
     });
@@ -246,14 +214,6 @@ export class Foo {
     }[] = [
         { type: Test1 },
     ];
-    /** @nocollapse */
-    static ctorParameters: () => ({
-        type: any;
-        decorators?: {
-            type: Function;
-            args?: any[];
-        }[];
-    } | null)[] = () => [];
 }
 `);
     });
@@ -282,15 +242,41 @@ export class Foo {
             }[] = [
                 { type: Test2 },
             ];
-            /** @nocollapse */
-            static ctorParameters: () => ({
-                type: any;
-                decorators?: {
-                    type: Function;
-                    args?: any[];
-                }[];
-            } | null)[] = () => [];
         }
+    }
+    static decorators: {
+        type: Function;
+        args?: any[];
+    }[] = [
+        { type: Test1 },
+    ];
+}
+`);
+    });
+  });
+
+  describe('ctor decorator rewriter', () => {
+    it('ignores ctors that have no applicable injects', () => {
+      expectUnchanged(`import { BarService } from 'bar';
+class Foo {
+    constructor(bar: BarService, num: number) {
+    }
+}
+`);
+    });
+
+    it('transforms empty ctors', () => {
+      expectTranslated(`
+import {FakeDecorator} from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+@Test1()
+class Foo {
+  constructor() {
+  }
+}`).to.equal(`import { FakeDecorator } from 'bar';
+/** @Annotation */ let Test1: FakeDecorator;
+class Foo {
+    constructor() {
     }
     static decorators: {
         type: Function;
@@ -306,17 +292,6 @@ export class Foo {
             args?: any[];
         }[];
     } | null)[] = () => [];
-}
-`);
-    });
-  });
-
-  describe('ctor decorator rewriter', () => {
-    it('ignores ctors that have no applicable injects', () => {
-      expectUnchanged(`import { BarService } from 'bar';
-class Foo {
-    constructor(bar: BarService, num: number) {
-    }
 }
 `);
     });


### PR DESCRIPTION
Fix DecoratorClassVisitor to only emit `ctorParameters` when the class has a constructor.

This more closely matches the behavior of TSC which only emits the "design:paramtypes" metadata
when the class actually has a constructor. For example, compiling the following TypeScript snippet:

```typescript
// compile with --target ES5 --experimentalDecorators --emitDecoratorMetadata
@Inject
class Bar {

}

@Inject
class Baz {
    constructor() {}
}

@Inject
class Foo {
    constructor(bar: Bar) {}
}

class Faz {
    constructor(@Inject bar: Bar) {}
}
```

Emits this JavaScript:

```javascript
var Bar = /** @class */ (function () {
    function Bar() {
    }
    Bar = __decorate([
        Inject
    ], Bar);
    return Bar;
}());
var Baz = /** @class */ (function () {
    function Baz() {
    }
    Baz = __decorate([
        Inject,
        __metadata("design:paramtypes", [])
    ], Baz);
    return Baz;
}());
var Foo = /** @class */ (function () {
    function Foo(bar) {
    }
    Foo = __decorate([
        Inject,
        __metadata("design:paramtypes", [Bar])
    ], Foo);
    return Foo;
}());
var Faz = /** @class */ (function () {
    function Faz(bar) {
    }
    Faz = __decorate([
        __param(0, Inject),
        __metadata("design:paramtypes", [Bar])
    ], Faz);
    return Faz;
}());
```

