### PR TITLE
don't wrap a function around the declarations of class members

### DIFF
--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -17,34 +17,32 @@ class Base {
         this.hasReturnType();
     }
 }
-function Base_tsickle_Closure_declarations() {
-    /**
-     * @abstract
-     * @return {void}
-     */
-    Base.prototype.simple = function () { };
-    /**
-     * @abstract
-     * @return {void}
-     */
-    Base.prototype.publicAbstract = function () { };
-    /**
-     * @abstract
-     * @param {!Array<number>} x
-     * @return {void}
-     */
-    Base.prototype.params = function (x) { };
-    /**
-     * @abstract
-     * @return {?}
-     */
-    Base.prototype.noReturnType = function () { };
-    /**
-     * @abstract
-     * @return {number}
-     */
-    Base.prototype.hasReturnType = function () { };
-}
+/**
+ * @abstract
+ * @return {void}
+ */
+Base.prototype.simple = function () { };
+/**
+ * @abstract
+ * @return {void}
+ */
+Base.prototype.publicAbstract = function () { };
+/**
+ * @abstract
+ * @param {!Array<number>} x
+ * @return {void}
+ */
+Base.prototype.params = function (x) { };
+/**
+ * @abstract
+ * @return {?}
+ */
+Base.prototype.noReturnType = function () { };
+/**
+ * @abstract
+ * @return {number}
+ */
+Base.prototype.hasReturnType = function () { };
 class Derived extends Base {
     constructor() {
         super();

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -18,12 +18,10 @@ class Foo {
         this.field = 'hello';
     }
 }
-function Foo_tsickle_Closure_declarations() {
-    /** @type {?} */
-    Foo.prototype.field;
-    /** @type {?} */
-    Foo.prototype.ctorArg;
-}
+/** @type {?} */
+Foo.prototype.field;
+/** @type {?} */
+Foo.prototype.ctorArg;
 // These two declarations should not have a @type annotation,
 // regardless of untyped.
 (function () {

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -57,13 +57,9 @@ superVar = new ImplementsTypeAlias();
 function Zone() { }
 class ZoneImplementsInterface {
 }
-function ZoneImplementsInterface_tsickle_Closure_declarations() {
-    /** @type {?} */
-    ZoneImplementsInterface.prototype.zone;
-}
+/** @type {?} */
+ZoneImplementsInterface.prototype.zone;
 class ZoneImplementsAlias {
 }
-function ZoneImplementsAlias_tsickle_Closure_declarations() {
-    /** @type {?} */
-    ZoneImplementsAlias.prototype.zone;
-}
+/** @type {?} */
+ZoneImplementsAlias.prototype.zone;

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -34,13 +34,11 @@ class AbstractClass {
      */
     nonAbstractFunc() { }
 }
-function AbstractClass_tsickle_Closure_declarations() {
-    /**
-     * @abstract
-     * @return {void}
-     */
-    AbstractClass.prototype.abstractFunc = function () { };
-}
+/**
+ * @abstract
+ * @return {void}
+ */
+AbstractClass.prototype.abstractFunc = function () { };
 /**
  * @record
  * @extends {Interface}
@@ -195,15 +193,11 @@ abstractClassVar = new ClassExtendsAbstractClass();
 function Zone() { }
 class ZoneImplementsInterface {
 }
-function ZoneImplementsInterface_tsickle_Closure_declarations() {
-    /** @type {string} */
-    ZoneImplementsInterface.prototype.zone;
-}
+/** @type {string} */
+ZoneImplementsInterface.prototype.zone;
 /** @typedef {?} */
 var ZoneAlias;
 class ZoneImplementsAlias {
 }
-function ZoneImplementsAlias_tsickle_Closure_declarations() {
-    /** @type {string} */
-    ZoneImplementsAlias.prototype.zone;
-}
+/** @type {string} */
+ZoneImplementsAlias.prototype.zone;

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -4,29 +4,27 @@
  */
 goog.module('test_files.comments.comments');var module = module || {id: 'test_files/comments/comments.js'};class Comments {
 }
-function Comments_tsickle_Closure_declarations() {
-    /**
-     * @export
-     * @type {string}
-     */
-    Comments.prototype.export1;
-    /** @type {string} */
-    Comments.prototype.export2;
-    /** @type {number} */
-    Comments.prototype.nodoc1;
-    /** @type {number} */
-    Comments.prototype.nodoc2;
-    /** @type {number} */
-    Comments.prototype.nodoc3;
-    /**
-     * inline jsdoc comment without type annotation
-     * @type {number}
-     */
-    Comments.prototype.jsdoc1;
-    /**
-     * multi-line jsdoc comment without
-     * type annotation.
-     * @type {number}
-     */
-    Comments.prototype.jsdoc2;
-}
+/**
+ * @export
+ * @type {string}
+ */
+Comments.prototype.export1;
+/** @type {string} */
+Comments.prototype.export2;
+/** @type {number} */
+Comments.prototype.nodoc1;
+/** @type {number} */
+Comments.prototype.nodoc2;
+/** @type {number} */
+Comments.prototype.nodoc3;
+/**
+ * inline jsdoc comment without type annotation
+ * @type {number}
+ */
+Comments.prototype.jsdoc1;
+/**
+ * multi-line jsdoc comment without
+ * type annotation.
+ * @type {number}
+ */
+Comments.prototype.jsdoc2;

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -11,8 +11,6 @@ class X {
         this.a = a;
     }
 }
-function X_tsickle_Closure_declarations() {
-    /** @type {number} */
-    X.prototype.a;
-}
+/** @type {number} */
+X.prototype.a;
 let /** @type {function(new: (!X), number): ?} */ y = X;

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -84,32 +84,28 @@ __decorate([
     decorator,
     __metadata("design:type", external_1.AClass)
 ], DecoratorTest.prototype, "z", void 0);
-function DecoratorTest_tsickle_Closure_declarations() {
-    /** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
-    DecoratorTest.decorators;
-    /**
-     * @nocollapse
-     * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
-     */
-    DecoratorTest.ctorParameters;
-    /** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
-    DecoratorTest.propDecorators;
-    /**
-     * Some comment
-     * @type {number}
-     */
-    DecoratorTest.prototype.x;
-    /** @type {number} */
-    DecoratorTest.prototype.y;
-    /** @type {!tsickle_forward_declare_1.AClass} */
-    DecoratorTest.prototype.z;
-}
+/** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
+DecoratorTest.decorators;
+/**
+ * @nocollapse
+ * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
+ */
+DecoratorTest.ctorParameters;
+/** @type {!Object<string,!Array<{type: !Function, args: (undefined|!Array<?>)}>>} */
+DecoratorTest.propDecorators;
+/**
+ * Some comment
+ * @type {number}
+ */
+DecoratorTest.prototype.x;
+/** @type {number} */
+DecoratorTest.prototype.y;
+/** @type {!tsickle_forward_declare_1.AClass} */
+DecoratorTest.prototype.z;
 let DecoratedClass = class DecoratedClass {
 };
 DecoratedClass = __decorate([
     classDecorator
 ], DecoratedClass);
-function DecoratedClass_tsickle_Closure_declarations() {
-    /** @type {string} */
-    DecoratedClass.prototype.z;
-}
+/** @type {string} */
+DecoratedClass.prototype.z;

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -22,14 +22,12 @@ function main() {
     TestComp3.ctorParameters = () => [
         { type: SomeService, },
     ];
-    function TestComp3_tsickle_Closure_declarations() {
-        /** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
-        TestComp3.decorators;
-        /**
-         * @nocollapse
-         * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
-         */
-        TestComp3.ctorParameters;
-    }
+    /** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
+    TestComp3.decorators;
+    /**
+     * @nocollapse
+     * @type {function(): !Array<(null|{type: ?, decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>)})>}
+     */
+    TestComp3.ctorParameters;
 }
 exports.main = main;

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -11,7 +11,5 @@ goog.module('test_files.doc_params.doc_params');var module = module || {id: 'tes
         this.a = a;
     }
 }
-function Foo_tsickle_Closure_declarations() {
-    /** @type {string} */
-    Foo.prototype.a;
-}
+/** @type {string} */
+Foo.prototype.a;

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -98,12 +98,10 @@ __decorate([
     __metadata("design:type", Number),
     __metadata("design:paramtypes", [Number])
 ], MyClass.prototype, "doNotExportThisSetter", null);
-function MyClass_tsickle_Closure_declarations() {
-    /**
-     * @type {boolean}
-     * @export
-     */
-    MyClass.prototype.exportMe;
-    /** @type {number} */
-    MyClass.prototype.doNotExportMe;
-}
+/**
+ * @type {boolean}
+ * @export
+ */
+MyClass.prototype.exportMe;
+/** @type {number} */
+MyClass.prototype.doNotExportMe;

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -21,16 +21,14 @@ goog.module('test_files.fields.fields');var module = module || {id: 'test_files/
         return this.field1;
     }
 }
-function FieldsTest_tsickle_Closure_declarations() {
-    /** @type {string} */
-    FieldsTest.prototype.field1;
-    /** @type {number} */
-    FieldsTest.prototype.field2;
-    /** @type {string} */
-    FieldsTest.prototype.field4;
-    /** @type {number} */
-    FieldsTest.prototype.field3;
-}
+/** @type {string} */
+FieldsTest.prototype.field1;
+/** @type {number} */
+FieldsTest.prototype.field2;
+/** @type {string} */
+FieldsTest.prototype.field4;
+/** @type {number} */
+FieldsTest.prototype.field3;
 let /** @type {!FieldsTest} */ fieldsTest = new FieldsTest(3);
 // Ensure the type is understood by Closure.
 fieldsTest.field1 = 'hi';

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -4,7 +4,5 @@
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');var module = module || {id: 'test_files/fields_no_ctor/fields_no_ctor.js'};class NoCtor {
 }
-function NoCtor_tsickle_Closure_declarations() {
-    /** @type {number} */
-    NoCtor.prototype.field1;
-}
+/** @type {number} */
+NoCtor.prototype.field1;

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -25,7 +25,5 @@ class Container {
         console.log(myT, myU);
     }
 }
-function Container_tsickle_Closure_declarations() {
-    /** @type {T} */
-    Container.prototype.tField;
-}
+/** @type {T} */
+Container.prototype.tField;

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -18,12 +18,10 @@ class MyPoint {
         this.y = y;
     }
 }
-function MyPoint_tsickle_Closure_declarations() {
-    /** @type {number} */
-    MyPoint.prototype.x;
-    /** @type {number} */
-    MyPoint.prototype.y;
-}
+/** @type {number} */
+MyPoint.prototype.x;
+/** @type {number} */
+MyPoint.prototype.y;
 /**
  * @extends {tsickle_forward_declare_1.User}
  */
@@ -35,10 +33,8 @@ class ImplementsUser {
         this.shoeSize = shoeSize;
     }
 }
-function ImplementsUser_tsickle_Closure_declarations() {
-    /** @type {number} */
-    ImplementsUser.prototype.shoeSize;
-}
+/** @type {number} */
+ImplementsUser.prototype.shoeSize;
 class ExtendsUser extends interface_1.User {
     constructor() {
         super();

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -21,10 +21,8 @@ function Point_tsickle_Closure_declarations() {
 class User {
 }
 exports.User = User;
-function User_tsickle_Closure_declarations() {
-    /** @type {number} */
-    User.prototype.shoeSize;
-}
+/** @type {number} */
+User.prototype.shoeSize;
 /**
  * @param {!Point} p
  * @return {number}

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -61,35 +61,33 @@ class JSDocTest {
  * \@internal
  */
 JSDocTest.X = [];
-function JSDocTest_tsickle_Closure_declarations() {
-    /**
-     * \@internal
-     * @type {!Array<string>}
-     */
-    JSDocTest.X;
-    /**
-     * \@internal
-     * @type {!Array<string>}
-     */
-    JSDocTest.prototype.x;
-    /**
-     * @export
-     * @type {string}
-     */
-    JSDocTest.prototype.exported;
-    /** @type {string} */
-    JSDocTest.prototype.badExport;
-    /** @type {string} */
-    JSDocTest.prototype.stringWithoutJSDoc;
-    /** @type {number} */
-    JSDocTest.prototype.typedThing;
-    /** @type {?} */
-    JSDocTest.prototype.badEnumThing;
-    /** @type {string} */
-    JSDocTest.prototype.badConstThing;
-    /** @type {string} */
-    JSDocTest.prototype.badTypeDef;
-}
+/**
+ * \@internal
+ * @type {!Array<string>}
+ */
+JSDocTest.X;
+/**
+ * \@internal
+ * @type {!Array<string>}
+ */
+JSDocTest.prototype.x;
+/**
+ * @export
+ * @type {string}
+ */
+JSDocTest.prototype.exported;
+/** @type {string} */
+JSDocTest.prototype.badExport;
+/** @type {string} */
+JSDocTest.prototype.stringWithoutJSDoc;
+/** @type {number} */
+JSDocTest.prototype.typedThing;
+/** @type {?} */
+JSDocTest.prototype.badEnumThing;
+/** @type {string} */
+JSDocTest.prototype.badConstThing;
+/** @type {string} */
+JSDocTest.prototype.badTypeDef;
 class BadTemplated {
 }
 class BadDict {

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -40,16 +40,12 @@ let /** @type {?} */ useNeverTypedTemplated;
  */
 class ImplementsNeverTyped {
 }
-function ImplementsNeverTyped_tsickle_Closure_declarations() {
-    /** @type {number} */
-    ImplementsNeverTyped.prototype.foo;
-}
+/** @type {number} */
+ImplementsNeverTyped.prototype.foo;
 /**
  * @template T
  */
 class ImplementsNeverTypedTemplated {
 }
-function ImplementsNeverTypedTemplated_tsickle_Closure_declarations() {
-    /** @type {T} */
-    ImplementsNeverTypedTemplated.prototype.foo;
-}
+/** @type {T} */
+ImplementsNeverTypedTemplated.prototype.foo;

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -22,7 +22,5 @@ goog.module('test_files.methods.methods');var module = module || {id: 'test_file
      */
     set f(n) { this._f = n - 1; }
 }
-function HasMethods_tsickle_Closure_declarations() {
-    /** @type {number} */
-    HasMethods.prototype._f;
-}
+/** @type {number} */
+HasMethods.prototype._f;

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -4,32 +4,28 @@
  */
 goog.module('test_files.nullable.nullable');var module = module || {id: 'test_files/nullable/nullable.js'};class Primitives {
 }
-function Primitives_tsickle_Closure_declarations() {
-    /** @type {(null|string)} */
-    Primitives.prototype.nullable;
-    /** @type {(undefined|number)} */
-    Primitives.prototype.undefinable;
-    /** @type {(undefined|null|string)} */
-    Primitives.prototype.nullableUndefinable;
-    /** @type {(undefined|string)} */
-    Primitives.prototype.optional;
-}
+/** @type {(null|string)} */
+Primitives.prototype.nullable;
+/** @type {(undefined|number)} */
+Primitives.prototype.undefinable;
+/** @type {(undefined|null|string)} */
+Primitives.prototype.nullableUndefinable;
+/** @type {(undefined|string)} */
+Primitives.prototype.optional;
 class NonPrimitive {
 }
 class NonPrimitives {
 }
-function NonPrimitives_tsickle_Closure_declarations() {
-    /** @type {!NonPrimitive} */
-    NonPrimitives.prototype.nonNull;
-    /** @type {(null|!NonPrimitive)} */
-    NonPrimitives.prototype.nullable;
-    /** @type {(undefined|!NonPrimitive)} */
-    NonPrimitives.prototype.undefinable;
-    /** @type {(undefined|null|!NonPrimitive)} */
-    NonPrimitives.prototype.nullableUndefinable;
-    /** @type {(undefined|!NonPrimitive)} */
-    NonPrimitives.prototype.optional;
-}
+/** @type {!NonPrimitive} */
+NonPrimitives.prototype.nonNull;
+/** @type {(null|!NonPrimitive)} */
+NonPrimitives.prototype.nullable;
+/** @type {(undefined|!NonPrimitive)} */
+NonPrimitives.prototype.undefinable;
+/** @type {(undefined|null|!NonPrimitive)} */
+NonPrimitives.prototype.nullableUndefinable;
+/** @type {(undefined|!NonPrimitive)} */
+NonPrimitives.prototype.optional;
 /**
  * @param {(string|number)} val
  * @return {void}

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -20,20 +20,18 @@ goog.module('test_files.parameter_properties.parameter_properties');var module =
         this.publicReadonlyP = publicReadonlyP;
     }
 }
-function ParamProps_tsickle_Closure_declarations() {
-    /**
-     * @export
-     * @type {string}
-     */
-    ParamProps.prototype.publicExportedP;
-    /** @type {string} */
-    ParamProps.prototype.publicP;
-    /** @type {string} */
-    ParamProps.prototype.protectedP;
-    /** @type {string} */
-    ParamProps.prototype.privateP;
-    /** @type {string} */
-    ParamProps.prototype.readonlyP;
-    /** @type {string} */
-    ParamProps.prototype.publicReadonlyP;
-}
+/**
+ * @export
+ * @type {string}
+ */
+ParamProps.prototype.publicExportedP;
+/** @type {string} */
+ParamProps.prototype.publicP;
+/** @type {string} */
+ParamProps.prototype.protectedP;
+/** @type {string} */
+ParamProps.prototype.privateP;
+/** @type {string} */
+ParamProps.prototype.readonlyP;
+/** @type {string} */
+ParamProps.prototype.publicReadonlyP;

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -7,9 +7,7 @@ goog.module('test_files.static.static');var module = module || {id: 'test_files/
 // This should not become a stub declaration.
 Static.bar = 3;
 Static.baz = 3;
-function Static_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Static.bar;
-    /** @type {number} */
-    Static.baz;
-}
+/** @type {number} */
+Static.bar;
+/** @type {number} */
+Static.baz;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -8,10 +8,8 @@ goog.module('test_files.structural.untyped.structural.untyped');var module = mod
      */
     method() { return this.field1; }
 }
-function StructuralTest_tsickle_Closure_declarations() {
-    /** @type {?} */
-    StructuralTest.prototype.field1;
-}
+/** @type {?} */
+StructuralTest.prototype.field1;
 /**
  * @param {?} st
  * @return {?}

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -13,10 +13,8 @@ class SuperTestBaseOneArg {
         this.x = x;
     }
 }
-function SuperTestBaseOneArg_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SuperTestBaseOneArg.prototype.x;
-}
+/** @type {number} */
+SuperTestBaseOneArg.prototype.x;
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     /**
      * @param {string} y
@@ -26,20 +24,16 @@ class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
         this.y = y;
     }
 }
-function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
-    /** @type {string} */
-    SuperTestDerivedParamProps.prototype.y;
-}
+/** @type {string} */
+SuperTestDerivedParamProps.prototype.y;
 class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
     constructor() {
         super(3);
         this.y = 'foo';
     }
 }
-function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
-    /** @type {string} */
-    SuperTestDerivedInitializedProps.prototype.y;
-}
+/** @type {string} */
+SuperTestDerivedInitializedProps.prototype.y;
 class SuperTestDerivedOrdinary extends SuperTestBaseOneArg {
     constructor() {
         super(3);
@@ -62,14 +56,10 @@ function SuperTestInterface_tsickle_Closure_declarations() {
  */
 class SuperTestDerivedInterface {
 }
-function SuperTestDerivedInterface_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SuperTestDerivedInterface.prototype.foo;
-}
+/** @type {number} */
+SuperTestDerivedInterface.prototype.foo;
 class SuperTestStaticProp extends SuperTestBaseOneArg {
 }
 SuperTestStaticProp.foo = 3;
-function SuperTestStaticProp_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SuperTestStaticProp.foo;
-}
+/** @type {number} */
+SuperTestStaticProp.foo;

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -5,10 +5,8 @@
 goog.module('test_files.this_type.this_type');var module = module || {id: 'test_files/this_type/this_type.js'};
 class SomeClass {
 }
-function SomeClass_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SomeClass.prototype.x;
-}
+/** @type {number} */
+SomeClass.prototype.x;
 const /** @type {function(this: (!SomeClass), string): number} */ variableWithFunctionTypeUsingThis = () => 1;
 /**
  * @return {(undefined|function(this: (string)): string)}

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -8,7 +8,5 @@ exports.TemplatizedTypeAndValue = 1;
 class Class {
 }
 exports.Class = Class;
-function Class_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Class.prototype.z;
-}
+/** @type {number} */
+Class.prototype.z;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -19,10 +19,8 @@ class __Class {
         return this.__member;
     }
 }
-function __Class_tsickle_Closure_declarations() {
-    /** @type {string} */
-    __Class.prototype.__member;
-}
+/** @type {string} */
+__Class.prototype.__member;
 /**
  * @record
  */


### PR DESCRIPTION
I think the use of a function here dates back to when we used to
emit the typeAnnotationsHelper as a method on the class.  And we
did that because we needed the resulting code to TS type-check.

None of that is true anymore, and Closure style is to declare members
etc. at the top level, not in a helper.