### PR TITLE
add a test and note about why we have a wrapper

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1329,6 +1329,7 @@ class Annotator extends ClosureRewriter {
     if (!classDecl.name) return;
     const className = getIdentifierText(classDecl.name);
 
+    // See test_files/fields/fields.ts:BaseThatThrows for a note on this wrapper.
     this.emit(`\n\nfunction ${className}_tsickle_Closure_declarations() {\n`);
     if (this.currentDecoratorConverter) {
       this.currentDecoratorConverter.emitMetadataTypeAnnotationsHelpers();

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -36,3 +36,21 @@ let /** @type {!FieldsTest} */ fieldsTest = new FieldsTest(3);
 fieldsTest.field1 = 'hi';
 let /** @type {?} */ AnonymousClass = class {
 };
+class BaseThatThrows {
+    /**
+     * @return {number}
+     */
+    get throwMe() { throw new Error(); }
+}
+class Derived extends BaseThatThrows {
+}
+function Derived_tsickle_Closure_declarations() {
+    /**
+     * Note: in Closure, this type is declared via an annotation on
+     * Derived.prototype.throwMe, which throws if it's evaluated.
+     * So any tsickle output that puts the type declaration at the
+     * top level is wrong.
+     * @type {number}
+     */
+    Derived.prototype.throwMe;
+}

--- a/test_files/fields/fields.ts
+++ b/test_files/fields/fields.ts
@@ -22,3 +22,17 @@ fieldsTest.field1 = 'hi';
 let AnonymousClass = class {
   field: number;
 };
+
+
+class BaseThatThrows {
+  get throwMe(): number { throw new Error(); }
+}
+class Derived extends BaseThatThrows {
+  /**
+   * Note: in Closure, this type is declared via an annotation on
+   * Derived.prototype.throwMe, which throws if it's evaluated.
+   * So any tsickle output that puts the type declaration at the
+   * top level is wrong.
+   */
+  throwMe: number;
+}


### PR DESCRIPTION
Include a demo of the getter pattern that made our
  function ${className}_tsickle_Closure_declarations() {
wrapper necessary.

Note that the test doesn't actually fail if we break this, but
at least there's a big comment in the output that will hopefully
make it more obvious.