### PR TITLE
add a license block to a source file

### DIFF
--- a/test_ts24/check_ts_version.js
+++ b/test_ts24/check_ts_version.js
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 if (!require('typescript').version.startsWith('2.4')) {
   throw new Error('Expected TypeScript 2.4');
 }


### PR DESCRIPTION
A license checker script complains about this file missing a license,
even though it is trivial.