### PR TITLE
Skip emitting clutz aliases for default exports.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -2156,6 +2156,15 @@ function addClutzAliases(
       if (declarations && !areAnyDeclarationsFromSourceFile(declarations, sf)) {
         continue;
       }
+
+      // default is a keyword in typescript, so the name of the export being default
+      // means that it's a default export
+      if (symbol.name === 'default') {
+        dtsFileContent +=
+            `// skipped emitting clutz aliases for a default export, which aren't currently supported`;
+        continue;
+      }
+
       // Want to alias the symbol to match what clutz would produce, so clutz .d.ts's
       // can reference symbols from typescript .d.ts's. See examples at:
       // https://github.com/angular/clutz/tree/master/src/test/java/com/google/javascript/clutz

--- a/test_files/export_default.declaration/default.d.ts
+++ b/test_files/export_default.declaration/default.d.ts
@@ -1,0 +1,3 @@
+export default class foo {
+}
+// skipped emitting clutz aliases for a default export, which aren't currently supported

--- a/test_files/export_default.declaration/default.ts
+++ b/test_files/export_default.declaration/default.ts
@@ -1,0 +1,3 @@
+export default class foo {
+    
+}


### PR DESCRIPTION
The current emit for default exports is broken and the alternative path from tsickle to clutz is also broken, so no one is currently relying on the current behaviour.  Since the style guide forbids default exports, the easiest way to get error free .d.ts files is to skip emitting aliases for default exports.