### PR TITLE
 Emit same module stanza in ES5 and ES6 modes.

### DIFF
--- a/src/es5processor.ts
+++ b/src/es5processor.ts
@@ -137,7 +137,7 @@ class ES5Processor extends Rewriter {
       }
       // The module=module bit suppresses an unused variable warning which
       // may trigger depending on the compilation flags.
-      this.emit(` var module = {id: '${moduleId}'}; module = module;`);
+      this.emit(` var module = module || {id: '${moduleId}'}; module = module;`);
     }
 
     let pos = 0;

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -217,7 +217,7 @@ describe('source maps with transformer', () => {
     const sourceMap = extractInlineSourceMap(compiledJs);
 
     expect(sourceMap).to.exist;
-    expect(compiledJs).to.contain(`var module = {id: 'input.js'};`);
+    expect(compiledJs).to.contain(`var module = module || {id: 'input.js'};`);
   });
 
   it(`handles mixed source mapped and non source mapped input`, () => {

--- a/test/es5processor_test.ts
+++ b/test/es5processor_test.ts
@@ -48,7 +48,7 @@ describe('convertCommonJsToGoogModule', () => {
     // NB: no line break added below.
     expectCommonJs('a.js', `console.log('hello');`, false)
         .not.differentFrom(
-            `goog.module('a'); exports = {}; var module = {id: 'a.js'}; module = module;console.log('hello');`);
+            `goog.module('a'); exports = {}; var module = module || {id: 'a.js'}; module = module;console.log('hello');`);
   });
 
   it('adds a goog.module call to empty files', () => {
@@ -232,7 +232,7 @@ __export(require('./export_star');
         .not.differentFrom(
             `goog.module('a');goog.require('tshelpers'); ` +
             `exports = {}; ` +
-            `var module = {id: 'a.js'}; module = module;` +
+            `var module = module || {id: 'a.js'}; module = module;` +
             `console.log('hello');`);
   });
 
@@ -241,7 +241,7 @@ __export(require('./export_star');
         'a.js', `console.log('hello'); module.exports = 1;`, false, `goog.require('tshelpers');`)
         .not.differentFrom(
             `goog.module('a');goog.require('tshelpers'); ` +
-            `var module = {id: 'a.js'}; module = module;` +
+            `var module = module || {id: 'a.js'}; module = module;` +
             `console.log('hello'); exports = 1;`);
   });
 });


### PR DESCRIPTION
Previously, tsickle would emit different module stanzas in ES5 vs ES6:

    var module = module || {id: '...'};  // ES5
    var module = {id: '...'};            // ES6

Using `module ||` will allow the ES6 code to run in NodeJS and still
receive the correct `module` object.

This code was added as is from the very get go. It is unclear why the
difference was important, maybe the author wanted to avoid accidentally
exposing a `module` object in ES6 mode.

I have confirmed Closure Compiler fully removes the module assignment
in either mode, and does not produce extra warnings, so this seems to
have been unnecessary.