### PR TITLE
fix: `const enums` when using `preserveConstEnums` are not being exported

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1043,7 +1043,7 @@ class Annotator extends ClosureRewriter {
       // Note: We create explicit reexports via closure at another place in
       return false;
     }
-    if (sym.flags & ts.SymbolFlags.ConstEnum) {
+    if (!this.tsOpts.preserveConstEnums && sym.flags & ts.SymbolFlags.ConstEnum) {
       return false;
     }
     return true;

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -83,6 +83,18 @@ describe('emitWithTsickle', () => {
     expect(jsSources['./a.js']).to.contain('exports.x = 2;');
   });
 
+  it('should export const enums when preserveConstEnums is true', () => {
+    const tsSources = {'a.ts': `export const enum Foo { Bar };`, 'b.ts': `export * from './a';`};
+
+    const jsSources = emitWithTsickle(
+        tsSources, {
+          preserveConstEnums: true,
+          module: ts.ModuleKind.ES2015,
+        },
+        {es5Mode: false, googmodule: false});
+
+    expect(jsSources['./b.js']).to.contain(`export { Foo } from './a';`);
+  });
 
   describe('regressions', () => {
     it('should produce correct .d.ts files when expanding `export *` with es2015 module syntax',


### PR DESCRIPTION
At the moment `const enums` are not exported when the user specifically chooses to preserve them by setting`preserveConstEnums` to `true` in the `CompilerOptions`.

Closes: #768