### PR TITLE
Break up variable statements into declarations.

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -263,6 +263,9 @@ function tagToString(tag: Tag, escapeExtraTags = new Set<string>()): string {
 /** Tags that must only occur onces in a comment (filtered below). */
 const SINGLETON_TAGS = new Set(['deprecated']);
 
+/** Tags that conflict with \@type in Closure Compiler (e.g. \@param). */
+export const TAGS_CONFLICTING_WITH_TYPE = new Set(['param', 'return']);
+
 /** Serializes a Comment out to a string, but does not include the start and end comment tokens. */
 export function toStringWithoutStartEnd(tags: Tag[], escapeExtraTags = new Set<string>()): string {
   return serialize(tags, false, escapeExtraTags);

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -139,6 +139,19 @@ export abstract class Rewriter {
   }
 
   /**
+   * Start a source mapping for the given node. This allows adding source mappings for statements
+   * that are not yet finished, and whose total length is unknown. Does not add recursive mappings
+   * for child nodes.
+   * @return a handler to finish the mapping.
+   */
+  startSourceMapping(node: ts.Node) {
+    const startPos = this.position.position;
+    return () => {
+      this.sourceMapper.addMappingForRange(node, startPos, this.position.position);
+    };
+  }
+
+  /**
    * Write a span of the input file as expressed by absolute offsets.
    * These offsets are found in attributes like node.getFullStart() and
    * node.getEnd().

--- a/src/source_map_utils.ts
+++ b/src/source_map_utils.ts
@@ -164,9 +164,17 @@ export interface SourceMapper {
   addMapping(
       originalNode: ts.Node, original: SourcePosition, generated: SourcePosition,
       length: number): void;
+  /**
+   * Adds a mapping from `startPosition` to `endPosition` in the generated output. Contrary to
+   * addMapping, this method does not attempt to add mappings for child nodes, nor does it always
+   * emit a mapping for the given `originalNode`. It also does not adjust original positions for any
+   * leading comments.
+   */
+  addMappingForRange(originalNode: ts.Node, startPosition: number, endPosition: number): void;
 }
 
 export const NOOP_SOURCE_MAPPER: SourceMapper = {
   shiftByOffset() {/* no-op */},
   addMapping() {/* no-op */},
+  addMappingForRange() {/* no-op */},
 };

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -442,6 +442,7 @@ function visitNodeStatementsWithSynthesizedComments<T extends ts.Node>(
     if (trailing.lastCommentEnd !== -1) {
       fileContext.lastCommentEnd = trailing.lastCommentEnd;
     }
+    ts.setOriginalNode((leading.commentStmt || trailing.commentStmt)!, node);
     return node;
   }
   return visitor(node, statements);
@@ -592,7 +593,7 @@ function synthesizeCommentRanges(
       commentText = commentText.replace(/(^\/\*)|(\*\/$)/g, '');
     } else if (kind === ts.SyntaxKind.SingleLineCommentTrivia) {
       if (commentText.startsWith('///')) {
-        // tripple-slash comments are typescript specific, ignore them in the output.
+        // triple-slash comments are typescript specific, ignore them in the output.
         return;
       }
       commentText = commentText.replace(/(^\/\/)/g, '');

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -693,7 +693,7 @@ class Annotator extends ClosureRewriter {
         if (node.kind === ts.SyntaxKind.ModuleDeclaration) continue;
         // Non-value objects do not exist at runtime, so we cannot access the symbol (it only
         // exists in externs). Export them as a typedef, which forwards to the type in externs.
-        this.emit(`\n/** @typedef {${declName}} */\nexports.${declName};\n`);
+        this.emit(`\n/** @typedef {!${declName}} */\nexports.${declName};\n`);
       } else {
         this.emit(`\nexports.${declName} = ${declName};\n`);
       }
@@ -1109,7 +1109,7 @@ class Annotator extends ClosureRewriter {
       if (!isTypeAlias) continue;
       const typeName = this.symbolsToAliasedNames.get(exp.sym) || exp.sym.name;
       // Leading newline prevents the typedef from being swallowed.
-      this.emit(`\n/** @typedef {${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
+      this.emit(`\n/** @typedef {!${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
     }
   }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -38,12 +38,10 @@ jasmine_node_test(
 ts_library(
     name = "e2e_test_lib",
     srcs = [
-        "closure.ts",
         "e2e_clutz_dts_test.ts",
         "e2e_main_test.ts",
         "e2e_node_kind_source_map_test.ts",
         "e2e_source_map_test.ts",
-        "e2e_test.ts",
     ],
     tsconfig = "//:tsconfig.json",
     deps = [
@@ -54,6 +52,33 @@ ts_library(
 
 jasmine_node_test(
     name = "e2e_test",
+    srcs = [":e2e_test_lib"],
+    data = ["//:test_files"],
+)
+
+test_suite(
+    name = "small_tests",
+    tests = [
+        ":e2e_test",
+        ":unit_test",
+    ],
+)
+
+ts_library(
+    name = "closure_e2e_test_lib",
+    srcs = [
+        "closure.ts",
+        "e2e_test.ts",
+    ],
+    tsconfig = "//:tsconfig.json",
+    deps = [
+        ":test_support",
+        "//src",
+    ],
+)
+
+jasmine_node_test(
+    name = "closure_e2e_test",
     srcs = [":e2e_test_lib"],
     data = ["//:test_files"],
 )

--- a/test/e2e_source_map_test.ts
+++ b/test/e2e_source_map_test.ts
@@ -232,22 +232,4 @@ describe('source maps with transformer', () => {
     assertSourceMapping(compiledJs, sourceMap, 'x = 3', {source: 'original.ts'});
     assertSourceMapping(compiledJs, sourceMap, 'another string', {line: 3, source: 'input2.ts'});
   });
-
-  it('maps at the start of lines correctly', () => {
-    const sources = new Map([[
-      'input.ts', `let x : number = 2;
-      x + 1;
-      let y = {z: 2};
-      y.z;`
-    ]]);
-
-    const {files} = compileWithTransfromer(sources, sourceMapCompilerOptions);
-    const compiledJs = files.get('input.js')!;
-    const sourceMap = getSourceMapWithName('input.js.map', files);
-
-    assertSourceMapping(
-        compiledJs, sourceMap, 'let /** @type {number} */ x', {line: 1, source: 'input.ts'});
-    assertSourceMapping(compiledJs, sourceMap, 'x + 1', {line: 2, source: 'input.ts'});
-    assertSourceMapping(compiledJs, sourceMap, 'y.z', {line: 4, source: 'input.ts'});
-  });
 });

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -22,6 +22,7 @@ describe('golden file tests', () => {
     const goldenJs = ([] as string[]).concat(...tests.map(t => t.jsPaths));
     goldenJs.push('src/closure_externs.js');
     goldenJs.push('test_files/helpers.js');
+    goldenJs.push('test_files/duplicated_externs.js');
     goldenJs.push('test_files/clutz.no_externs/some_name_space.js');
     goldenJs.push('test_files/clutz.no_externs/some_other.js');
     goldenJs.push('test_files/import_from_goog/closure_Module.js');

--- a/test/source_map_test.ts
+++ b/test/source_map_test.ts
@@ -45,6 +45,10 @@ class TestSourceMapper implements SourceMapper {
       source: this.fileName,
     });
   }
+
+  addMappingForRange(node: ts.Node, from: number, to: number) {
+    throw new Error('not implemented');
+  }
 }
 
 describe('source maps', () => {

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -230,18 +230,24 @@ export function readSources(filePaths: string[]): Map<string, string> {
 }
 
 function getLineAndColumn(source: string, token: string): {line: number, column: number} {
-  const lines = source.split('\n');
-  const line = lines.findIndex(l => l.indexOf(token) !== -1) + 1;
-  if (line === 0) {
-    throw new Error(`Couldn't find token '${token}' in source`);
+  const idx = source.indexOf(token);
+  if (idx === -1) {
+    throw new Error(`Couldn't find token '${token}' in source ${source}`);
   }
-  const column = lines[line - 1].indexOf(token);
+  let line = 1, column = 0;
+  for (let i = 0; i < idx; i++) {
+    column++;
+    if (source[i] === '\n') {
+      line++;
+      column = 0;
+    }
+  }
   return {line, column};
 }
 
 export function assertSourceMapping(
     compiledJs: string, sourceMap: SourceMapConsumer, sourceSnippet: string,
-    expectedPosition: {line?: number, column?: number, source?: string}) {
+    expectedPosition: {source: string, line?: number, column?: number}) {
   const {line, column} = getLineAndColumn(compiledJs, sourceSnippet);
   const originalPosition = sourceMap.originalPositionFor({line, column});
   if (expectedPosition.line) {

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -73,4 +73,5 @@ class Derived extends Base {
      */
     hasReturnType() { return 3; }
 }
-let /** @type {!Base} */ x = new Derived();
+/** @type {!Base} */
+let x = new Derived();

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -4,10 +4,12 @@
  */
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');
 var module = module || { id: 'test_files/arrow_fn.es5/arrow_fn_es5.ts' };
-var /** @type {function(): void} */ foo = function () {
+/** @type {function(): void} */
+var foo = function () {
     // this comment must not get inserted between the return and expression in ES5 (ASI).
     return console.log('foo');
 };
-var /** @type {function(): void} */ bar = function () {
+/** @type {function(): void} */
+var bar = function () {
     console.log('bar');
 };

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };
-var /** @type {?} */ fn3 = (a) => 12;
+/** @type {?} */
+var fn3 = (a) => 12;

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -4,6 +4,13 @@
  */
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };
-var /** @type {function(number): number} */ fn3 = (a) => 12;
-var /** @type {function(?): ?} */ fn4 = (a) => a + 12;
+/** @type {function(number): number} */
+var fn3 = (a) => 12;
+/** @type {function(?): ?} */
+var fn4 = (a) => a + 12;
+/** @type {function(number): number} */
 exports.fn5 = (a = 10) => a;
+/** *
+ * \@param a this must be escaped, as Closure bails on it.
+  @type {function(number): number} */
+const fn6 = (a = 10) => a;

--- a/test_files/arrow_fn/arrow_fn.ts
+++ b/test_files/arrow_fn/arrow_fn.ts
@@ -1,3 +1,6 @@
 var fn3 = (a: number): number => 12;
 var fn4 = (a) => a + 12;
 export var fn5 = (a = 10) => a;
+
+/** @param a this must be escaped, as Closure bails on it. */
+const fn6 = (a = 10) => a;

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -29,10 +29,8 @@ function Foo_tsickle_Closure_declarations() {
 // These two declarations should not have a @type annotation,
 // regardless of untyped.
 (function () {
-    // With a type annotation:
     let { a, b } = { a: '', b: 0 };
 })();
 (function () {
-    // Without a type annotation:
     let { a, b } = { a: null, b: null };
 })();

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -44,12 +44,13 @@ class ImplementsTypeAlias {
      */
     superFunc() { }
 }
-// Verify Closure accepts the various casts.
-let /** @type {?} */ interfaceVar;
+/** @type {?} */
+let interfaceVar;
 interfaceVar = new Implements();
 interfaceVar = new Extends();
 interfaceVar = new ImplementsTypeAlias();
-let /** @type {?} */ superVar;
+/** @type {?} */
+let superVar;
 superVar = new Implements();
 superVar = new Extends();
 superVar = new ImplementsTypeAlias();

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -52,7 +52,8 @@ function InterfaceExtendsInterface_tsickle_Closure_declarations() {
     /** @type {function(): void} */
     InterfaceExtendsInterface.prototype.interfaceFunc2;
 }
-let /** @type {!InterfaceExtendsInterface} */ interfaceExtendsInterface = {
+/** @type {!InterfaceExtendsInterface} */
+let interfaceExtendsInterface = {
     /**
      * @return {void}
      */
@@ -177,18 +178,18 @@ class ImplementsTypeAlias {
      */
     classFunc() { }
 }
-// Verify Closure accepts the various subtypes of Interface.
-let /** @type {!Interface} */ interfaceVar;
+/** @type {!Interface} */
+let interfaceVar;
 interfaceVar = interfaceExtendsInterface;
 interfaceVar = new ClassImplementsInterface();
 interfaceVar = new ImplementsTypeAlias();
-// Verify Closure accepts the various subtypes of Class.
-let /** @type {!Class} */ classVar;
+/** @type {!Class} */
+let classVar;
 classVar = new ClassImplementsClass();
 classVar = new ClassExtendsClass();
 classVar = new ImplementsTypeAlias();
-// Verify Closure accepts the various subtypes of AbstractClass.
-let /** @type {!AbstractClass} */ abstractClassVar;
+/** @type {!AbstractClass} */
+let abstractClassVar;
 abstractClassVar = new ClassImplementsAbstractClass();
 abstractClassVar = new ClassExtendsAbstractClass();
 /**

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -8,7 +8,9 @@ var goog_some_name_space_1 = goog.require('some.name.space');
 const tsickle_forward_declare_1 = goog.forwardDeclare("some.name.space");
 const tsickle_forward_declare_2 = goog.forwardDeclare("some.other");
 goog.require("some.other"); // force type-only module to be loaded
-let /** @type {!tsickle_forward_declare_1.ClutzedClass} */ clutzedClass = new goog_some_name_space_1.ClutzedClass();
+/** @type {!tsickle_forward_declare_1.ClutzedClass} */
+let clutzedClass = new goog_some_name_space_1.ClutzedClass();
 console.log(clutzedClass);
-let /** @type {!tsickle_forward_declare_2.ClutzedInterface} */ typeAliased = clutzedClass.field;
+/** @type {!tsickle_forward_declare_2.ClutzedInterface} */
+let typeAliased = clutzedClass.field;
 goog_some_name_space_1.clutzedFn(typeAliased);

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -4,7 +4,8 @@
  */
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };
-let /** @type {function(new: (!Document)): ?} */ x = Document;
+/** @type {function(new: (!Document)): ?} */
+let x = Document;
 class X {
     /**
      * @param {number} a
@@ -17,4 +18,5 @@ function X_tsickle_Closure_declarations() {
     /** @type {number} */
     X.prototype.a;
 }
-let /** @type {function(new: (!X), number): ?} */ y = X;
+/** @type {function(new: (!X), number): ?} */
+let y = X;

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };
-let /** @type {!GlobalClass} */ x;
-let /** @type {!globalNamespace.GlobalNamespaced} */ y;
+/** @type {!GlobalClass} */
+let x;
+/** @type {!globalNamespace.GlobalNamespaced} */
+let y;

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -14,7 +14,7 @@
 // Closure builtin Error type.
 goog.module('test_files.declare_export.declare_export');
 var module = module || { id: 'test_files/declare_export/declare_export.ts' };
-/** @typedef {ExportDeclaredIf} */
+/** @typedef {!ExportDeclaredIf} */
 exports.ExportDeclaredIf;
 let /** @type {!ExportDeclaredIf} */ user1;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;
@@ -26,6 +26,6 @@ let /** @type {function(): string} */ user4 = exportedDeclaredFn;
 exports.multiExportedDeclaredVar1 = window.multiExportedDeclaredVar1;
 exports.multiExportedDeclaredVar2 = window.multiExportedDeclaredVar2;
 let /** @type {string} */ user5 = exports.multiExportedDeclaredVar1;
-/** @typedef {X} */
+/** @typedef {!X} */
 exports.X;
 let /** @type {string} */ user6;

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -16,16 +16,22 @@ goog.module('test_files.declare_export.declare_export');
 var module = module || { id: 'test_files/declare_export/declare_export.ts' };
 /** @typedef {!ExportDeclaredIf} */
 exports.ExportDeclaredIf;
-let /** @type {!ExportDeclaredIf} */ user1;
+/** @type {!ExportDeclaredIf} */
+let user1;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;
-let /** @type {number} */ user2 = exports.exportedDeclaredVar;
+/** @type {number} */
+let user2 = exports.exportedDeclaredVar;
 exports.ExportDeclaredClass = ExportDeclaredClass;
-let /** @type {!ExportDeclaredClass} */ user3;
+/** @type {!ExportDeclaredClass} */
+let user3;
 exports.exportedDeclaredFn = exportedDeclaredFn;
-let /** @type {function(): string} */ user4 = exportedDeclaredFn;
+/** @type {function(): string} */
+let user4 = exportedDeclaredFn;
 exports.multiExportedDeclaredVar1 = window.multiExportedDeclaredVar1;
 exports.multiExportedDeclaredVar2 = window.multiExportedDeclaredVar2;
-let /** @type {string} */ user5 = exports.multiExportedDeclaredVar1;
+/** @type {string} */
+let user5 = exports.multiExportedDeclaredVar1;
 /** @typedef {!X} */
 exports.X;
-let /** @type {string} */ user6;
+/** @type {string} */
+let user6;

--- a/test_files/duplicated_externs.js
+++ b/test_files/duplicated_externs.js
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview A file containing externs duplicating the symbols generated from
+ * declare/declare.d.ts (and thus declare/externs.js). This is used to ensure generated externs do
+ * not conflict with pre-existing externs.
+ * @externs
+ */
+
+/** @type {number} */
+var declareGlobalVar;

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -7,30 +7,34 @@
  */
 goog.module('test_files.enum.enum');
 var module = module || { id: 'test_files/enum/enum.ts' };
-// Line with a missing semicolon should not break the following enum.
-const /** @type {!Array<?>} */ EnumTestMissingSemi = [];
+/** @type {!Array<?>} */
+const EnumTestMissingSemi = [];
 /** @enum {number} */
 const EnumTest1 = {
     XYZ: 0, PI: 3.14159,
 };
 EnumTest1[EnumTest1.XYZ] = 'XYZ';
 EnumTest1[EnumTest1.PI] = 'PI';
-// Verify that the resulting TypeScript still allows you to index into the enum with all the various
-// ways allowed of enums.
-let /** @type {EnumTest1} */ enumTestValue = EnumTest1.XYZ;
-let /** @type {EnumTest1} */ enumTestValue2 = EnumTest1['XYZ'];
-let /** @type {string} */ enumNumIndex = EnumTest1[/** @type {number} */ ((null))];
-let /** @type {number} */ enumStrIndex = EnumTest1[/** @type {string} */ ((null))];
+/** @type {EnumTest1} */
+let enumTestValue = EnumTest1.XYZ;
+/** @type {EnumTest1} */
+let enumTestValue2 = EnumTest1['XYZ'];
+/** @type {string} */
+let enumNumIndex = EnumTest1[/** @type {number} */ ((null))];
+/** @type {number} */
+let enumStrIndex = EnumTest1[/** @type {string} */ ((null))];
 /**
  * @param {EnumTest1} val
  * @return {void}
  */
 function enumTestFunction(val) { }
 enumTestFunction(enumTestValue);
-let /** @type {EnumTest1} */ enumTestLookup = EnumTest1["XYZ"];
-let /** @type {?} */ enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
-// Verify that unions of enum members and other values are handled correctly.
-let /** @type {(boolean|EnumTest1)} */ enumUnionType = EnumTest1.XYZ;
+/** @type {EnumTest1} */
+let enumTestLookup = EnumTest1["XYZ"];
+/** @type {?} */
+let enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
+/** @type {(boolean|EnumTest1)} */
+let enumUnionType = EnumTest1.XYZ;
 /** @enum {number} */
 const EnumTest2 = {
     XYZ: 0, PI: 3.14159,
@@ -38,7 +42,8 @@ const EnumTest2 = {
 exports.EnumTest2 = EnumTest2;
 EnumTest2[EnumTest2.XYZ] = 'XYZ';
 EnumTest2[EnumTest2.PI] = 'PI';
-let /** @type {EnumTest2} */ variableUsingExportedEnum;
+/** @type {EnumTest2} */
+let variableUsingExportedEnum;
 /** @enum {number} */
 const ComponentIndex = {
     Scheme: 1,
@@ -57,7 +62,8 @@ const ConstEnum = {
     EMITTED_ENUM_VALUE_2: 1,
 };
 exports.ConstEnum = ConstEnum;
-let /** @type {ConstEnum} */ constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
+/** @type {ConstEnum} */
+let constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
 /**
  * @record
  */

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -14,4 +14,5 @@ function EnumUsingIf_tsickle_Closure_declarations() {
     /** @type {tsickle_forward_declare_1.ConstEnum} */
     EnumUsingIf.prototype.field;
 }
-const /** @type {tsickle_forward_declare_1.ConstEnum} */ fieldUsingConstEnum = 0 /* EMITTED_ENUM_VALUE */;
+/** @type {tsickle_forward_declare_1.ConstEnum} */
+const fieldUsingConstEnum = 0 /* EMITTED_ENUM_VALUE */;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -16,4 +16,5 @@ const ExportedEnum = {
 exports.ExportedEnum = ExportedEnum;
 ExportedEnum[ExportedEnum.VALUE] = 'VALUE';
 ExportedEnum[ExportedEnum.OTHERVALUE] = 'OTHERVALUE';
+/** @type {ExportedEnum} */
 exports.x = ExportedEnum.VALUE;

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -22,20 +22,17 @@ exports.DeclaredType; // re-export typedef
 /** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
-// These conflict with an export discovered via the above exports,
-// so the above export's versions should not show up.
+/** @type {string} */
 exports.export1 = 'wins';
 var export_helper_2 = export_helper_1;
 exports.export3 = export_helper_2.export4;
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
 /** @typedef {!tsickle_forward_declare_3.Interface} */
 exports.RenamedInterface; // re-export typedef
-// This local should be fine to export.
+/** @type {number} */
 exports.exportLocal = 3;
-// The existence of a local should not prevent "export2" from making
-// it to the exports list.  export2 should only show up once in the
-// above two "export *" lines, though.
-let /** @type {number} */ export2 = 3;
+/** @type {number} */
+let export2 = 3;
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.export.export_helper");
 var type_and_value_1 = goog.require('test_files.export.type_and_value');
 exports.TypeAndValue = type_and_value_1.TypeAndValue;

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -9,17 +9,17 @@ exports.export2 = export_helper_1.export2;
 exports.export5 = export_helper_1.export5;
 exports.export4 = export_helper_1.export4;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_1.Bar} */
+/** @typedef {!tsickle_forward_declare_1.Bar} */
 exports.Bar; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.Interface} */
+/** @typedef {!tsickle_forward_declare_1.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
 // These conflict with an export discovered via the above exports,
@@ -28,7 +28,7 @@ exports.export1 = 'wins';
 var export_helper_2 = export_helper_1;
 exports.export3 = export_helper_2.export4;
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_3.Interface} */
+/** @typedef {!tsickle_forward_declare_3.Interface} */
 exports.RenamedInterface; // re-export typedef
 // This local should be fine to export.
 exports.exportLocal = 3;
@@ -49,5 +49,5 @@ function createFoo() {
     return { fooStr: 'fooStr' };
 }
 exports.createFoo = createFoo;
-/** @typedef {tsickle_forward_declare_6.Foo} */
+/** @typedef {!tsickle_forward_declare_6.Foo} */
 exports.Foo; // re-export typedef

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -9,13 +9,13 @@ var module = module || { id: 'test_files/export/export_helper.ts' };
 var export_helper_2_1 = goog.require('test_files.export.export_helper_2');
 exports.export4 = export_helper_2_1.export4;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper_2");
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.Interface} */
+/** @typedef {!tsickle_forward_declare_1.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 exports.export1 = 3;
 exports.export2 = 3;
@@ -30,5 +30,5 @@ function Bar_tsickle_Closure_declarations() {
 }
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -17,7 +17,9 @@ exports.Interface; // re-export typedef
 exports.DeclaredType; // re-export typedef
 /** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
+/** @type {number} */
 exports.export1 = 3;
+/** @type {number} */
 exports.export2 = 3;
 /**
  * @record
@@ -28,6 +30,7 @@ function Bar_tsickle_Closure_declarations() {
     /** @type {number} */
     Bar.prototype.barField;
 }
+/** @type {number} */
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
 /** @typedef {!tsickle_forward_declare_2.TypeDef} */

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -26,7 +26,7 @@ const ConstEnum = {
     AValue: 1,
 };
 exports.ConstEnum = ConstEnum;
-/** @typedef {DeclaredType} */
+/** @typedef {!DeclaredType} */
 exports.DeclaredType;
-/** @typedef {DeclaredInterface} */
+/** @typedef {!DeclaredInterface} */
 exports.DeclaredInterface;

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -4,10 +4,11 @@
  */
 goog.module('test_files.export.export_helper_2');
 var module = module || { id: 'test_files/export/export_helper_2.ts' };
-// This file isn't itself a test case, but it is imported by the
-// export.in.ts test case.
+/** @type {number} */
 exports.export2 = 3;
+/** @type {number} */
 exports.export3 = 3;
+/** @type {number} */
 exports.export4 = 3;
 /** @typedef {(string|number)} */
 var TypeDef;

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -23,5 +23,6 @@ exports.Interface; // re-export typedef
 exports.DeclaredType; // re-export typedef
 /** @typedef {!tsickle_forward_declare_2.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
-const /** @type {number} */ something = 1;
+/** @type {number} */
+const something = 1;
 exports.export2 = something;

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -11,17 +11,17 @@ exports.export3 = export_helper_1.export3;
 exports.export5 = export_helper_1.export5;
 exports.export4 = export_helper_1.export4;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_2.Bar} */
+/** @typedef {!tsickle_forward_declare_2.Bar} */
 exports.Bar; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.Interface} */
+/** @typedef {!tsickle_forward_declare_2.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_2.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_2.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 const /** @type {number} */ something = 1;
 exports.export2 = something;

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };
+/** @type {number} */
 exports.TypeAndValue = 1;

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -5,5 +5,7 @@
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export_declare_namespace.export_declare_namespace");
-let /** @type {!exportedDeclaredNamespace.Used} */ x;
-let /** @type {!nested.exportedNamespace.User} */ y;
+/** @type {!exportedDeclaredNamespace.Used} */
+let x;
+/** @type {!nested.exportedNamespace.User} */
+let y;

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -33,10 +33,12 @@ function FieldsTest_tsickle_Closure_declarations() {
     /** @type {number} */
     FieldsTest.prototype.field3;
 }
-let /** @type {!FieldsTest} */ fieldsTest = new FieldsTest(3);
+/** @type {!FieldsTest} */
+let fieldsTest = new FieldsTest(3);
 // Ensure the type is understood by Closure.
 fieldsTest.field1 = 'hi';
-let /** @type {?} */ AnonymousClass = class {
+/** @type {?} */
+let AnonymousClass = class {
 };
 class BaseThatThrows {
     /**

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -8,5 +8,6 @@
 goog.module('test_files.file_comment.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment/comment_before_elided_import.ts' };
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.file_comment.comment_before_class");
-const /** @type {(null|!tsickle_forward_declare_1.Clazz)} */ x = null;
+/** @type {(null|!tsickle_forward_declare_1.Clazz)} */
+const x = null;
 console.log(x);

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -8,4 +8,5 @@
  */
 goog.module('test_files.file_comment.comment_before_var');
 var module = module || { id: 'test_files/file_comment/comment_before_var.ts' };
+/** @type {number} */
 exports.y = 3;

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -5,5 +5,5 @@
 /** A comment without any tags. */
 goog.module('test_files.file_comment.comment_no_tag');
 var module = module || { id: 'test_files/file_comment/comment_no_tag.ts' };
-// here comes code.
+/** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -4,7 +4,7 @@
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };
-/**
+/** *
  * @noalias
- */
-const /** @type {number} */ aVariable = 1;
+  @type {number} */
+const aVariable = 1;

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -4,5 +4,5 @@
  */
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress.ts' };
-// here comes code.
+/** @type {number} */
 exports.x = 1;

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -4,8 +4,8 @@
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };
-/**
+/** *
  * A function type that includes a generic type argument. Unsupported by
  * Closure, so tsickle should emit ?.
- */
-let /** @type {function(?): ?} */ genericFnType = (x) => x;
+  @type {function(?): ?} */
+let genericFnType = (x) => x;

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -20,10 +20,10 @@ class Container {
      * @return {void}
      */
     method(u) {
-        const /** @type {T} */ myT = this.tField;
-        // Closure Compiler's Old Type Inference does not support using generic
-        // method parameters as local symbols, so myU must be emitted as ?.
-        const /** @type {?} */ myU = u;
+        /** @type {T} */
+        const myT = this.tField;
+        /** @type {?} */
+        const myU = u;
         console.log(myT, myU);
     }
 }

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview See user.ts for the actual test.
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.exporter');
+var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.interface");
+goog.require("test_files.implement_reexported_interface.interface"); // force type-only module to be loaded
+/** @typedef {!tsickle_forward_declare_1.ExportedInterface} */
+exports.ExportedInterface; // re-export typedef

--- a/test_files/implement_reexported_interface/exporter.ts
+++ b/test_files/implement_reexported_interface/exporter.ts
@@ -1,0 +1,3 @@
+/** @fileoverview See user.ts for the actual test. */
+
+export {ExportedInterface} from './interface';

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview See user.ts for the actual test.
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.interface');
+var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };
+/**
+ * @record
+ */
+function ExportedInterface() { }
+exports.ExportedInterface = ExportedInterface;
+function ExportedInterface_tsickle_Closure_declarations() {
+    /** @type {string} */
+    ExportedInterface.prototype.fooStr;
+}

--- a/test_files/implement_reexported_interface/interface.ts
+++ b/test_files/implement_reexported_interface/interface.ts
@@ -1,0 +1,3 @@
+/** @fileoverview See user.ts for the actual test. */
+
+export interface ExportedInterface { fooStr: string; }

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -1,0 +1,25 @@
+/**
+ *
+ * @fileoverview Tests that a re-exported interface can be implemented. This reproduces a bug where
+ * tsickle would define re-exports as just "ExportedInterface", not "!ExportedInterface", which
+ * would then crash Closure Compiler as it creates a union type, which is unexpected for super
+ * interfaces.
+ *
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.user');
+var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.exporter");
+goog.require("test_files.implement_reexported_interface.exporter"); // force type-only module to be loaded
+/**
+ * @implements {tsickle_forward_declare_1.ExportedInterface}
+ */
+class Test {
+    constructor() {
+        this.fooStr = 'a';
+    }
+}
+function Test_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Test.prototype.fooStr;
+}

--- a/test_files/implement_reexported_interface/user.ts
+++ b/test_files/implement_reexported_interface/user.ts
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Tests that a re-exported interface can be implemented. This reproduces a bug where
+ * tsickle would define re-exports as just "ExportedInterface", not "!ExportedInterface", which
+ * would then crash Closure Compiler as it creates a union type, which is unexpected for super
+ * interfaces.
+ */
+
+import {ExportedInterface} from './exporter';
+
+class Test implements ExportedInterface {
+  fooStr = 'a';
+}

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -4,5 +4,6 @@
  */
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };
-const /** @type {number} */ FOO = 1;
+/** @type {number} */
+const FOO = 1;
 exports.FOO = FOO;

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -7,8 +7,7 @@ var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' }
 var goog_closure_Module_1 = goog.require('closure.Module');
 const tsickle_forward_declare_1 = goog.forwardDeclare("closure.Module");
 const tsickle_forward_declare_2 = goog.forwardDeclare("closure.OtherModule");
-// Make sure that default imports from goog: modules are emitted as just the
-// module symbol, without a ".default" property.
-// tslint:disable-next-line:no-inferrable-new-expression
-const /** @type {!tsickle_forward_declare_1} */ x = new goog_closure_Module_1();
-let /** @type {!tsickle_forward_declare_2.SymA} */ y;
+/** @type {!tsickle_forward_declare_1} */
+const x = new goog_closure_Module_1();
+/** @type {!tsickle_forward_declare_2.SymA} */
+let y;

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -8,6 +8,8 @@ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_only_ty
 goog.require("test_files.import_only_types.types_only"); // force type-only module to be loaded
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.import_only_types.types_and_constenum");
 goog.require("test_files.import_only_types.types_and_constenum"); // force type-only module to be loaded
-let /** @type {!tsickle_forward_declare_1.Foo} */ x = { x: 'x' };
-let /** @type {!tsickle_forward_declare_2.SomeInterface} */ y = x;
+/** @type {!tsickle_forward_declare_1.Foo} */
+let x = { x: 'x' };
+/** @type {!tsickle_forward_declare_2.SomeInterface} */
+let y = x;
 console.log(y);

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -4,6 +4,7 @@
  */
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };
+/** @type {number} */
 exports.valueExport = 1;
 /** @typedef {(string|number)} */
 var TypeExport;

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -8,5 +8,6 @@ goog.module('test_files.import_prefixed.import_prefixed_mixed');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_mixed.ts' };
 var exporter = goog.require('test_files.import_prefixed.exporter');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
-let /** @type {tsickle_forward_declare_1.TypeExport} */ someVar;
+/** @type {tsickle_forward_declare_1.TypeExport} */
+let someVar;
 console.log(exporter.valueExport);

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -9,5 +9,6 @@
 goog.module('test_files.import_prefixed.import_prefixed_types');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_types.ts' };
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
-const /** @type {tsickle_forward_declare_1.TypeExport} */ someVar = 1;
+/** @type {tsickle_forward_declare_1.TypeExport} */
+const someVar = 1;
 console.log(someVar);

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };
+/** @type {number} */
 exports.a = 1;

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };
+/** @type {number} */
 exports.b = 2;

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -33,7 +33,8 @@ function User_tsickle_Closure_declarations() {
 function usePoint(p) {
     return p.x + p.y;
 }
-let /** @type {!Point} */ p = { x: 1, y: 1 };
+/** @type {!Point} */
+let p = { x: 1, y: 1 };
 usePoint(p);
 usePoint({ x: 1, y: 1 });
 /**

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -135,21 +135,21 @@ class RedundantJSDocShouldBeStripped {
  * @return {void}
  */
 function JSDocWithBadTag() { }
-/**
+/** *
  * For example,
  * \@madeUpTag
- */
-const /** @type {string} */ c = 'c';
-/**
+  @type {string} */
+const c = 'c';
+/***
  * Don't emit type comments for Polymer behaviors,
  * as this breaks their closure plugin :-(
  *
  * @polymerBehavior
  */
 const somePolymerBehavior = {};
-/**
+/** *
  * Don't emit type comments for Polymer behaviors
  * if they are declared via the Polymer function.
- */
-let /** @type {?} */ Polymer;
+  @type {?} */
+let Polymer;
 Polymer({ behaviors: ['test'] });

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -13,22 +13,31 @@ var module2_1 = goog.require('test_files.jsdoc_types.untyped.module2');
 var module2_2 = module2_1;
 var module2_3 = module2_1;
 var default_1 = goog.require('test_files.jsdoc_types.untyped.default');
-// Check that imported types get the proper names in JSDoc.
-let /** @type {?} */ useNamespacedClass = new module1.Class();
-let /** @type {?} */ useNamespacedClassAsType;
-let /** @type {?} */ useNamespacedType;
-// Should be references to the symbols in module2, perhaps via locals.
-let /** @type {?} */ useLocalClass = new module2_1.ClassOne();
-let /** @type {?} */ useLocalClassRenamed = new module2_2.ClassOne();
-let /** @type {?} */ useLocalClassRenamedTwo = new module2_3.ClassTwo();
-let /** @type {?} */ useLocalClassAsTypeRenamed;
-let /** @type {?} */ useLocalInterface;
-let /** @type {?} */ useClassWithParams;
-// This is purely a value; it doesn't need renaming.
-let /** @type {?} */ useLocalValue = module2_1.value;
-// Check a default import.
-let /** @type {?} */ useDefaultClass = new default_1.default();
-let /** @type {?} */ useDefaultClassAsType;
-// NeverTyped should be {?}, even in typed mode.
-let /** @type {?} */ useNeverTyped;
-let /** @type {?} */ useNeverTyped2;
+/** @type {?} */
+let useNamespacedClass = new module1.Class();
+/** @type {?} */
+let useNamespacedClassAsType;
+/** @type {?} */
+let useNamespacedType;
+/** @type {?} */
+let useLocalClass = new module2_1.ClassOne();
+/** @type {?} */
+let useLocalClassRenamed = new module2_2.ClassOne();
+/** @type {?} */
+let useLocalClassRenamedTwo = new module2_3.ClassTwo();
+/** @type {?} */
+let useLocalClassAsTypeRenamed;
+/** @type {?} */
+let useLocalInterface;
+/** @type {?} */
+let useClassWithParams;
+/** @type {?} */
+let useLocalValue = module2_1.value;
+/** @type {?} */
+let useDefaultClass = new default_1.default();
+/** @type {?} */
+let useDefaultClassAsType;
+/** @type {?} */
+let useNeverTyped;
+/** @type {?} */
+let useNeverTyped2;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -25,7 +25,5 @@ function Interface_tsickle_Closure_declarations() {
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;
-// TODO(evanm):
-// export type TypeAlias = number;
-// export type TypeAliasWithParam<T> = T[];
+/** @type {?} */
 exports.value = 3;

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -1,0 +1,16 @@
+/**
+ *
+ * @fileoverview Tests that initialized variables that end up untyped (`?`) do not get an explicit
+ * type annotation, so that Closure's type inference can kick in and possibly do a better job.
+ *
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.jsdoc_types.initialized_unknown');
+var module = module || { id: 'test_files/jsdoc_types/initialized_unknown.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
+goog.require("test_files.jsdoc_types.nevertyped"); // force type-only module to be loaded
+const initializedUntyped = {
+    foo: 1
+};
+/** @type {?} */
+let uninitializedUntyped;

--- a/test_files/jsdoc_types/initialized_unknown.ts
+++ b/test_files/jsdoc_types/initialized_unknown.ts
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Tests that initialized variables that end up untyped (`?`) do not get an explicit
+ * type annotation, so that Closure's type inference can kick in and possibly do a better job.
+ */
+
+import {NeverTyped} from '../jsdoc_types/nevertyped';
+
+// This should not have a type annotation.
+const initializedUntyped: NeverTyped = {
+  foo: 1
+};
+
+// This should have a type annotation as the variable is not initialized.
+// tslint:disable-next-line:prefer-const
+let uninitializedUntyped: NeverTyped;

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -16,26 +16,36 @@ var default_1 = goog.require('test_files.jsdoc_types.default');
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.default");
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
 goog.require("test_files.jsdoc_types.nevertyped"); // force type-only module to be loaded
-// Check that imported types get the proper names in JSDoc.
-let /** @type {!tsickle_forward_declare_1.Class} */ useNamespacedClass = new module1.Class();
-let /** @type {!tsickle_forward_declare_1.Class} */ useNamespacedClassAsType;
-let /** @type {!tsickle_forward_declare_1.Interface} */ useNamespacedType;
-// Should be references to the symbols in module2, perhaps via locals.
-let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClass = new module2_1.ClassOne();
-let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClassRenamed = new module2_1.ClassOne();
-let /** @type {!tsickle_forward_declare_2.ClassTwo} */ useLocalClassRenamedTwo = new module2_1.ClassTwo();
-let /** @type {!tsickle_forward_declare_2.ClassOne} */ useLocalClassAsTypeRenamed;
-let /** @type {!tsickle_forward_declare_2.Interface} */ useLocalInterface;
-let /** @type {!tsickle_forward_declare_2.ClassWithParams<number>} */ useClassWithParams;
-// This is purely a value; it doesn't need renaming.
-let /** @type {number} */ useLocalValue = module2_1.value;
-// Check a default import.
-let /** @type {!tsickle_forward_declare_3.default} */ useDefaultClass = new default_1.default();
-let /** @type {!tsickle_forward_declare_3.default} */ useDefaultClassAsType;
-// NeverTyped should be {?}, even in typed mode.
-let /** @type {?} */ useNeverTyped;
-let /** @type {(string|?)} */ useNeverTyped2;
-let /** @type {?} */ useNeverTypedTemplated;
+/** @type {!tsickle_forward_declare_1.Class} */
+let useNamespacedClass = new module1.Class();
+/** @type {!tsickle_forward_declare_1.Class} */
+let useNamespacedClassAsType;
+/** @type {!tsickle_forward_declare_1.Interface} */
+let useNamespacedType;
+/** @type {!tsickle_forward_declare_2.ClassOne} */
+let useLocalClass = new module2_1.ClassOne();
+/** @type {!tsickle_forward_declare_2.ClassOne} */
+let useLocalClassRenamed = new module2_1.ClassOne();
+/** @type {!tsickle_forward_declare_2.ClassTwo} */
+let useLocalClassRenamedTwo = new module2_1.ClassTwo();
+/** @type {!tsickle_forward_declare_2.ClassOne} */
+let useLocalClassAsTypeRenamed;
+/** @type {!tsickle_forward_declare_2.Interface} */
+let useLocalInterface;
+/** @type {!tsickle_forward_declare_2.ClassWithParams<number>} */
+let useClassWithParams;
+/** @type {number} */
+let useLocalValue = module2_1.value;
+/** @type {!tsickle_forward_declare_3.default} */
+let useDefaultClass = new default_1.default();
+/** @type {!tsickle_forward_declare_3.default} */
+let useDefaultClassAsType;
+/** @type {?} */
+let useNeverTyped;
+/** @type {(string|?)} */
+let useNeverTyped2;
+/** @type {?} */
+let useNeverTypedTemplated;
 /**
  * Note: no implements JSDoc clause because the type is blacklisted.
  */

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -25,7 +25,5 @@ function Interface_tsickle_Closure_declarations() {
 class ClassWithParams {
 }
 exports.ClassWithParams = ClassWithParams;
-// TODO(evanm):
-// export type TypeAlias = number;
-// export type TypeAliasWithParam<T> = T[];
+/** @type {number} */
 exports.value = 3;

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -4,9 +4,12 @@
  */
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };
-let /** @type {!JSX.Element} */ simple = React.createElement("div", null);
-let /** @type {string} */ hello = 'hello';
-let /** @type {!JSX.Element} */ helloDiv = React.createElement("div", null,
+/** @type {!JSX.Element} */
+let simple = React.createElement("div", null);
+/** @type {string} */
+let hello = 'hello';
+/** @type {!JSX.Element} */
+let helloDiv = React.createElement("div", null,
     hello,
     "hello, world",
     React.createElement(Component, null));

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };
-let /** @type {!decl.ns.one.NamespacedClass} */ user;
+/** @type {!decl.ns.one.NamespacedClass} */
+let user;

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -10,4 +10,5 @@ var unexported;
     }
     unexported.Unexported = Unexported;
 })(unexported || (unexported = {}));
-let /** @type {?} */ x;
+/** @type {?} */
+let x;

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -6,5 +6,7 @@ goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };
 var export_namespace_1 = goog.require('test_files.namespaced.export_namespace');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.namespaced.export_namespace");
-const /** @type {?} */ x = new export_namespace_1.valueNamespace.ValueClass();
-let /** @type {?} */ y;
+/** @type {?} */
+const x = new export_namespace_1.valueNamespace.ValueClass();
+/** @type {?} */
+let y;

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -20,7 +20,8 @@ function getOrDefault(value, def) {
  * @return {string}
  */
 function getMsg() {
-    const /** @type {(null|string)} */ maybeNull = Math.random() > 0.5 ? 'hello' : null;
+    /** @type {(null|string)} */
+    const maybeNull = Math.random() > 0.5 ? 'hello' : null;
     // The value below is inferred as string|null, which would normally cause Closure Compiler to
     // complain about an inconsistent nullable return type. However the @suppress {checkTypes}
     // inserted by tsickle at the top will supprress that error.

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -37,8 +37,10 @@ function NonPrimitives_tsickle_Closure_declarations() {
  * @return {void}
  */
 function takesNonNullable(val) { }
-let /** @type {{field: (null|string|number)}} */ x = { field: null };
+/** @type {{field: (null|string|number)}} */
+let x = { field: null };
 takesNonNullable(/** @type {(string|number)} */ ((x.field)));
 takesNonNullable(`${(/** @type {(string|number)} */ ((x.field)))}`);
-let /** @type {?} */ ctx;
+/** @type {?} */
+let ctx;
 takesNonNullable(`org/${(/** @type {?} */ ((ctx.getTargetOrganization()))).key}/admin/folders`);

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -24,5 +24,6 @@ class OptionalTest {
      */
     method(c = 'hi') { }
 }
-let /** @type {!OptionalTest} */ optionalTest = new OptionalTest('a');
+/** @type {!OptionalTest} */
+let optionalTest = new OptionalTest('a');
 optionalTest.method();

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };
-let /** @type {!PromiseLike<string>} */ promiseLikeOfString;
+/** @type {!PromiseLike<string>} */
+let promiseLikeOfString;

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -17,7 +17,8 @@ function Quoted_tsickle_Closure_declarations() {
     [k: string]: number;
     */
 }
-let /** @type {!Quoted} */ quoted = {};
+/** @type {!Quoted} */
+let quoted = {};
 console.log(quoted["hello"]);
 quoted["hello"] = 1;
 quoted['hello'] = 1;
@@ -37,7 +38,8 @@ function QuotedMixed_tsickle_Closure_declarations() {
     /** @type {number} */
     QuotedMixed.prototype.quotedIdent;
 }
-let /** @type {!QuotedMixed} */ quotedMixed = { foo: 1, 'invalid-identifier': 2, 'quotedIdent': 3 };
+/** @type {!QuotedMixed} */
+let quotedMixed = { foo: 1, 'invalid-identifier': 2, 'quotedIdent': 3 };
 console.log(quotedMixed.foo);
 quotedMixed.foo = 1;
 // Intentionally kept as a quoted access, but gives a warning.
@@ -47,6 +49,6 @@ quotedMixed['foo'] = 1;
 quotedMixed['invalid-identifier'] = 1;
 // Must not be converted to non-quoted access because it was declared quoted.
 quotedMixed['quotedIdent'] = 1;
-// any does not declare any symbols.
-let /** @type {?} */ anyTyped;
+/** @type {?} */
+let anyTyped;
 console.log(anyTyped['token']);

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -10,7 +10,8 @@ function SomeClass_tsickle_Closure_declarations() {
     /** @type {number} */
     SomeClass.prototype.x;
 }
-const /** @type {function(this: (!SomeClass), string): number} */ variableWithFunctionTypeUsingThis = () => 1;
+/** @type {function(this: (!SomeClass), string): number} */
+const variableWithFunctionTypeUsingThis = () => 1;
 /**
  * @return {(undefined|function(this: (string)): string)}
  */

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -5,28 +5,50 @@
  */
 goog.module('test_files.type.type');
 var module = module || { id: 'test_files/type/type.ts' };
-let /** @type {?} */ typeAny;
-let /** @type {!Array<?>} */ typeArr;
-let /** @type {!Array<?>} */ typeArr2;
-let /** @type {!Array<!Array<{a: ?}>>} */ typeNestedArr;
-let /** @type {{a: number, b: string}} */ typeObject = { a: 3, b: 'b' };
-let /** @type {!Object<string,number>} */ typeObjectIndexable;
-let /** @type {?} */ typeObjectMixedIndexProperty;
-let /** @type {!Object} */ typeObjectEmpty;
-let /** @type {!Object} */ typeNonPrimitive;
-let /** @type {!Array<?>} */ typeTuple = [1, 2];
-let /** @type {!Array<?>} */ typeComplexTuple = ['', true];
-let /** @type {!Array<?>} */ typeTupleTuple = [[1, 2]];
-let /** @type {!Array<?>} */ typeTupleTuple2 = [[1, 2], ''];
-let /** @type {(string|boolean)} */ typeUnion = Math.random() > 0.5 ? false : '';
-let /** @type {(string|boolean)} */ typeUnion2 = Math.random() > 0.5 ? false : '';
-let /** @type {{optional: (undefined|boolean)}} */ typeOptionalField = {};
-let /** @type {{optional: (undefined|string|boolean)}} */ typeOptionalUnion = {};
-let /** @type {function(): void} */ typeFunc = function () { };
-let /** @type {function(number, ?): string} */ typeFunc2 = function (a, b) { return ''; };
-let /** @type {function(number, function(number): string): string} */ typeFunc3 = function (x, cb) { return ''; };
-let /** @type {function(number, (undefined|!Object)=): string} */ typeFuncOptionalArg;
-let /** @type {function(number, ...number): void} */ typeFuncVarArgs;
+/** @type {?} */
+let typeAny;
+/** @type {!Array<?>} */
+let typeArr;
+/** @type {!Array<?>} */
+let typeArr2;
+/** @type {!Array<!Array<{a: ?}>>} */
+let typeNestedArr;
+/** @type {{a: number, b: string}} */
+let typeObject = { a: 3, b: 'b' };
+/** @type {!Object<string,number>} */
+let typeObjectIndexable;
+/** @type {?} */
+let typeObjectMixedIndexProperty;
+/** @type {!Object} */
+let typeObjectEmpty;
+/** @type {!Object} */
+let typeNonPrimitive;
+/** @type {!Array<?>} */
+let typeTuple = [1, 2];
+/** @type {!Array<?>} */
+let typeComplexTuple = ['', true];
+/** @type {!Array<?>} */
+let typeTupleTuple = [[1, 2]];
+/** @type {!Array<?>} */
+let typeTupleTuple2 = [[1, 2], ''];
+/** @type {(string|boolean)} */
+let typeUnion = Math.random() > 0.5 ? false : '';
+/** @type {(string|boolean)} */
+let typeUnion2 = Math.random() > 0.5 ? false : '';
+/** @type {{optional: (undefined|boolean)}} */
+let typeOptionalField = {};
+/** @type {{optional: (undefined|string|boolean)}} */
+let typeOptionalUnion = {};
+/** @type {function(): void} */
+let typeFunc = function () { };
+/** @type {function(number, ?): string} */
+let typeFunc2 = function (a, b) { return ''; };
+/** @type {function(number, function(number): string): string} */
+let typeFunc3 = function (x, cb) { return ''; };
+/** @type {function(number, (undefined|!Object)=): string} */
+let typeFuncOptionalArg;
+/** @type {function(number, ...number): void} */
+let typeFuncVarArgs;
 /**
  * @param {function(number): number} callback
  * @return {void}

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -7,4 +7,5 @@ var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' 
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
-let /** @type {(null|!tsickle_forward_declare_2.X|!tsickle_forward_declare_1.Y)} */ xy = null;
+/** @type {(null|!tsickle_forward_declare_2.X|!tsickle_forward_declare_1.Y)} */
+let xy = null;

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.type_alias_imported.export_constant');
 var module = module || { id: 'test_files/type_alias_imported/export_constant.ts' };
+/** @type {number} */
 exports.SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -10,12 +10,12 @@ var export_constant_1 = goog.require('test_files.type_alias_imported.export_cons
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_default_exporter");
-// The union types below use members from the exporting files that are not
-// explicitly imported into this file. tsickle must emit extra forwardDeclare
-// statements for them.
-let /** @type {tsickle_forward_declare_2.XY} */ usingTypeAlias;
-let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_2.Y)} */ usingTypeAliasInUnion;
-let /** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_3.Z)} */ usingDefaultExportAlias;
+/** @type {tsickle_forward_declare_2.XY} */
+let usingTypeAlias;
+/** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_2.Y)} */
+let usingTypeAliasInUnion;
+/** @type {(boolean|!tsickle_forward_declare_4.X|!tsickle_forward_declare_3.Z)} */
+let usingDefaultExportAlias;
 // The code below reproduces an issue where tsickle would break source maps if it just post-hoc
 // prepended imports to its emit, which in turn would break the references to imported symbols, as
 // tsc would no longer understand these symbols are imported and need to be prefixed with the module

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -4,7 +4,9 @@
  */
 goog.module('test_files.type_and_value.module');
 var module = module || { id: 'test_files/type_and_value/module.ts' };
+/** @type {number} */
 exports.TypeAndValue = 3;
+/** @type {number} */
 exports.TemplatizedTypeAndValue = 1;
 class Class {
 }

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -9,16 +9,17 @@ goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };
 var conflict = goog.require('test_files.type_and_value.module');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_and_value.module");
-// This test deals with symbols that are simultaneously types and values.
-// Use a browser built-in as both a type and a value.
-let /** @type {function(new: (!Document)): ?} */ useBuiltInAsValue = Document;
-let /** @type {!Document} */ useBuiltInAsType;
-// Use a user-defined class as both a type and a value.
-let /** @type {?} */ useUserClassAsValue = conflict.Class;
-let /** @type {!tsickle_forward_declare_1.Class} */ useUserClassAsType;
-// Use a user-defined interface/value pair as both a type and a value.
-let /** @type {number} */ useAsValue = conflict.TypeAndValue;
-// Note: because of the conflict, we currently just use the type {?} here.
-let /** @type {?} */ useAsType;
-// Use a templatized user-defined interface/value pair as a type.
-let /** @type {?} */ useAsTypeTemplatized;
+/** @type {function(new: (!Document)): ?} */
+let useBuiltInAsValue = Document;
+/** @type {!Document} */
+let useBuiltInAsType;
+/** @type {?} */
+let useUserClassAsValue = conflict.Class;
+/** @type {!tsickle_forward_declare_1.Class} */
+let useUserClassAsType;
+/** @type {number} */
+let useAsValue = conflict.TypeAndValue;
+/** @type {?} */
+let useAsType;
+/** @type {?} */
+let useAsTypeTemplatized;

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -5,4 +5,5 @@
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };
 const tsickle_forward_declare_1 = goog.forwardDeclare("type_propaccess.nested.clazz");
-const /** @type {(null|!tsickle_forward_declare_1.ClutzedClassWithNested.NestedClutzedClass)} */ x = null;
+/** @type {(null|!tsickle_forward_declare_1.ClutzedClassWithNested.NestedClutzedClass)} */
+const x = null;

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };
-var /** @type {?} */ y = 3;
+/** @type {?} */
+var y = 3;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -6,7 +6,8 @@ goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };
 /** @typedef {number} */
 var MyType;
-var /** @type {number} */ y = 3;
+/** @type {number} */
+var y = 3;
 /** @typedef {{value: number, next: ?}} */
 var Recursive;
 /** @typedef {string} */

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -4,4 +4,5 @@
  */
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };
+/** @type {number} */
 exports.__test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -9,7 +9,8 @@ var module = module || { id: 'test_files/underscore/underscore.ts' };
 var export_underscore_1 = goog.require('test_files.underscore.export_underscore');
 exports.__test = export_underscore_1.__test;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.underscore.export_underscore");
-let /** @type {number} */ __foo = 3;
+/** @type {number} */
+let __foo = 3;
 exports.__bar = __foo;
 class __Class {
     /**

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -8,10 +8,15 @@
 goog.module('test_files.use_closure_externs.use_closure_externs');
 var module = module || { id: 'test_files/use_closure_externs/use_closure_externs.ts' };
 console.log('work around TS dropping consecutive comments');
-let /** @type {!NodeListOf<!HTMLParagraphElement>} */ x = document.getElementsByTagName('p');
+/** @type {!NodeListOf<!HTMLParagraphElement>} */
+let x = document.getElementsByTagName('p');
 console.log(x);
-const /** @type {(null|!RegExpExecArray)} */ res = /** @type {!RegExpExecArray} */ ((/asd/.exec('asd asd')));
+/** @type {(null|!RegExpExecArray)} */
+const res = /** @type {!RegExpExecArray} */ ((/asd/.exec('asd asd')));
 console.log(res);
-let /** @type {!ReadonlyArray<string>} */ a = [''];
-let /** @type {!ReadonlyMap<string, string>} */ m = new Map();
-let /** @type {!ReadonlySet<string>} */ s = new Set();
+/** @type {!ReadonlyArray<string>} */
+let a = [''];
+/** @type {!ReadonlyMap<string, string>} */
+let m = new Map();
+/** @type {!ReadonlySet<string>} */
+let s = new Set();

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -4,7 +4,24 @@
  */
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };
-var /** @type {string} */ v1;
-var /** @type {string} */ v2, /** @type {number} */ v3;
-// Tests that tsickle emits a precise type for the inferred anonymous type of `inferred`.
-const /** @type {{a: number, b: !Array<{c: string}>}} */ inferred = { a: 1, b: [{ c: '2' }] };
+/** @type {string} */
+var v1;
+/** @type {string} */
+var v2;
+/** @type {number} */
+var v3;
+/** @type {{a: number, b: !Array<{c: string}>}} */
+const inferred = { a: 1, b: [{ c: '2' }] };
+/** @type {number} */
+exports.v4 = 1;
+/** @type {number} */
+exports.v6 = 1;
+/** @type {number} */
+let v7 = 1;
+/** @type {number} */
+let v8 = 1;
+const [destructured1, destructured2] = ['destructured1', 'destructured2'];
+const { destructured3, destructured4 } = {
+    destructured3: 3,
+    destructured4: 4
+};

--- a/test_files/variables/variables.ts
+++ b/test_files/variables/variables.ts
@@ -3,7 +3,20 @@ export {};
 var v1: string;
 var v2: string, v3: number;
 
-
 // Tests that tsickle emits a precise type for the inferred anonymous type of `inferred`.
 
 const inferred = {a: 1, b: [{c: '2'}]};
+
+export const v4 = 1;
+export let v5: string, v6 = 1;
+
+let v7 = 1, v8 = 1;
+
+// Closure Compiler has no syntax for destructuring patterns, so these are emitted without a type
+// annotation.
+
+const [destructured1, destructured2]: string[] = ['destructured1', 'destructured2'];
+const {destructured3, destructured4}: {destructured3: number, destructured4: number} = {
+  destructured3: 3,
+  destructured4: 4
+};


### PR DESCRIPTION
tsickle would previously emit variable types inline:

    var /** @type {string} */ x, /** @type {number} y;

This has two issues:
* For exported variables, the type is dropped entirely by TS' emit.
* JSDoc preceding the variable declaration is not merged with the JSDoc
  containing the @type tag.

This change breaks up variable declaration lists into the individual
declarations contained in them, and emits any preceding JSDoc on each
of them, merged with the `@type` declaration.