### PR TITLE
drop an unused import from the testing code

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -15,7 +15,6 @@ import * as ts from 'typescript';
 
 import * as cliSupport from '../src/cli_support';
 import * as es5processor from '../src/es5processor';
-import {toClosureJS} from '../src/main';
 import {BasicSourceMapConsumer, sourceMapTextToConsumer} from '../src/source_map_utils';
 import * as tsickle from '../src/tsickle';
 


### PR DESCRIPTION
This extra import brings in src/main, which then brings in more
dependencies on JavaScript libraries.  To build the tests within
Google it's easier to just not have these dependencies, given
that this import isn't used anyway.