### PR TITLE
Handle inferred types.

### DIFF
--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,4 +1,4 @@
-// Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type
+// Warning at test_files/fields/fields.ts:22:5: unhandled anonymous type with constructor signature but no declaration
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -1,4 +1,3 @@
-// Warning at test_files/jsdoc/jsdoc.ts:44:3: unhandled anonymous type
 // Warning at test_files/jsdoc/jsdoc.ts:16:1: the type annotation on @param is redundant with its TypeScript type, remove the {...} part
 // Warning at test_files/jsdoc/jsdoc.ts:35:3: the type annotation on @export is redundant with its TypeScript type, remove the {...} part
 // Warning at test_files/jsdoc/jsdoc.ts:40:3: @type annotations are redundant with TypeScript equivalents
@@ -83,7 +82,7 @@ function JSDocTest_tsickle_Closure_declarations() {
     JSDocTest.prototype.stringWithoutJSDoc;
     /** @type {number} */
     JSDocTest.prototype.typedThing;
-    /** @type {?} */
+    /** @type {{A: string}} */
     JSDocTest.prototype.badEnumThing;
     /** @type {string} */
     JSDocTest.prototype.badConstThing;

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,4 +1,4 @@
-// Warning at test_files/type/type.ts:14:5: unhandled type literal
+// Warning at test_files/type/type.ts:14:5: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -1,4 +1,4 @@
-// Warning at test_files/type_and_value/type_and_value.ts:10:5: unhandled anonymous type
+// Warning at test_files/type_and_value/type_and_value.ts:10:5: unhandled anonymous type with constructor signature but no declaration
 // Warning at test_files/type_and_value/type_and_value.ts:16:5: type/symbol conflict for TypeAndValue, using {?} for now
 // Warning at test_files/type_and_value/type_and_value.ts:19:5: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -2,5 +2,8 @@
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
-goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};var /** @type {string} */ v1;
+goog.module('test_files.variables.variables');var module = module || {id: 'test_files/variables/variables.js'};
+var /** @type {string} */ v1;
 var /** @type {string} */ v2, /** @type {number} */ v3;
+// Tests that tsickle emits a precise type for the inferred anonymous type of `inferred`.
+const /** @type {{a: number, b: !Array<{c: string}>}} */ inferred = { a: 1, b: [{ c: '2' }] };

--- a/test_files/variables/variables.ts
+++ b/test_files/variables/variables.ts
@@ -1,2 +1,9 @@
+export {};
+
 var v1: string;
 var v2: string, v3: number;
+
+
+// Tests that tsickle emits a precise type for the inferred anonymous type of `inferred`.
+
+const inferred = {a: 1, b: [{c: '2'}]};


### PR DESCRIPTION
Previously, tsickle would only handle defined literal types, e.g.:
    const x: {a: number} = {a: 1};

With this change, tsickle will also emit a type for inferred types:
    const x = {a: 1};

Both of these convert to the same type.