### PR TITLE
Do not export the function using a global this.

### DIFF
--- a/test_files/file_comment.puretransform/multiple_comments.js
+++ b/test_files/file_comment.puretransform/multiple_comments.js
@@ -20,4 +20,3 @@ function f() {
     // Make sure the globalThis suppression above is maintained.
     return this.x;
 }
-exports.f = f;

--- a/test_files/file_comment.puretransform/multiple_comments.ts
+++ b/test_files/file_comment.puretransform/multiple_comments.ts
@@ -15,7 +15,9 @@
  */
 /** Here's another trailing comment */
 
-export function f() {
+function f() {
   // Make sure the globalThis suppression above is maintained.
   return this.x;
 }
+
+export {};

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -25,4 +25,3 @@ function f() {
     // Make sure the globalThis suppression above is maintained.
     return this.x;
 }
-exports.f = f;

--- a/test_files/file_comment/multiple_comments.ts
+++ b/test_files/file_comment/multiple_comments.ts
@@ -15,7 +15,9 @@
  */
 /** Here's another trailing comment */
 
-export function f() {
+function f() {
   // Make sure the globalThis suppression above is maintained.
   return this.x;
 }
+
+export {};


### PR DESCRIPTION
It turns out JSCompiler has a second warning for using `this` in a
static function. The warning is triggered if the function is exported,
because it gets inlined into the exports object and is then considered
to be a static function. This warning cannot be disabled and isn't
included in the `globalThis` suppression, so this fails in newer Closure
Compiler versions.

The fix is to simply not export the function - we're only testing that
the comment gets retained here, so whether or not the function is
exported is irrelevant. This still adds an empty `export {}` block so
that your IDE doesn't complain about duplicate declarations of `f`.