### PR TITLE
Emit exported typedefs for use in the local scope.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1417,21 +1417,22 @@ class Annotator extends ClosureRewriter {
     if (sym.flags & ts.SymbolFlags.Value) return;
 
     // Write a Closure typedef, which involves an unused "var" declaration.
-    // Note: in the case of an export, we cannot emit a literal "var" because
-    // TypeScript drops exports that are never assigned to (and Closure
-    // requires us to not assign to typedef exports).  Instead, emit the
-    // "exports.foo;" line directly in that case.
     this.newTypeTranslator(node).blacklistTypeParameters(
         this.symbolsToAliasedNames, node.typeParameters);
 
     const typeStr = this.typeToClosure(node, undefined, true /* resolveAlias */);
+    const typeName = node.name.getText();
     this.emit(`\n/** @typedef {${typeStr}} */\n`);
+    this.emit(`var ${typeName};\n`);
+    // In the case of an export, we cannot emit a `export var foo;` because TypeScript drops exports
+    // that are never assigned values (and Closure requires us to not assign values to typedef
+    // exports).
+    // tsickle must also still emit the `var` line above so that the type can be used within the
+    // local module scope (Closure does not allow refering to "exports.Foo" within a module).
+    // With that, emit an additional "exports.foo = foo;" line assigning the unset variable into it.
     if (hasModifierFlag(node, ts.ModifierFlags.Export)) {
-      this.emit('exports.');
-    } else {
-      this.emit('var ');
+      this.emit(`exports.${typeName} = ${typeName}\n`);
     }
-    this.emit(`${node.name.getText()};\n`);
   }
 
   /**

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -10,7 +10,8 @@ exports.export2 = 3;
 exports.export3 = 3;
 exports.export4 = 3;
 /** @typedef {(string|number)} */
-exports.TypeDef;
+var TypeDef;
+exports.TypeDef = TypeDef;
 /**
  * @record
  */

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -15,4 +15,15 @@ function Foo_tsickle_Closure_declarations() {
     Foo.prototype.x;
 }
 /** @typedef {number} */
-exports.Bar;
+var Bar;
+exports.Bar = Bar;
+/** @typedef {function(): void} */
+var FnType;
+exports.FnType = FnType;
+/**
+ * Uses exported types to demonstrate that the symbols can be resolved locally.
+ * @param {!Foo} a
+ * @param {FnType} b
+ * @return {void}
+ */
+function doThing(a, b) { }

--- a/test_files/import_only_types/types_only.ts
+++ b/test_files/import_only_types/types_only.ts
@@ -5,3 +5,9 @@ export interface Foo {
 }
 
 export type Bar = number;
+
+/** A type that will be used within this file below. */
+export type FnType = () => void;
+
+/** Uses exported types to demonstrate that the symbols can be resolved locally. */
+function doThing(a: Foo, b: FnType) {}

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -6,4 +6,5 @@ goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };
 exports.valueExport = 1;
 /** @typedef {(string|number)} */
-exports.TypeExport;
+var TypeExport;
+exports.TypeExport = TypeExport;

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -10,4 +10,5 @@ class Y {
 }
 exports.Y = Y;
 /** @typedef {(!tsickle_forward_declare_1.X|!Y)} */
-exports.XY;
+var XY;
+exports.XY = XY;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -10,4 +10,5 @@ var /** @type {number} */ y = 3;
 /** @typedef {{value: number, next: ?}} */
 var Recursive;
 /** @typedef {string} */
-exports.ExportedType;
+var ExportedType;
+exports.ExportedType = ExportedType;


### PR DESCRIPTION
Previously, tsickle would emit an `exports.Foo` typedef, but then
references to this typedef in the local scope would use just `Foo`,
which breaks compilation.

Closure however does not support referencing `exports.Foo` within a
module. Additionally, because typedefs do not create values, they cannot
be aliased and re-exported (`exports.Foo = Foo;`). Thus the only
recourse is to emit the same typedef twice, once for export, once for
local use.

While not particularly elegant, given that typedefs in Closure have no
identity and are pure aliases, this should not create problems.