### PR TITLE
Support property access on imported types.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1216,6 +1216,15 @@ class Annotator extends ClosureRewriter {
       if (sym.flags & ts.SymbolFlags.Alias) {
         sym = this.typeChecker.getAliasedSymbol(sym);
       }
+      // tsickle does not emit exports for ambient namespace declarations:
+      //    "export declare namespace {...}"
+      // So tsickle must not introduce aliases for them that point to the imported module, as those
+      // then don't resolve in Closure Compiler.
+      if (!sym.declarations ||
+          !sym.declarations.some(
+              d => d.kind !== ts.SyntaxKind.ModuleDeclaration || !isAmbient(d))) {
+        continue;
+      }
       // goog: imports don't actually use the .default property that TS thinks they have.
       const qualifiedName = nsImport && isDefaultImport ? forwardDeclarePrefix :
                                                           forwardDeclarePrefix + '.' + sym.name;

--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -24,6 +24,7 @@ export function checkClosureCompile(useNewTypeInferece: boolean, done: DoneFn) {
   goldenJs.push('test_files/import_from_goog/closure_Module.js');
   goldenJs.push('test_files/import_from_goog/closure_OtherModule.js');
   goldenJs.push('test_files/export_equals/shim.js');
+  goldenJs.push('test_files/type_propaccess.no_externs/nested_clazz.js');
   const externs = tests.map(t => t.externsPath).filter(fs.existsSync);
   const startTime = Date.now();
   const total = goldenJs.length;

--- a/test_files/type_propaccess.no_externs/clutzed_namespace.d.ts
+++ b/test_files/type_propaccess.no_externs/clutzed_namespace.d.ts
@@ -1,0 +1,11 @@
+declare namespace ಠ_ಠ.clutz.type_propaccess.nested.clazz {
+  class ClutzedClassWithNested {}
+  namespace ClutzedClassWithNested {
+    export class NestedClutzedClass {}
+  }
+}
+
+declare module 'goog:type_propaccess.nested.clazz' {
+  import alias = ಠ_ಠ.clutz.type_propaccess.nested.clazz;
+  export = alias;
+}

--- a/test_files/type_propaccess.no_externs/nested_clazz.js
+++ b/test_files/type_propaccess.no_externs/nested_clazz.js
@@ -1,0 +1,5 @@
+goog.provide('type_propaccess.nested.clazz');
+
+type_propaccess.nested.clazz.ClutzedClassWithNested = class {};
+
+type_propaccess.nested.clazz.ClutzedClassWithNested.NestedClutzedClass = class {};

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -1,0 +1,8 @@
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+goog.module('test_files.type_propaccess.no_externs.type_propaccess');
+var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("type_propaccess.nested.clazz");
+const /** @type {(null|!tsickle_forward_declare_1.ClutzedClassWithNested.NestedClutzedClass)} */ x = null;

--- a/test_files/type_propaccess.no_externs/type_propaccess.ts
+++ b/test_files/type_propaccess.no_externs/type_propaccess.ts
@@ -1,0 +1,3 @@
+import {ClutzedClassWithNested} from 'goog:type_propaccess.nested.clazz';
+
+const x: ClutzedClassWithNested.NestedClutzedClass|null = null;


### PR DESCRIPTION
TypeScript uses forward declares to refer to imported modules in type
annotations to match TS' loading semantics:

    import {SomeImport} from 'some-module';
    const foo: SomeImport = ...;

tsickle will introduce a forward declare for the imported module:

    var tsickle_fwd_decl_1 = goog.forwardDeclare('some-module')'
    const /** @type {!tsickle_fwd_decl_1.SomeImport} */ foo = ...;

TypeScript code can use types nested in an imported symbol:

    import {SomeImport} from 'some-module';
    const bar: SomeImport.SomeNestedType = ...;

Previously, tsickle would only use an alias for a top level symbol
directly (`SomeImport`), but not for a symbol accessed on an aliased
symbol. This change has tsickle consult the alias map for all symbols
encountered in a type expression.

    const bar: SomeImport.SomeNestedType = ...;
    // gets emitted as:
    const /** @type {!tsickle_fwd_decl_1.SomeImport.SomeNestedType} */ foo = ...;

This also required a change to make sure tsickle does not introduce
aliases for exported declared namespaces, as those do not have an
exported symbol that can be aliased but should rather fall back to the
global symbol emitted for them (covered by existing tests).