### PR TITLE
Export enums declared in namespaces.

### DIFF
--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -5,7 +5,6 @@
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };
 // tslint:disable-next-line:no-namespace
-// tslint:disable-next-line:no-namespace
 var Reflect;
 // tslint:disable-next-line:no-namespace
 (function (Reflect) {

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -1,0 +1,20 @@
+/**
+ *
+ * @fileoverview tsickle's Closure compatible exported enum emit does not work in namespaces. Bar
+ * below must be exported onto foo, which tsickle does by disabling its emit for namespace'd enums.
+ *
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.namespaced.export_enum_in_namespace');
+var module = module || { id: 'test_files/namespaced/export_enum_in_namespace.ts' };
+// tslint:disable:no-namespace
+var foo;
+// tslint:disable:no-namespace
+(function (foo) {
+    let Bar;
+    (function (Bar) {
+        Bar[Bar["X"] = 0] = "X";
+        Bar[Bar["Y"] = 1] = "Y";
+    })(Bar = foo.Bar || (foo.Bar = {}));
+    console.log(Bar); // avoid an "unused assignment" error in Closure.
+})(foo = exports.foo || (exports.foo = {}));

--- a/test_files/namespaced/export_enum_in_namespace.ts
+++ b/test_files/namespaced/export_enum_in_namespace.ts
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview tsickle's Closure compatible exported enum emit does not work in namespaces. Bar
+ * below must be exported onto foo, which tsickle does by disabling its emit for namespace'd enums.
+ */
+
+// tslint:disable:no-namespace
+
+export namespace foo {
+  export enum Bar {
+    X,
+    Y,
+  }
+  console.log(Bar);  // avoid an "unused assignment" error in Closure.
+}

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -2,6 +2,7 @@
  * @fileoverview added by tsickle
  * @suppress {checkTypes} checked by tsc
  */
+// tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_namespace');
 var module = module || { id: 'test_files/namespaced/export_namespace.ts' };
 var valueNamespace;

--- a/test_files/namespaced/export_namespace.ts
+++ b/test_files/namespaced/export_namespace.ts
@@ -1,3 +1,5 @@
+// tslint:disable:no-namespace
+
 export namespace valueNamespace {
   export class ValueClass {}
 }


### PR DESCRIPTION
tsickle normally splits enum declaration and export, so that just `Enum`
in the local scope of the file resolves to the correct symbol:

    /** @enum {...} */
    const Enum = { ... };
    export {Enum};

This works for ES6 exports, but TypeScript's namespaces do not support
separate export statements. To avoid the problem, disable processing of
exported enums that are declared in namespaces.

This fixes the runtime behaviour (`x.Enum` resolves to the right value).
It also means enums in namespaces no longer introduce Closure types.
However tsickle's emit for namespaces is not understood by Closure in
either case, so this fixes runtime behaviour while at least not
regressing otherwise.

Fixes #805.