### PR TITLE
Recognize @tags with leading spaces.

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -159,7 +159,7 @@ export function parseContents(commentText: string): {tags: Tag[], warnings?: str
   const tags: Tag[] = [];
   const warnings: string[] = [];
   for (const line of lines) {
-    let match = line.match(/^@(\S+) *(.*)/);
+    let match = line.match(/^\s*@(\S+) *(.*)/);
     if (match) {
       let [_, tagName, text] = match;
       if (tagName === 'returns') {

--- a/test/jsdoc_test.ts
+++ b/test/jsdoc_test.ts
@@ -22,6 +22,7 @@ describe('jsdoc.parse', () => {
   it('gathers @tags from jsdoc', () => {
     const source = `/**
   * @param foo
+  *   @param indented from line start.
   * @param bar multiple
   *    line comment
   * @return foobar
@@ -30,6 +31,7 @@ describe('jsdoc.parse', () => {
     expect(jsdoc.parse(source)).to.deep.equal({
       tags: [
         {tagName: 'param', parameterName: 'foo'},
+        {tagName: 'param', parameterName: 'indented', text: 'from line start.'},
         {tagName: 'param', parameterName: 'bar', text: 'multiple\n   line comment'},
         {tagName: 'return', text: 'foobar'},
         {tagName: 'nosideeffects'},

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -128,9 +128,9 @@ class RedundantJSDocShouldBeStripped {
  * This comment has code that needs to be escaped to pass Closure checking.
  * \@example
  *
- *   \@Reflect
+ * \@Reflect
  *   function example() {}
- *   \@Reflect.metadata(foo, bar)
+ * \@Reflect.metadata(foo, bar)
  *   function example2() {}
  * @return {void}
  */


### PR DESCRIPTION
Previously, tsickle would ignore and escape such tags. The tags are
parsed by other JSDoc readers (Closure Compiler!), so tsickle should
preserve them for consistency.