### PR TITLE
Handle the re-export edge case where typedef is swallowed.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1119,7 +1119,8 @@ class Annotator extends ClosureRewriter {
               (exp.sym.flags & ts.SymbolFlags.Value) === 0;
       if (!isTypeAlias) continue;
       const typeName = this.symbolsToAliasedNames.get(exp.sym) || exp.sym.name;
-      this.emit(`/** @typedef {${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
+      // Leading newline prevents the typedef from being swallowed.
+      this.emit(`\n/** @typedef {${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
     }
   }
 

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -40,3 +40,14 @@ const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.export.export_
 var type_and_value_1 = goog.require('test_files.export.type_and_value');
 exports.TypeAndValue = type_and_value_1.TypeAndValue;
 const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.export.type_and_value");
+const tsickle_forward_declare_6 = goog.forwardDeclare("test_files.export.export_helper_3");
+goog.require("test_files.export.export_helper_3"); // force type-only module to be loaded
+/**
+ * @return {!tsickle_forward_declare_6.Foo}
+ */
+function createFoo() {
+    return { fooStr: 'fooStr' };
+}
+exports.createFoo = createFoo;
+/** @typedef {tsickle_forward_declare_6.Foo} */
+exports.Foo; // re-export typedef

--- a/test_files/export/export.ts
+++ b/test_files/export/export.ts
@@ -18,3 +18,13 @@ let export2 = 3;
 import {export5} from './export_helper';
 
 export * from './type_and_value';
+
+// Using the interface Foo and the re-exporting it, should preserve
+// typedef annotation.
+import {Foo} from './export_helper_3';
+
+export function createFoo(): Foo {
+  return {fooStr: 'fooStr'};
+}
+
+export {Foo};

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes} checked by tsc
+ */
+goog.module('test_files.export.export_helper_3');
+var module = module || { id: 'test_files/export/export_helper_3.ts' };
+/**
+ * @record
+ */
+function Foo() { }
+exports.Foo = Foo;
+function Foo_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Foo.prototype.fooStr;
+}

--- a/test_files/export/export_helper_3.ts
+++ b/test_files/export/export_helper_3.ts
@@ -1,0 +1,3 @@
+// This file isn't itself a test case, but it is imported by the
+// export.in.ts test case.
+export interface Foo { fooStr: string; }


### PR DESCRIPTION
Allows one to use these types in Closure from where they are re-exported. For example,

If we have the file `export.ts` and some interface `Foo` in `export_helper_3.ts`:
```
import {Foo} from './export_helper_3';
// Do stuff with Foo.
export {Foo};
```

A type definition for Foo should be preserved. Currently, its stripped because
there's no trailing newline written when the node `export {Foo};\n` is written.
Thus, the type isn't available in Closure.

Fixes #816