### PR TITLE
drop use of the google-closure-compiler npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/chai": "4.1.2",
     "@types/diff": "3.2.2",
     "@types/glob": "5.0.35",
-    "@types/google-closure-compiler": "0.0.18",
     "@types/jasmine": "2.8.6",
     "@types/minimatch": "3.0.3",
     "@types/minimist": "1.2.0",

--- a/test/BUILD
+++ b/test/BUILD
@@ -39,6 +39,7 @@ jasmine_node_test(
 ts_library(
     name = "e2e_test_lib",
     srcs = [
+        "closure.ts",
         "e2e_clutz_dts_test.ts",
         "e2e_main_test.ts",
         "e2e_node_kind_source_map_test.ts",

--- a/test/closure.ts
+++ b/test/closure.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview Wrapper around shelling out to the Java Closure Compiler.
+ *
+ * This is the same functionality as the google-closure-compiler npm module,
+ * but to make things easy to use in Google's internal environment where
+ * the dependencies of that module are unavailable, we don't use any of that
+ * module's JavaScript code but only for compiler.jar.
+ */
+
+import * as child_process from 'child_process';
+
+/** Options for invoking the compiler. */
+export interface Options {
+  /**
+   * Path to the Closure compiler .jar.
+   * Defaults to using the one found in the google-closure-compiler npm
+   * package.
+   */
+  jarPath?: string;
+}
+
+/**
+ * The type of command-line flags passed to the compiler, as a map of
+ * flag name to flag value.  Array-valued flags are translated into the
+ * repeated form expected by the compiler.
+ */
+export interface Flags { [flag: string]: boolean|string|string[]; }
+
+/** The type of compilation results, containing exit code and console output. */
+export interface Result {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Converts a flags object into command-line arguments. */
+function flagsToArgs(flags: Flags): string[] {
+  const args: string[] = [];
+  for (const flag in flags) {
+    if (!flags.hasOwnProperty(flag)) continue;
+    const value = flags[flag];
+    if (typeof value === 'boolean') {
+      args.push(`--${flag}`);
+    } else if (typeof value === 'string') {
+      args.push(`--${flag}=${value}`);
+    } else {  // string[]
+      for (const val of value) {
+        args.push(`--${flag}=${val}`);
+      }
+    }
+  }
+  return args;
+}
+
+/** Run the compiler, asynchronously returning a Result. */
+export function compile(options: Options, flags: Flags): Promise<Result> {
+  const jarPath = options.jarPath || require.resolve('google-closure-compiler/compiler.jar');
+
+  const javaArgs = ['-jar', jarPath, ...flagsToArgs(flags)];
+  const proc = child_process.spawn('java', javaArgs);
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', data => {
+      stdout += data;
+    });
+    proc.stderr.on('data', data => {
+      stderr += data;
+    });
+    proc.on('close', exitCode => {
+      resolve({stdout, stderr, exitCode});
+    });
+    proc.on('error', err => {
+      reject(err);
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,22 +14,12 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
-"@types/fancy-log@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/fancy-log/-/fancy-log-1.3.0.tgz#a61ab476e5e628cd07a846330df53b85e05c8ce0"
-
 "@types/glob@5.0.35":
   version "5.0.35"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
   dependencies:
     "@types/events" "*"
     "@types/minimatch" "*"
-    "@types/node" "*"
-
-"@types/google-closure-compiler@0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@types/google-closure-compiler/-/google-closure-compiler-0.0.18.tgz#fe233d02d9bf9c7af95c9e007f042fb7609b9ec4"
-  dependencies:
     "@types/node" "*"
 
 "@types/jasmine@2.8.6":
@@ -96,7 +86,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.0:
+ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -274,14 +264,6 @@ chai@4.1.2:
     get-func-name "^2.0.0"
     pathval "^1.0.0"
     type-detect "^4.0.0"
-
-chalk@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
-  dependencies:
-    ansi-styles "^3.2.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.2.0"
 
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
@@ -610,7 +592,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+extend-shallow@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   dependencies:
@@ -634,7 +616,7 @@ extglob@^2.0.2:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fancy-log@1.3.2, fancy-log@^1.1.0:
+fancy-log@^1.1.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -891,17 +873,6 @@ gulp-diff@^1.0.0:
     gulp-util "^3.0.6"
     through2 "^2.0.0"
 
-gulp-tslint@8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.3.tgz#a89ed144038ae861ee7bfea9528272d126a93da1"
-  dependencies:
-    "@types/fancy-log" "1.3.0"
-    chalk "2.3.1"
-    fancy-log "1.3.2"
-    map-stream "~0.0.7"
-    plugin-error "1.0.1"
-    through "~2.3.8"
-
 gulp-typescript@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-4.0.1.tgz#fd9d2e06a06ea3c1c15885b82ebfb037c07d75b2"
@@ -969,10 +940,6 @@ has-ansi@^2.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -1377,10 +1344,6 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
 
-map-stream@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
-
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
@@ -1654,15 +1617,6 @@ pause-stream@0.0.11:
 pkginfo@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
-
-plugin-error@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
-  dependencies:
-    ansi-colors "^1.0.1"
-    arr-diff "^4.0.0"
-    arr-union "^3.1.0"
-    extend-shallow "^3.0.2"
 
 plugin-error@^0.1.2:
   version "0.1.2"
@@ -2005,12 +1959,6 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
-  dependencies:
-    has-flag "^3.0.0"
-
 temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -2039,7 +1987,7 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, through@~2.3, through@~2.3.1, through@~2.3.8:
+through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
This module depends on a bunch of other npm modules (like vinyl
and so on) that we don't use, which makes it difficult to run
inside of Google.

Instead, rewrite just the tiny bit of the compiler API that we want.

Note: this keeps the google-closure-compiler npm dep in package.json
just for access to the compiler .jar file.  Users can override which
jar to use by setting compiler.jarPath.