### PR TITLE
build fix workaround for tsutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "merge2": "1.2.1",
     "temp": "0.8.3",
     "tslint": "5.9.1",
+    "tsutils": "^2.27.1",
     "typescript": "2.8.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,6 +2069,12 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
+tsutils@^2.27.1:
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.1.tgz#ab0276ac23664f36ce8fd4414daec4aebf4373ee"
+  dependencies:
+    tslib "^1.8.1"
+
 type-detect@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.7.tgz#862bd2cf6058ad92799ff5a5b8cf7b6cec726198"


### PR DESCRIPTION
Both tsetse and tslint want different versions of tsutils.
Somehow adding a local dep on tsutils works around this,
perhaps by pinning it to a newer version?