### PR TITLE
upgrade @types/node and fix code

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/minimatch": "3.0.3",
     "@types/minimist": "1.2.0",
     "@types/mkdirp": "0.5.2",
-    "@types/node": "6.0.102",
+    "@types/node": "^10.3.3",
     "@types/source-map-support": "0.4.0",
     "clang-format": "1.2.2",
     "diff": "3.5.0",

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -199,7 +199,8 @@ export class GoldenFileTest {
 }
 
 export function goldenTests(): GoldenFileTest[] {
-  const basePath = path.join(process.env['RUNFILES'], 'tsickle', 'test_files');
+  assert(process.env['RUNFILES']);
+  const basePath = path.join(process.env['RUNFILES']!, 'tsickle', 'test_files');
   const testNames = fs.readdirSync(basePath);
 
   const testDirs = testNames.map(testName => path.join(basePath, testName))

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
 
-"@types/node@6.0.102":
-  version "6.0.102"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.102.tgz#a6cf3b9843286b63eb362a8522bc382d96fe68d1"
+"@types/node@^10.3.3":
+  version "10.3.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
 
 "@types/source-map-support@0.4.0":
   version "0.4.0"


### PR DESCRIPTION
process.env was type 'any' in our node typings(!).
Upgrading these typings revealed a place where we violate strict null
checks.