### PR TITLE
Export types as non-nullable `@typedefs`.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -693,7 +693,7 @@ class Annotator extends ClosureRewriter {
         if (node.kind === ts.SyntaxKind.ModuleDeclaration) continue;
         // Non-value objects do not exist at runtime, so we cannot access the symbol (it only
         // exists in externs). Export them as a typedef, which forwards to the type in externs.
-        this.emit(`\n/** @typedef {${declName}} */\nexports.${declName};\n`);
+        this.emit(`\n/** @typedef {!${declName}} */\nexports.${declName};\n`);
       } else {
         this.emit(`\nexports.${declName} = ${declName};\n`);
       }
@@ -1109,7 +1109,7 @@ class Annotator extends ClosureRewriter {
       if (!isTypeAlias) continue;
       const typeName = this.symbolsToAliasedNames.get(exp.sym) || exp.sym.name;
       // Leading newline prevents the typedef from being swallowed.
-      this.emit(`\n/** @typedef {${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
+      this.emit(`\n/** @typedef {!${typeName}} */\nexports.${exp.name}; // re-export typedef\n`);
     }
   }
 

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -14,7 +14,7 @@
 // Closure builtin Error type.
 goog.module('test_files.declare_export.declare_export');
 var module = module || { id: 'test_files/declare_export/declare_export.ts' };
-/** @typedef {ExportDeclaredIf} */
+/** @typedef {!ExportDeclaredIf} */
 exports.ExportDeclaredIf;
 let /** @type {!ExportDeclaredIf} */ user1;
 exports.exportedDeclaredVar = window.exportedDeclaredVar;
@@ -26,6 +26,6 @@ let /** @type {function(): string} */ user4 = exportedDeclaredFn;
 exports.multiExportedDeclaredVar1 = window.multiExportedDeclaredVar1;
 exports.multiExportedDeclaredVar2 = window.multiExportedDeclaredVar2;
 let /** @type {string} */ user5 = exports.multiExportedDeclaredVar1;
-/** @typedef {X} */
+/** @typedef {!X} */
 exports.X;
 let /** @type {string} */ user6;

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -9,17 +9,17 @@ exports.export2 = export_helper_1.export2;
 exports.export5 = export_helper_1.export5;
 exports.export4 = export_helper_1.export4;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_1.Bar} */
+/** @typedef {!tsickle_forward_declare_1.Bar} */
 exports.Bar; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.Interface} */
+/** @typedef {!tsickle_forward_declare_1.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
 // These conflict with an export discovered via the above exports,
@@ -28,7 +28,7 @@ exports.export1 = 'wins';
 var export_helper_2 = export_helper_1;
 exports.export3 = export_helper_2.export4;
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_3.Interface} */
+/** @typedef {!tsickle_forward_declare_3.Interface} */
 exports.RenamedInterface; // re-export typedef
 // This local should be fine to export.
 exports.exportLocal = 3;
@@ -49,5 +49,5 @@ function createFoo() {
     return { fooStr: 'fooStr' };
 }
 exports.createFoo = createFoo;
-/** @typedef {tsickle_forward_declare_6.Foo} */
+/** @typedef {!tsickle_forward_declare_6.Foo} */
 exports.Foo; // re-export typedef

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -9,13 +9,13 @@ var module = module || { id: 'test_files/export/export_helper.ts' };
 var export_helper_2_1 = goog.require('test_files.export.export_helper_2');
 exports.export4 = export_helper_2_1.export4;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper_2");
-/** @typedef {tsickle_forward_declare_1.TypeDef} */
+/** @typedef {!tsickle_forward_declare_1.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.Interface} */
+/** @typedef {!tsickle_forward_declare_1.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_1.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 exports.export1 = 3;
 exports.export2 = 3;
@@ -30,5 +30,5 @@ function Bar_tsickle_Closure_declarations() {
 }
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -26,7 +26,7 @@ const ConstEnum = {
     AValue: 1,
 };
 exports.ConstEnum = ConstEnum;
-/** @typedef {DeclaredType} */
+/** @typedef {!DeclaredType} */
 exports.DeclaredType;
-/** @typedef {DeclaredInterface} */
+/** @typedef {!DeclaredInterface} */
 exports.DeclaredInterface;

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -11,17 +11,17 @@ exports.export3 = export_helper_1.export3;
 exports.export5 = export_helper_1.export5;
 exports.export4 = export_helper_1.export4;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {tsickle_forward_declare_2.Bar} */
+/** @typedef {!tsickle_forward_declare_2.Bar} */
 exports.Bar; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.RenamedTypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.TypeDef} */
+/** @typedef {!tsickle_forward_declare_2.TypeDef} */
 exports.TypeDef; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.Interface} */
+/** @typedef {!tsickle_forward_declare_2.Interface} */
 exports.Interface; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.DeclaredType} */
+/** @typedef {!tsickle_forward_declare_2.DeclaredType} */
 exports.DeclaredType; // re-export typedef
-/** @typedef {tsickle_forward_declare_2.DeclaredInterface} */
+/** @typedef {!tsickle_forward_declare_2.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
 const /** @type {number} */ something = 1;
 exports.export2 = something;

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview See user.ts for the actual test.
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.exporter');
+var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.interface");
+goog.require("test_files.implement_reexported_interface.interface"); // force type-only module to be loaded
+/** @typedef {!tsickle_forward_declare_1.ExportedInterface} */
+exports.ExportedInterface; // re-export typedef

--- a/test_files/implement_reexported_interface/exporter.ts
+++ b/test_files/implement_reexported_interface/exporter.ts
@@ -1,0 +1,3 @@
+/** @fileoverview See user.ts for the actual test. */
+
+export {ExportedInterface} from './interface';

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview See user.ts for the actual test.
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.interface');
+var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };
+/**
+ * @record
+ */
+function ExportedInterface() { }
+exports.ExportedInterface = ExportedInterface;
+function ExportedInterface_tsickle_Closure_declarations() {
+    /** @type {string} */
+    ExportedInterface.prototype.fooStr;
+}

--- a/test_files/implement_reexported_interface/interface.ts
+++ b/test_files/implement_reexported_interface/interface.ts
@@ -1,0 +1,3 @@
+/** @fileoverview See user.ts for the actual test. */
+
+export interface ExportedInterface { fooStr: string; }

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -1,0 +1,25 @@
+/**
+ *
+ * @fileoverview Tests that a re-exported interface can be implemented. This reproduces a bug where
+ * tsickle would define re-exports as just "ExportedInterface", not "!ExportedInterface", which
+ * would then crash Closure Compiler as it creates a union type, which is unexpected for super
+ * interfaces.
+ *
+ * @suppress {checkTypes,extraRequire} checked by tsc
+ */
+goog.module('test_files.implement_reexported_interface.user');
+var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.exporter");
+goog.require("test_files.implement_reexported_interface.exporter"); // force type-only module to be loaded
+/**
+ * @implements {tsickle_forward_declare_1.ExportedInterface}
+ */
+class Test {
+    constructor() {
+        this.fooStr = 'a';
+    }
+}
+function Test_tsickle_Closure_declarations() {
+    /** @type {string} */
+    Test.prototype.fooStr;
+}

--- a/test_files/implement_reexported_interface/user.ts
+++ b/test_files/implement_reexported_interface/user.ts
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Tests that a re-exported interface can be implemented. This reproduces a bug where
+ * tsickle would define re-exports as just "ExportedInterface", not "!ExportedInterface", which
+ * would then crash Closure Compiler as it creates a union type, which is unexpected for super
+ * interfaces.
+ */
+
+import {ExportedInterface} from './exporter';
+
+class Test implements ExportedInterface {
+  fooStr = 'a';
+}


### PR DESCRIPTION
In Closure Compiler's `@typedef`, any mentioned types without a `!` are
implicitly nullable (as in all other locations). While `typeToClosure`
takes care to insert the `!` as needed, some locations in tsickle export
a plain type name. In that case, we must take care to insert the `!`
at the emit site.

This fixes a crash in Closure Compiler when as it encounters a union
type when resolving super types (e.g. implemented interfaces).