### PR TITLE
Only emit forwardDeclares for exported modules.

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -305,6 +305,7 @@ export function addDiffMatchers() {
   // tslint:disable:no-require-imports
   jasmine.addMatchers(require('jasmine-diff')(jasmine, {
     colors: true,
+    inline: true,
   }));
 }
 

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -21,30 +21,29 @@ exports.Interface; // re-export typedef
 exports.DeclaredType; // re-export typedef
 /** @typedef {!tsickle_forward_declare_1.DeclaredInterface} */
 exports.DeclaredInterface; // re-export typedef
-const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");
 /** @type {string} */
 exports.export1 = 'wins';
 var export_helper_2 = export_helper_1;
 exports.export3 = export_helper_2.export4;
-const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
-/** @typedef {!tsickle_forward_declare_3.Interface} */
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper");
+/** @typedef {!tsickle_forward_declare_2.Interface} */
 exports.RenamedInterface; // re-export typedef
 /** @type {number} */
 exports.exportLocal = 3;
 /** @type {number} */
 let export2 = 3;
-const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.export.export_helper");
+const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.export.export_helper");
 var type_and_value_1 = goog.require('test_files.export.type_and_value');
 exports.TypeAndValue = type_and_value_1.TypeAndValue;
-const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.export.type_and_value");
-const tsickle_forward_declare_6 = goog.forwardDeclare("test_files.export.export_helper_3");
+const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.export.type_and_value");
+const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.export.export_helper_3");
 goog.require("test_files.export.export_helper_3"); // force type-only module to be loaded
 /**
- * @return {!tsickle_forward_declare_6.Foo}
+ * @return {!tsickle_forward_declare_5.Foo}
  */
 function createFoo() {
     return { fooStr: 'fooStr' };
 }
 exports.createFoo = createFoo;
-/** @typedef {!tsickle_forward_declare_6.Foo} */
+/** @typedef {!tsickle_forward_declare_5.Foo} */
 exports.Foo; // re-export typedef

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -10,5 +10,4 @@ exports.a = has_index_1.a;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.index_import.has_index.index");
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.index_import.has_index.index");
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.index_import.has_index.index");
-const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.index_import.has_index.index");
-const tsickle_forward_declare_6 = goog.forwardDeclare("test_files.index_import.lib");
+const tsickle_forward_declare_5 = goog.forwardDeclare("test_files.index_import.lib");


### PR DESCRIPTION
Previously, tsickle would emit a forwardDeclare even if it did not emit
an export statement for the referenced module. That'd cause a module
to be forward declared that was never imported, which then breaks the
build on the Closure side, as the forward declare is never satisfied.