### PR TITLE
rearrange @fileoverview handling

### DIFF
--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.abstract.abstract');
 var module = module || { id: 'test_files/abstract/abstract.ts' };

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.basic.untyped.basic.untyped');
 var module = module || { id: 'test_files/basic.untyped/basic.untyped.ts' };

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.class.untyped.class');
 var module = module || { id: 'test_files/class.untyped/class.ts' };

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,7 +1,7 @@
 // test_files/class/class.ts(129,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // This test exercises the various ways classes and interfaces can interact.
 // There are three types of classy things:

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.clutz.no_externs.strip_clutz_type');
 var module = module || { id: 'test_files/clutz.no_externs/strip_clutz_type.ts' };

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.coerce.coerce');
 var module = module || { id: 'test_files/coerce/coerce.ts' };

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.comments.comments');
 var module = module || { id: 'test_files/comments/comments.ts' };

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.declare_class_ns.declare_class_ns');
 var module = module || { id: 'test_files/declare_class_ns/declare_class_ns.ts' };

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.declare_class_overloads.declare_class_overloads');
 var module = module || { id: 'test_files/declare_class_overloads/declare_class_overloads.ts' };

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.declare_export.untyped.declare_export');
 var module = module || { id: 'test_files/declare_export.untyped/declare_export.ts' };

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // All of the types/values declared in this file should
 // 1) generate externs

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.decorator.external');
 var module = module || { id: 'test_files/decorator/external.ts' };

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.decorator.external2');
 var module = module || { id: 'test_files/decorator/external2.ts' };

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');
 var module = module || { id: 'test_files/decorator_nested_scope/decorator_nested_scope.ts' };

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.default.default');
 var module = module || { id: 'test_files/default/default.ts' };

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.doc_params.doc_params');
 var module = module || { id: 'test_files/doc_params/doc_params.ts' };

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.enum.untyped.enum.untyped');
 var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -3,7 +3,7 @@
 // test_files/enum/enum.ts(15,22): warning TS0: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.enum.enum');
 var module = module || { id: 'test_files/enum/enum.ts' };

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.enum.enum_user');
 var module = module || { id: 'test_files/enum/enum_user.ts' };

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // Note: if you only have one value in the enum, then the type of "x" below
 // is just ExportedEnum, regardless of the annotation.  This might be a bug

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.export');
 var module = module || { id: 'test_files/export/export.ts' };

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.export_helper');
 var module = module || { id: 'test_files/export/export_helper.ts' };

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.export_helper_2');
 var module = module || { id: 'test_files/export/export_helper_2.ts' };

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.export_helper_3');
 var module = module || { id: 'test_files/export/export_helper_3.ts' };

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.export_star_imported');
 var module = module || { id: 'test_files/export/export_star_imported.ts' };

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.export_declare_namespace');
 var module = module || { id: 'test_files/export_declare_namespace/export_declare_namespace.ts' };

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };

--- a/test_files/export_equals/export_equals.js
+++ b/test_files/export_equals/export_equals.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_equals.export_equals');
 var module = module || { id: 'test_files/export_equals/export_equals.ts' };

--- a/test_files/export_equals/user.js
+++ b/test_files/export_equals/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_equals.user');
 var module = module || { id: 'test_files/export_equals/user.ts' };

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.importer');
 var module = module || { id: 'test_files/export_types_values.untyped/importer.ts' };

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.value_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/value_exporter.ts' };

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,7 +1,7 @@
 // test_files/fields/fields.ts(22,5): warning TS0: unhandled anonymous type with constructor signature but no declaration
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.fields.fields');
 var module = module || { id: 'test_files/fields/fields.ts' };

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');
 var module = module || { id: 'test_files/fields_no_ctor/fields_no_ctor.ts' };

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 /** A comment without any tags. */
 goog.module('test_files.file_comment.comment_no_tag');

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview
- * @suppress {undefinedVars,checkTypes}  because we don't like them errors
+ * @suppress {checkTypes,extraRequire,undefinedVars}  because we don't like them errors
  *
  */
 goog.module('test_files.file_comment.comment_with_text');

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.file_comment.file_comment');
 var module = module || { id: 'test_files/file_comment/file_comment.ts' };

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview Tests merging JSDoc tags in fileoverview comments.
- * @suppress {extraRequire,checkTypes}
+ * @suppress {checkTypes,extraRequire}
  *
  */
 goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.file_comment.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment/jsdoc_comment.ts' };

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -12,7 +12,7 @@
 /**
  *
  * @fileoverview The last fileoverview actually takes effect.
- * @suppress {globalThis,checkTypes}
+ * @suppress {checkTypes,extraRequire,globalThis}
  *
  */
 /** Here's another trailing comment */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,7 +1,7 @@
 /**
+ * @fileoverview added by tsickle
  * @modName {some_mod}
  * @suppress {checkTypes,extraRequire} checked by tsc
- * @fileoverview
  */
 goog.module('test_files.file_comment.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment/other_fileoverview_comments.ts' };

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.functions.untyped.functions');
 var module = module || { id: 'test_files/functions.untyped/functions.ts' };

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.functions.functions');
 var module = module || { id: 'test_files/functions/functions.ts' };

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.generic_local_var.generic_local_var');
 var module = module || { id: 'test_files/generic_local_var/generic_local_var.ts' };

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.generic_type_alias.generic_type_alias');
 var module = module || { id: 'test_files/generic_type_alias/generic_type_alias.ts' };

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_alias.importer');
 var module = module || { id: 'test_files/import_alias/importer.ts' };

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_default.exporter');
 var module = module || { id: 'test_files/import_default/exporter.ts' };

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_default.import_default');
 var module = module || { id: 'test_files/import_default/import_default.ts' };

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_empty.imported');
 var module = module || { id: 'test_files/import_empty/imported.ts' };

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_from_goog.import_from_goog');
 var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' };

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_only_types.import_only_types');
 var module = module || { id: 'test_files/import_only_types/import_only_types.ts' };

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // const enum values are inlined, so even though const enums are values,
 // TypeScript might not generate any imports for them, which means modules

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // Exports only types, but must still be goog.require'd for Closure Compiler.
 goog.module('test_files.import_only_types.types_only');

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // This file imports exporter with a prefix import (* as ...), and then uses the
 // import in a type and in a value position.

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // This file imports exporter with a prefix import (* as ...), and then only
 // uses the import in a type position.

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.index_import.has_index.relative');
 var module = module || { id: 'test_files/index_import/has_index/relative.ts' };

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.index_import.user');
 var module = module || { id: 'test_files/index_import/user.ts' };

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.interface.implement_import');
 var module = module || { id: 'test_files/interface/implement_import.ts' };

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.interface.interface');
 var module = module || { id: 'test_files/interface/interface.ts' };

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.interface.interface_extends');
 var module = module || { id: 'test_files/interface/interface_extends.ts' };

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.interface.interface_type_params');
 var module = module || { id: 'test_files/interface/interface_type_params.ts' };

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -19,7 +19,7 @@
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc.jsdoc');
 var module = module || { id: 'test_files/jsdoc/jsdoc.ts' };

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.default');
 var module = module || { id: 'test_files/jsdoc_types.untyped/default.ts' };

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 /**
  * This test tests importing a type across module boundaries,

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module1');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module1.ts' };

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module2');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module2.ts' };

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.default');
 var module = module || { id: 'test_files/jsdoc_types/default.ts' };

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 /**
  * This test tests importing a type across module boundaries,

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module1');
 var module = module || { id: 'test_files/jsdoc_types/module1.ts' };

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module2');
 var module = module || { id: 'test_files/jsdoc_types/module2.ts' };

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.methods.methods');
 var module = module || { id: 'test_files/methods/methods.ts' };

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_namespace');

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.namespaced.local_namespace');
 var module = module || { id: 'test_files/namespaced/local_namespace.ts' };

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.nonnull_generics.nonnull_generics');
 var module = module || { id: 'test_files/nonnull_generics/nonnull_generics.ts' };

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.nullable.nullable');
 var module = module || { id: 'test_files/nullable/nullable.ts' };

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.optional.optional');
 var module = module || { id: 'test_files/optional/optional.ts' };

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.parameter_properties.parameter_properties');
 var module = module || { id: 'test_files/parameter_properties/parameter_properties.ts' };

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.promiseconstructor.promiseconstructor');
 var module = module || { id: 'test_files/promiseconstructor/promiseconstructor.ts' };

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.promisectorlike.promisectorlike');
 var module = module || { id: 'test_files/promisectorlike/promisectorlike.ts' };

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -4,7 +4,7 @@
 // test_files/quote_props/quote.ts(29,1): warning TS0: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.quote_props.quote');
 var module = module || { id: 'test_files/quote_props/quote.ts' };

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.static.static');
 var module = module || { id: 'test_files/static/static.ts' };

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.structural.untyped.structural.untyped');
 var module = module || { id: 'test_files/structural.untyped/structural.untyped.ts' };

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.super.super');
 var module = module || { id: 'test_files/super/super.ts' };

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.this_type.this_type');
 var module = module || { id: 'test_files/this_type/this_type.ts' };

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,7 +1,7 @@
 // test_files/type/type.ts(14,5): warning TS0: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type.type');
 var module = module || { id: 'test_files/type/type.ts' };

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_alias_imported.elided_comment');
 var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' };

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_exporter.ts' };

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_and_value.module');
 var module = module || { id: 'test_files/type_and_value/module.ts' };

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -3,7 +3,7 @@
 // test_files/type_and_value/type_and_value.ts(19,5): warning TS0: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_guard_fn.type_guard_fn');
 var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 // Verify that double-underscored names in various places don't get corrupted.
 // See getIdentifierText() in tsickle.ts.

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes} checked by tsc
+ * @suppress {checkTypes,extraRequire} checked by tsc
  */
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };


### PR DESCRIPTION
The fileoverview logic had three different cases where it added to
the suppress list, and extraRequire was only included in one of the
three.  I want to add another entry to our suppression list, so I'll
start by refactoring this so that suppressions are handled in one place.

This rebaselines ~every test because we now consistently suppress
extraRequire.