### PR TITLE
remove function wrappers for member type declarations

### DIFF
--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -60,6 +60,9 @@ function augmentFileoverviewComments(tags: jsdoc.Tag[]) {
   // 2) Suppress extraRequire.  We remove extra requires at the TypeScript level, so any require
   // that gets to the JS level is a load-bearing require.
   suppressions.add('extraRequire');
+  // 3) Suppress uselessCode.  We emit an "if (false)" around type declarations,
+  // which is flagged as unused code unless we suppress it.
+  suppressions.add('uselessCode');
   suppressTag.type = Array.from(suppressions.values()).sort().join(',');
 
   return tags;

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1288,7 +1288,7 @@ class Annotator extends ClosureRewriter {
     if (docTags.length > 0) this.emit(jsdoc.toString(docTags));
     // this.writeNode(classDecl, true /*skipComments*/);
     this.writeNodeFrom(classDecl, classDecl.getStart(), classDecl.getEnd());
-    this.emitTypeAnnotationsHelper(classDecl);
+    this.emitMemberTypes(classDecl);
     return true;
   }
 
@@ -1312,23 +1312,20 @@ class Annotator extends ClosureRewriter {
     const name = getIdentifierText(iface.name);
     this.emit(`function ${name}() {}\n`);
 
-    this.emit(`\n\nfunction ${name}_tsickle_Closure_declarations() {\n`);
     const memberNamespace = [name, 'prototype'];
     for (const elem of iface.members) {
       const isOptional = elem.questionToken != null;
       this.visitProperty(memberNamespace, elem, isOptional);
     }
-    this.emit(`}\n`);
   }
 
   /**
-   * emitTypeAnnotationsHelper produces a _tsickle_typeAnnotationsHelper() where
-   * none existed in the original source. It's necessary in the case where
-   * TypeScript syntax specifies there are additional properties on the class,
-   * because to declare these in Closure you must declare these in a method
-   * somewhere.
+   * emitMemberTypes emits the type annotations for members of a class.
+   * It's necessary in the case where TypeScript syntax specifies
+   * there are additional properties on the class, because to declare
+   * these in Closure you must declare these separately from the class.
    */
-  private emitTypeAnnotationsHelper(classDecl: ts.ClassDeclaration) {
+  private emitMemberTypes(classDecl: ts.ClassDeclaration) {
     // Gather parameter properties from the constructor, if it exists.
     const ctors: ts.ConstructorDeclaration[] = [];
     let paramProps: ts.ParameterDeclaration[] = [];
@@ -1372,7 +1369,7 @@ class Annotator extends ClosureRewriter {
     const className = getIdentifierText(classDecl.name);
 
     // See test_files/fields/fields.ts:BaseThatThrows for a note on this wrapper.
-    this.emit(`\n\nfunction ${className}_tsickle_Closure_declarations() {\n`);
+    this.emit(`\n\nif (false) {`);
     staticProps.forEach(p => this.visitProperty([className], p));
     const memberNamespace = [className, 'prototype'];
     nonStaticProps.forEach((p) => this.visitProperty(memberNamespace, p));

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.abstract.abstract');
 var module = module || { id: 'test_files/abstract/abstract.ts' };
@@ -19,7 +19,7 @@ class Base {
         this.hasReturnType();
     }
 }
-function Base_tsickle_Closure_declarations() {
+if (false) {
     /**
      * @abstract
      * @return {void}

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Reproduces an error that caused incorrect Automatic Semicolon Insertion.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');
 var module = module || { id: 'test_files/arrow_fn.es5/arrow_fn_es5.ts' };

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.basic.untyped.basic.untyped');
 var module = module || { id: 'test_files/basic.untyped/basic.untyped.ts' };
@@ -20,7 +20,7 @@ class Foo {
         this.field = 'hello';
     }
 }
-function Foo_tsickle_Closure_declarations() {
+if (false) {
     /** @type {?} */
     Foo.prototype.field;
     /** @type {?} */

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.class.untyped.class');
 var module = module || { id: 'test_files/class.untyped/class.ts' };
@@ -8,10 +8,8 @@ var module = module || { id: 'test_files/class.untyped/class.ts' };
  * @record
  */
 function Interface() { }
-function Interface_tsickle_Closure_declarations() {
-    /** @type {?} */
-    Interface.prototype.interfaceFunc;
-}
+/** @type {?} */
+Interface.prototype.interfaceFunc;
 class Super {
     /**
      * @return {?}
@@ -62,7 +60,7 @@ superVar = new ImplementsTypeAlias();
 function Zone() { }
 class ZoneImplementsInterface {
 }
-function ZoneImplementsInterface_tsickle_Closure_declarations() {
+if (false) {
     /** @type {?} */
     ZoneImplementsInterface.prototype.zone;
 }
@@ -70,7 +68,7 @@ function ZoneImplementsInterface_tsickle_Closure_declarations() {
 var ZoneAlias;
 class ZoneImplementsAlias {
 }
-function ZoneImplementsAlias_tsickle_Closure_declarations() {
+if (false) {
     /** @type {?} */
     ZoneImplementsAlias.prototype.zone;
 }

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,7 +1,7 @@
 // test_files/class/class.ts(129,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // This test exercises the various ways classes and interfaces can interact.
 // There are three types of classy things:
@@ -17,10 +17,8 @@ var module = module || { id: 'test_files/class/class.ts' };
  * @record
  */
 function Interface() { }
-function Interface_tsickle_Closure_declarations() {
-    /** @type {function(): void} */
-    Interface.prototype.interfaceFunc;
-}
+/** @type {function(): void} */
+Interface.prototype.interfaceFunc;
 class Class {
     /**
      * @return {void}
@@ -36,7 +34,7 @@ class AbstractClass {
      */
     nonAbstractFunc() { }
 }
-function AbstractClass_tsickle_Closure_declarations() {
+if (false) {
     /**
      * @abstract
      * @return {void}
@@ -48,10 +46,8 @@ function AbstractClass_tsickle_Closure_declarations() {
  * @extends {Interface}
  */
 function InterfaceExtendsInterface() { }
-function InterfaceExtendsInterface_tsickle_Closure_declarations() {
-    /** @type {function(): void} */
-    InterfaceExtendsInterface.prototype.interfaceFunc2;
-}
+/** @type {function(): void} */
+InterfaceExtendsInterface.prototype.interfaceFunc2;
 /** @type {!InterfaceExtendsInterface} */
 let interfaceExtendsInterface = {
     /**
@@ -67,10 +63,8 @@ let interfaceExtendsInterface = {
  * @record
  */
 function InterfaceExtendsClass() { }
-function InterfaceExtendsClass_tsickle_Closure_declarations() {
-    /** @type {function(): void} */
-    InterfaceExtendsClass.prototype.interfaceFunc3;
-}
+/** @type {function(): void} */
+InterfaceExtendsClass.prototype.interfaceFunc3;
 /**
  * @implements {Interface}
  */
@@ -198,7 +192,7 @@ abstractClassVar = new ClassExtendsAbstractClass();
 function Zone() { }
 class ZoneImplementsInterface {
 }
-function ZoneImplementsInterface_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     ZoneImplementsInterface.prototype.zone;
 }
@@ -206,7 +200,7 @@ function ZoneImplementsInterface_tsickle_Closure_declarations() {
 var ZoneAlias;
 class ZoneImplementsAlias {
 }
-function ZoneImplementsAlias_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     ZoneImplementsAlias.prototype.zone;
 }

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.clutz.no_externs.strip_clutz_type');
 var module = module || { id: 'test_files/clutz.no_externs/strip_clutz_type.ts' };

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.coerce.coerce');
 var module = module || { id: 'test_files/coerce/coerce.ts' };

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,12 +1,12 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.comments.comments');
 var module = module || { id: 'test_files/comments/comments.ts' };
 class Comments {
 }
-function Comments_tsickle_Closure_declarations() {
+if (false) {
     /**
      * @export
      * @type {string}

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };
@@ -14,7 +14,7 @@ class X {
         this.a = a;
     }
 }
-function X_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     X.prototype.a;
 }

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_ns.declare_class_ns');
 var module = module || { id: 'test_files/declare_class_ns/declare_class_ns.ts' };

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_overloads.declare_class_overloads');
 var module = module || { id: 'test_files/declare_class_overloads/declare_class_overloads.ts' };

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_export.untyped.declare_export');
 var module = module || { id: 'test_files/declare_export.untyped/declare_export.ts' };

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // All of the types/values declared in this file should
 // 1) generate externs

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };
@@ -119,7 +119,7 @@ tslib_1.__decorate([
     decorator,
     tslib_1.__metadata("design:type", external_1.AClass)
 ], DecoratorTest.prototype, "z", void 0);
-function DecoratorTest_tsickle_Closure_declarations() {
+if (false) {
     /**
      * Some comment
      * @type {number}
@@ -135,7 +135,7 @@ let DecoratedClass = class DecoratedClass {
 DecoratedClass = tslib_1.__decorate([
     classDecorator
 ], DecoratedClass);
-function DecoratedClass_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     DecoratedClass.prototype.z;
 }

--- a/test_files/decorator/default_export.js
+++ b/test_files/decorator/default_export.js
@@ -1,13 +1,13 @@
 /**
  * @fileoverview Tests using a default imported class for in a decorated ctor.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.default_export');
 var module = module || { id: 'test_files/decorator/default_export.ts' };
 class DefaultExport {
 }
 exports.default = DefaultExport;
-function DefaultExport_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     DefaultExport.prototype.field;
 }

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external');
 var module = module || { id: 'test_files/decorator/external.ts' };
@@ -21,5 +21,3 @@ exports.AClassWithGenerics = AClassWithGenerics;
  */
 function AType() { }
 exports.AType = AType;
-function AType_tsickle_Closure_declarations() {
-}

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external2');
 var module = module || { id: 'test_files/decorator/external2.ts' };

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -3,7 +3,7 @@
  * @fileoverview only_types only exports types, so TypeScript will elide the
  * import entirely.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.only_types');
 var module = module || { id: 'test_files/decorator/only_types.ts' };
@@ -12,7 +12,5 @@ var module = module || { id: 'test_files/decorator/only_types.ts' };
  */
 function AnotherType() { }
 exports.AnotherType = AnotherType;
-function AnotherType_tsickle_Closure_declarations() {
-    /** @type {string} */
-    AnotherType.prototype.field;
-}
+/** @type {string} */
+AnotherType.prototype.field;

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');
 var module = module || { id: 'test_files/decorator_nested_scope/decorator_nested_scope.ts' };

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.default.default');
 var module = module || { id: 'test_files/default/default.ts' };

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.doc_params.doc_params');
 var module = module || { id: 'test_files/doc_params/doc_params.ts' };
@@ -13,7 +13,7 @@ class Foo {
         this.a = a;
     }
 }
-function Foo_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     Foo.prototype.a;
 }

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.untyped.enum.untyped');
 var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -3,7 +3,7 @@
 // test_files/enum/enum.ts(15,22): warning TS0: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.enum');
 var module = module || { id: 'test_files/enum/enum.ts' };
@@ -69,12 +69,10 @@ let constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
  */
 function InterfaceUsingConstEnum() { }
 exports.InterfaceUsingConstEnum = InterfaceUsingConstEnum;
-function InterfaceUsingConstEnum_tsickle_Closure_declarations() {
-    /** @type {ConstEnum} */
-    InterfaceUsingConstEnum.prototype.field;
-    /** @type {ConstEnum} */
-    InterfaceUsingConstEnum.prototype.field2;
-}
+/** @type {ConstEnum} */
+InterfaceUsingConstEnum.prototype.field;
+/** @type {ConstEnum} */
+InterfaceUsingConstEnum.prototype.field2;
 /** @enum {number} */
 const EnumWithNonConstValues = {
     Scheme: (x => x + 1)(3),

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.enum_user');
 var module = module || { id: 'test_files/enum/enum_user.ts' };
@@ -10,9 +10,7 @@ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.enum.enum");
  */
 function EnumUsingIf() { }
 exports.EnumUsingIf = EnumUsingIf;
-function EnumUsingIf_tsickle_Closure_declarations() {
-    /** @type {tsickle_forward_declare_1.ConstEnum} */
-    EnumUsingIf.prototype.field;
-}
+/** @type {tsickle_forward_declare_1.ConstEnum} */
+EnumUsingIf.prototype.field;
 /** @type {tsickle_forward_declare_1.ConstEnum} */
 const fieldUsingConstEnum = 0 /* EMITTED_ENUM_VALUE */;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // Note: if you only have one value in the enum, then the type of "x" below
 // is just ExportedEnum, regardless of the annotation.  This might be a bug

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export');
 var module = module || { id: 'test_files/export/export.ts' };

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper');
 var module = module || { id: 'test_files/export/export_helper.ts' };
@@ -26,10 +26,8 @@ exports.export2 = 3;
  */
 function Bar() { }
 exports.Bar = Bar;
-function Bar_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Bar.prototype.barField;
-}
+/** @type {number} */
+Bar.prototype.barField;
 /** @type {number} */
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper_2');
 var module = module || { id: 'test_files/export/export_helper_2.ts' };
@@ -18,10 +18,8 @@ exports.TypeDef = TypeDef;
  */
 function Interface() { }
 exports.Interface = Interface;
-function Interface_tsickle_Closure_declarations() {
-    /** @type {string} */
-    Interface.prototype.x;
-}
+/** @type {string} */
+Interface.prototype.x;
 /** @enum {number} */
 const ConstEnum = {
     AValue: 1,

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper_3');
 var module = module || { id: 'test_files/export/export_helper_3.ts' };
@@ -9,7 +9,5 @@ var module = module || { id: 'test_files/export/export_helper_3.ts' };
  */
 function Foo() { }
 exports.Foo = Foo;
-function Foo_tsickle_Closure_declarations() {
-    /** @type {string} */
-    Foo.prototype.fooStr;
-}
+/** @type {string} */
+Foo.prototype.fooStr;

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_star_imported');
 var module = module || { id: 'test_files/export/export_star_imported.ts' };

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.export_declare_namespace');
 var module = module || { id: 'test_files/export_declare_namespace/export_declare_namespace.ts' };

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };

--- a/test_files/export_equals/export_equals.js
+++ b/test_files/export_equals/export_equals.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.export_equals');
 var module = module || { id: 'test_files/export_equals/export_equals.ts' };

--- a/test_files/export_equals/user.js
+++ b/test_files/export_equals/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.user');
 var module = module || { id: 'test_files/export_equals/user.ts' };

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.importer');
 var module = module || { id: 'test_files/export_types_values.untyped/importer.ts' };

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.value_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/value_exporter.ts' };

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };
@@ -101,7 +101,7 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:type", Number),
     tslib_1.__metadata("design:paramtypes", [Number])
 ], MyClass.prototype, "doNotExportThisSetter", null);
-function MyClass_tsickle_Closure_declarations() {
+if (false) {
     /**
      * @type {boolean}
      * @export

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,7 +1,7 @@
 // test_files/fields/fields.ts(22,5): warning TS0: unhandled anonymous type with constructor signature but no declaration
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.fields.fields');
 var module = module || { id: 'test_files/fields/fields.ts' };
@@ -23,7 +23,7 @@ class FieldsTest {
         return this.field1;
     }
 }
-function FieldsTest_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     FieldsTest.prototype.field1;
     /** @type {number} */
@@ -48,7 +48,7 @@ class BaseThatThrows {
 }
 class Derived extends BaseThatThrows {
 }
-function Derived_tsickle_Closure_declarations() {
+if (false) {
     /**
      * Note: in Closure, this type is declared via an annotation on
      * Derived.prototype.throwMe, which throws if it's evaluated.

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,12 +1,12 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');
 var module = module || { id: 'test_files/fields_no_ctor/fields_no_ctor.ts' };
 class NoCtor {
 }
-function NoCtor_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     NoCtor.prototype.field1;
 }

--- a/test_files/file_comment/before_import.js
+++ b/test_files/file_comment/before_import.js
@@ -4,7 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the regular import case.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.before_import');
 var module = module || { id: 'test_files/file_comment/before_import.ts' };

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -4,7 +4,7 @@
  * it before its JSDoc block. This comment would not get emitted if detached
  * source file comments were not emitted separately.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_class');
 var module = module || { id: 'test_files/file_comment/comment_before_class.ts' };

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -3,7 +3,7 @@
  * @fileoverview This is a comment before an import, where the import will be elided but the comment
  * must be kept.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment/comment_before_elided_import.ts' };

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -4,7 +4,7 @@
  * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
  * @modName {foobar}
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_var');
 var module = module || { id: 'test_files/file_comment/comment_before_var.ts' };

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 /** A comment without any tags. */
 goog.module('test_files.file_comment.comment_no_tag');

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview
- * @suppress {checkTypes,extraRequire,undefinedVars}  because we don't like them errors
+ * @suppress {checkTypes,extraRequire,undefinedVars,uselessCode}  because we don't like them errors
  *
  */
 goog.module('test_files.file_comment.comment_with_text');

--- a/test_files/file_comment/export_star.js
+++ b/test_files/file_comment/export_star.js
@@ -4,7 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the export * case.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.export_star');
 var module = module || { id: 'test_files/file_comment/export_star.ts' };

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.file_comment');
 var module = module || { id: 'test_files/file_comment/file_comment.ts' };

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview a comment without a suppress tag.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress.ts' };

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview Tests merging JSDoc tags in fileoverview comments.
- * @suppress {checkTypes,extraRequire}
+ * @suppress {checkTypes,extraRequire,uselessCode}
  *
  */
 goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment/jsdoc_comment.ts' };

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -12,7 +12,7 @@
 /**
  *
  * @fileoverview The last fileoverview actually takes effect.
- * @suppress {checkTypes,extraRequire,globalThis}
+ * @suppress {checkTypes,extraRequire,globalThis,uselessCode}
  *
  */
 /** Here's another trailing comment */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview added by tsickle
  * @modName {some_mod}
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment/other_fileoverview_comments.ts' };

--- a/test_files/file_comment/side_effect_import.js
+++ b/test_files/file_comment/side_effect_import.js
@@ -4,7 +4,7 @@
  * transformer_util.ts has special logic to handle comments before
  * import/require() calls. This file tests the side-effect import case.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.side_effect_import');
 var module = module || { id: 'test_files/file_comment/side_effect_import.ts' };

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.untyped.functions');
 var module = module || { id: 'test_files/functions.untyped/functions.ts' };

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.functions');
 var module = module || { id: 'test_files/functions/functions.ts' };

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -2,7 +2,7 @@
  *
  * @fileoverview This text here matches the     text below in length.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.two_jsdoc_blocks');
 var module = module || { id: 'test_files/functions/two_jsdoc_blocks.ts' };

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_local_var.generic_local_var');
 var module = module || { id: 'test_files/generic_local_var/generic_local_var.ts' };
@@ -27,7 +27,7 @@ class Container {
         console.log(myT, myU);
     }
 }
-function Container_tsickle_Closure_declarations() {
+if (false) {
     /** @type {T} */
     Container.prototype.tField;
 }

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_type_alias.generic_type_alias');
 var module = module || { id: 'test_files/generic_type_alias/generic_type_alias.ts' };

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.exporter');
 var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.interface');
 var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };
@@ -9,7 +9,5 @@ var module = module || { id: 'test_files/implement_reexported_interface/interfac
  */
 function ExportedInterface() { }
 exports.ExportedInterface = ExportedInterface;
-function ExportedInterface_tsickle_Closure_declarations() {
-    /** @type {string} */
-    ExportedInterface.prototype.fooStr;
-}
+/** @type {string} */
+ExportedInterface.prototype.fooStr;

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -5,7 +5,7 @@
  * would then crash Closure Compiler as it creates a union type, which is unexpected for super
  * interfaces.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.user');
 var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };
@@ -19,7 +19,7 @@ class Test {
         this.fooStr = 'a';
     }
 }
-function Test_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     Test.prototype.fooStr;
 }

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.importer');
 var module = module || { id: 'test_files/import_alias/importer.ts' };

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.exporter');
 var module = module || { id: 'test_files/import_default/exporter.ts' };

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.import_default');
 var module = module || { id: 'test_files/import_default/import_default.ts' };

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Make sure tsickle does not crash on empty imports.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.import_empty');
 var module = module || { id: 'test_files/import_empty/import_empty.ts' };

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.imported');
 var module = module || { id: 'test_files/import_empty/imported.ts' };

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_from_goog.import_from_goog');
 var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' };

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_only_types.import_only_types');
 var module = module || { id: 'test_files/import_only_types/import_only_types.ts' };

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // const enum values are inlined, so even though const enums are values,
 // TypeScript might not generate any imports for them, which means modules
@@ -18,5 +18,3 @@ exports.ConstEnum = ConstEnum;
  */
 function SomeInterface() { }
 exports.SomeInterface = SomeInterface;
-function SomeInterface_tsickle_Closure_declarations() {
-}

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // Exports only types, but must still be goog.require'd for Closure Compiler.
 goog.module('test_files.import_only_types.types_only');
@@ -10,10 +10,8 @@ var module = module || { id: 'test_files/import_only_types/types_only.ts' };
  */
 function Foo() { }
 exports.Foo = Foo;
-function Foo_tsickle_Closure_declarations() {
-    /** @type {string} */
-    Foo.prototype.x;
-}
+/** @type {string} */
+Foo.prototype.x;
 /** @typedef {number} */
 var Bar;
 exports.Bar = Bar;

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // This file imports exporter with a prefix import (* as ...), and then uses the
 // import in a type and in a value position.

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // This file imports exporter with a prefix import (* as ...), and then only
 // uses the import in a type position.

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.relative');
 var module = module || { id: 'test_files/index_import/has_index/relative.ts' };

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.user');
 var module = module || { id: 'test_files/index_import/user.ts' };

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.implement_import');
 var module = module || { id: 'test_files/interface/implement_import.ts' };
@@ -19,7 +19,7 @@ class MyPoint {
         this.y = y;
     }
 }
-function MyPoint_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     MyPoint.prototype.x;
     /** @type {number} */
@@ -36,7 +36,7 @@ class ImplementsUser {
         this.shoeSize = shoeSize;
     }
 }
-function ImplementsUser_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     ImplementsUser.prototype.shoeSize;
 }

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface');
 var module = module || { id: 'test_files/interface/interface.ts' };
@@ -10,19 +10,17 @@ var module = module || { id: 'test_files/interface/interface.ts' };
  */
 function Point() { }
 exports.Point = Point;
-function Point_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Point.prototype.x;
-    /** @type {number} */
-    Point.prototype.y;
-}
+/** @type {number} */
+Point.prototype.x;
+/** @type {number} */
+Point.prototype.y;
 /**
  * Used by implement_import.ts
  */
 class User {
 }
 exports.User = User;
-function User_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     User.prototype.shoeSize;
 }
@@ -41,25 +39,23 @@ usePoint({ x: 1, y: 1 });
  * @record
  */
 function TrickyInterface() { }
-function TrickyInterface_tsickle_Closure_declarations() {
-    /* TODO: handle strange member:
-    [offset: number]: number;
-    */
-    /** @type {number} */
-    TrickyInterface.prototype.foo;
-    /* TODO: handle strange member:
-    (x: number): __ yuck __
-          number;
-    */
-    /** @type {(undefined|string)} */
-    TrickyInterface.prototype.foobar;
-    /** @type {?|undefined} */
-    TrickyInterface.prototype.optAny;
-    /**
-     * \@param a some string value
-     * \@return some number value
-     * @override
-     * @type {function(string): number}
-     */
-    TrickyInterface.prototype.hasSomeParamJsDoc;
-}
+/* TODO: handle strange member:
+[offset: number]: number;
+*/
+/** @type {number} */
+TrickyInterface.prototype.foo;
+/* TODO: handle strange member:
+(x: number): __ yuck __
+      number;
+*/
+/** @type {(undefined|string)} */
+TrickyInterface.prototype.foobar;
+/** @type {?|undefined} */
+TrickyInterface.prototype.optAny;
+/**
+ * \@param a some string value
+ * \@return some number value
+ * @override
+ * @type {function(string): number}
+ */
+TrickyInterface.prototype.hasSomeParamJsDoc;

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_extends');
 var module = module || { id: 'test_files/interface/interface_extends.ts' };
@@ -8,26 +8,20 @@ var module = module || { id: 'test_files/interface/interface_extends.ts' };
  * @record
  */
 function ParentInterface() { }
-function ParentInterface_tsickle_Closure_declarations() {
-    /** @type {number} */
-    ParentInterface.prototype.x;
-}
+/** @type {number} */
+ParentInterface.prototype.x;
 /**
  * @record
  * @extends {ParentInterface}
  */
 function SubType() { }
-function SubType_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SubType.prototype.y;
-}
+/** @type {number} */
+SubType.prototype.y;
 /**
  * @record
  * @extends {ParentInterface}
  * @extends {SubType}
  */
 function SubMulti() { }
-function SubMulti_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SubMulti.prototype.z;
-}
+/** @type {number} */
+SubMulti.prototype.z;

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_type_params');
 var module = module || { id: 'test_files/interface/interface_type_params.ts' };
@@ -8,19 +8,15 @@ var module = module || { id: 'test_files/interface/interface_type_params.ts' };
  * @record
  */
 function UpperBound() { }
-function UpperBound_tsickle_Closure_declarations() {
-    /** @type {number} */
-    UpperBound.prototype.x;
-}
+/** @type {number} */
+UpperBound.prototype.x;
 // unsupported: template constraints.
 /**
  * @record
  * @template T, U
  */
 function WithTypeParam() { }
-function WithTypeParam_tsickle_Closure_declarations() {
-    /** @type {T} */
-    WithTypeParam.prototype.tea;
-    /** @type {U} */
-    WithTypeParam.prototype.you;
-}
+/** @type {T} */
+WithTypeParam.prototype.tea;
+/** @type {U} */
+WithTypeParam.prototype.you;

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -19,7 +19,7 @@
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc.jsdoc');
 var module = module || { id: 'test_files/jsdoc/jsdoc.ts' };
@@ -62,7 +62,7 @@ class JSDocTest {
  * \@internal
  */
 JSDocTest.X = [];
-function JSDocTest_tsickle_Closure_declarations() {
+if (false) {
     /**
      * \@internal
      * @type {!Array<string>}

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.default');
 var module = module || { id: 'test_files/jsdoc_types.untyped/default.ts' };

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 /**
  * This test tests importing a type across module boundaries,

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module1');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module1.ts' };
@@ -12,10 +12,5 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-function Interface_tsickle_Closure_declarations() {
-    /** @type {?} */
-    Interface.prototype.x;
-    /* TODO: handle strange member:
-    "quoted-bad-name": string;
-    */
-}
+/** @type {?} */
+Interface.prototype.x;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module2');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module2.ts' };
@@ -15,10 +15,8 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-function Interface_tsickle_Closure_declarations() {
-    /** @type {?} */
-    Interface.prototype.x;
-}
+/** @type {?} */
+Interface.prototype.x;
 /**
  * @template T
  */

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
@@ -11,7 +11,5 @@ var module = module || { id: 'test_files/jsdoc_types.untyped/nevertyped.ts' };
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-function NeverTyped_tsickle_Closure_declarations() {
-    /** @type {?} */
-    NeverTyped.prototype.foo;
-}
+/** @type {?} */
+NeverTyped.prototype.foo;

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.default');
 var module = module || { id: 'test_files/jsdoc_types/default.ts' };

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -3,7 +3,7 @@
  * @fileoverview Tests that initialized variables that end up untyped (`?`) do not get an explicit
  * type annotation, so that Closure's type inference can kick in and possibly do a better job.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.initialized_unknown');
 var module = module || { id: 'test_files/jsdoc_types/initialized_unknown.ts' };

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 /**
  * This test tests importing a type across module boundaries,
@@ -51,7 +51,7 @@ let useNeverTypedTemplated;
  */
 class ImplementsNeverTyped {
 }
-function ImplementsNeverTyped_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     ImplementsNeverTyped.prototype.foo;
 }
@@ -60,7 +60,7 @@ function ImplementsNeverTyped_tsickle_Closure_declarations() {
  */
 class ImplementsNeverTypedTemplated {
 }
-function ImplementsNeverTypedTemplated_tsickle_Closure_declarations() {
+if (false) {
     /** @type {T} */
     ImplementsNeverTypedTemplated.prototype.foo;
 }

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module1');
 var module = module || { id: 'test_files/jsdoc_types/module1.ts' };
@@ -12,10 +12,5 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-function Interface_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Interface.prototype.x;
-    /* TODO: handle strange member:
-    "quoted-bad-name": string;
-    */
-}
+/** @type {number} */
+Interface.prototype.x;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module2');
 var module = module || { id: 'test_files/jsdoc_types/module2.ts' };
@@ -15,10 +15,8 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-function Interface_tsickle_Closure_declarations() {
-    /** @type {number} */
-    Interface.prototype.x;
-}
+/** @type {number} */
+Interface.prototype.x;
 /**
  * @template T
  */

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/
@@ -11,17 +11,13 @@ var module = module || { id: 'test_files/jsdoc_types/nevertyped.ts' };
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-function NeverTyped_tsickle_Closure_declarations() {
-    /** @type {number} */
-    NeverTyped.prototype.foo;
-}
+/** @type {number} */
+NeverTyped.prototype.foo;
 /**
  * @record
  * @template T
  */
 function NeverTypedTemplated() { }
 exports.NeverTypedTemplated = NeverTypedTemplated;
-function NeverTypedTemplated_tsickle_Closure_declarations() {
-    /** @type {T} */
-    NeverTypedTemplated.prototype.foo;
-}
+/** @type {T} */
+NeverTypedTemplated.prototype.foo;

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.methods.methods');
 var module = module || { id: 'test_files/methods/methods.ts' };
@@ -24,7 +24,7 @@ class HasMethods {
      */
     set f(n) { this._f = n - 1; }
 }
-function HasMethods_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     HasMethods.prototype._f;
 }

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -3,7 +3,7 @@
  * @fileoverview tsickle's Closure compatible exported enum emit does not work in namespaces. Bar
  * below must be exported onto foo, which tsickle does by disabling its emit for namespace'd enums.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.export_enum_in_namespace');
 var module = module || { id: 'test_files/namespaced/export_enum_in_namespace.ts' };

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_namespace');
@@ -18,6 +18,4 @@ var typeNamespace;
      */
     function Interface() { }
     typeNamespace.Interface = Interface;
-    function Interface_tsickle_Closure_declarations() {
-    }
 })(typeNamespace = typeNamespace || (typeNamespace = {}));

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.local_namespace');
 var module = module || { id: 'test_files/namespaced/local_namespace.ts' };

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.nonnull_generics.nonnull_generics');
 var module = module || { id: 'test_files/nonnull_generics/nonnull_generics.ts' };

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,12 +1,12 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.nullable.nullable');
 var module = module || { id: 'test_files/nullable/nullable.ts' };
 class Primitives {
 }
-function Primitives_tsickle_Closure_declarations() {
+if (false) {
     /** @type {(null|string)} */
     Primitives.prototype.nullable;
     /** @type {(undefined|number)} */
@@ -20,7 +20,7 @@ class NonPrimitive {
 }
 class NonPrimitives {
 }
-function NonPrimitives_tsickle_Closure_declarations() {
+if (false) {
     /** @type {!NonPrimitive} */
     NonPrimitives.prototype.nonNull;
     /** @type {(null|!NonPrimitive)} */

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.optional.optional');
 var module = module || { id: 'test_files/optional/optional.ts' };

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.parameter_properties.parameter_properties');
 var module = module || { id: 'test_files/parameter_properties/parameter_properties.ts' };
@@ -22,7 +22,7 @@ class ParamProps {
         this.publicReadonlyP = publicReadonlyP;
     }
 }
-function ParamProps_tsickle_Closure_declarations() {
+if (false) {
     /**
      * @export
      * @type {string}

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.promiseconstructor.promiseconstructor');
 var module = module || { id: 'test_files/promiseconstructor/promiseconstructor.ts' };

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.promisectorlike.promisectorlike');
 var module = module || { id: 'test_files/promisectorlike/promisectorlike.ts' };

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -4,7 +4,7 @@
 // test_files/quote_props/quote.ts(29,1): warning TS0: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.quote_props.quote');
 var module = module || { id: 'test_files/quote_props/quote.ts' };
@@ -12,11 +12,6 @@ var module = module || { id: 'test_files/quote_props/quote.ts' };
  * @record
  */
 function Quoted() { }
-function Quoted_tsickle_Closure_declarations() {
-    /* TODO: handle strange member:
-    [k: string]: number;
-    */
-}
 /** @type {!Quoted} */
 let quoted = {};
 console.log(quoted["hello"]);
@@ -29,15 +24,13 @@ quoted["hello"] = 1;
  * @extends {Quoted}
  */
 function QuotedMixed() { }
-function QuotedMixed_tsickle_Closure_declarations() {
-    /** @type {number} */
-    QuotedMixed.prototype.foo;
-    /* TODO: handle strange member:
-    'invalid-identifier': number;
-    */
-    /** @type {number} */
-    QuotedMixed.prototype.quotedIdent;
-}
+/** @type {number} */
+QuotedMixed.prototype.foo;
+/* TODO: handle strange member:
+'invalid-identifier': number;
+*/
+/** @type {number} */
+QuotedMixed.prototype.quotedIdent;
 /** @type {!QuotedMixed} */
 let quotedMixed = { foo: 1, 'invalid-identifier': 2, 'quotedIdent': 3 };
 console.log(quotedMixed.foo);

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.static.static');
 var module = module || { id: 'test_files/static/static.ts' };
@@ -9,7 +9,7 @@ class Static {
 // This should not become a stub declaration.
 Static.bar = 3;
 Static.baz = 3;
-function Static_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     Static.bar;
     /** @type {number} */

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.structural.untyped.structural.untyped');
 var module = module || { id: 'test_files/structural.untyped/structural.untyped.ts' };
@@ -10,7 +10,7 @@ class StructuralTest {
      */
     method() { return this.field1; }
 }
-function StructuralTest_tsickle_Closure_declarations() {
+if (false) {
     /** @type {?} */
     StructuralTest.prototype.field1;
 }

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.super.super');
 var module = module || { id: 'test_files/super/super.ts' };
@@ -15,7 +15,7 @@ class SuperTestBaseOneArg {
         this.x = x;
     }
 }
-function SuperTestBaseOneArg_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     SuperTestBaseOneArg.prototype.x;
 }
@@ -28,7 +28,7 @@ class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
         this.y = y;
     }
 }
-function SuperTestDerivedParamProps_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     SuperTestDerivedParamProps.prototype.y;
 }
@@ -38,7 +38,7 @@ class SuperTestDerivedInitializedProps extends SuperTestBaseOneArg {
         this.y = 'foo';
     }
 }
-function SuperTestDerivedInitializedProps_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     SuperTestDerivedInitializedProps.prototype.y;
 }
@@ -55,23 +55,21 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
  * @record
  */
 function SuperTestInterface() { }
-function SuperTestInterface_tsickle_Closure_declarations() {
-    /** @type {number} */
-    SuperTestInterface.prototype.foo;
-}
+/** @type {number} */
+SuperTestInterface.prototype.foo;
 /**
  * @implements {SuperTestInterface}
  */
 class SuperTestDerivedInterface {
 }
-function SuperTestDerivedInterface_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     SuperTestDerivedInterface.prototype.foo;
 }
 class SuperTestStaticProp extends SuperTestBaseOneArg {
 }
 SuperTestStaticProp.foo = 3;
-function SuperTestStaticProp_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     SuperTestStaticProp.foo;
 }

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,12 +1,12 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.this_type.this_type');
 var module = module || { id: 'test_files/this_type/this_type.ts' };
 class SomeClass {
 }
-function SomeClass_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     SomeClass.prototype.x;
 }

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,7 +1,7 @@
 // test_files/type/type.ts(14,5): warning TS0: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type.type');
 var module = module || { id: 'test_files/type/type.ts' };

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.elided_comment');
 var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' };

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See comments in type_alias_imported.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.export_constant');
 var module = module || { id: 'test_files/type_alias_imported/export_constant.ts' };

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -3,7 +3,7 @@
  * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
  * must ultimately be imported by type_alias_imported.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_declare');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_declare.ts' };
@@ -12,7 +12,5 @@ var module = module || { id: 'test_files/type_alias_imported/type_alias_declare.
  */
 function X() { }
 exports.X = X;
-function X_tsickle_Closure_declarations() {
-    /** @type {string} */
-    X.prototype.x;
-}
+/** @type {string} */
+X.prototype.x;

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -3,7 +3,7 @@
  * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
  * type reference is created (no .default property).
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_default_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_default_exporter.ts' };

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_exporter.ts' };

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Make sure imports are inserted *after* the fileoverview.
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_imported');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_imported.ts' };

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_and_value.module');
 var module = module || { id: 'test_files/type_and_value/module.ts' };
@@ -11,7 +11,7 @@ exports.TemplatizedTypeAndValue = 1;
 class Class {
 }
 exports.Class = Class;
-function Class_tsickle_Closure_declarations() {
+if (false) {
     /** @type {number} */
     Class.prototype.z;
 }

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -3,7 +3,7 @@
 // test_files/type_and_value/type_and_value.ts(19,5): warning TS0: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_guard_fn.type_guard_fn');
 var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 // Verify that double-underscored names in various places don't get corrupted.
 // See getIdentifierText() in tsickle.ts.
@@ -21,7 +21,7 @@ class __Class {
         return this.__member;
     }
 }
-function __Class_tsickle_Closure_declarations() {
+if (false) {
     /** @type {string} */
     __Class.prototype.__member;
 }
@@ -29,5 +29,3 @@ function __Class_tsickle_Closure_declarations() {
  * @record
  */
 function __Interface() { }
-function __Interface_tsickle_Closure_declarations() {
-}

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -3,7 +3,7 @@
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
  *
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.use_closure_externs.use_closure_externs');
 var module = module || { id: 'test_files/use_closure_externs/use_closure_externs.ts' };

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire} checked by tsc
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };


### PR DESCRIPTION
To declare the types of class members, we want to emit e.g.
  /** @type {Foo} */
  MyClass.prototype.foo;

We cannot declare these in the class constructor because sometimes
we don't have a constructor and it's difficult to create our own
(we'd need to match the superclass in that case).

We sometimes cannot declare these at the top level because it's possible
there's a supertype that throws on get, which means the code cannot be
loaded as written without compiling it first.  (We know this actually
can happen because we tried it.)

In the past we declared these in a helper method or bare function,
but it turns out declarations in those are ignored by Closure in
unpredictable circumstances.

So our final approach is:
- for interfaces, declare them at the top level
- for classes, wrap them in an 'if (false)' block.
To do so we must suppress the 'useless code' compiler check, because
putting code in an 'if (false)' is pretty suspicious looking otherwise.
