### PR TITLE
sort symbols before emitting them

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -2020,6 +2020,13 @@ export function emitWithTsickle(
   };
 }
 
+/** Compares two strings and returns a number suitable for use in sort(). */
+function stringCompare(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 /**
  * A tsickle produced declaration file might be consumed be referenced by Clutz
  * produced .d.ts files, which use symbol names based on Closure's internal
@@ -2049,6 +2056,10 @@ function addClutzAliases(
     return e.declarations.some(d => d.getSourceFile() === origSourceFile);
   });
   if (!localExports.length) return dtsFileContent;
+
+  // TypeScript 2.8 and TypeScript 2.9 differ on the order in which the
+  // module symbols come out, so sort here to make the tests stable.
+  localExports.sort((a, b) => stringCompare(a.name, b.name));
 
   const moduleName = host.pathToModuleName('', sourceFile.fileName);
   const clutzModuleName = moduleName.replace(/\./g, '$');

--- a/test_files/basic.declaration/basic.d.ts
+++ b/test_files/basic.declaration/basic.d.ts
@@ -1,12 +1,15 @@
 export declare const x = 1;
 export declare function incr(n: any): number;
+export declare const y = 1;
 declare global {
 	namespace ಠ_ಠ.clutz {
 		export {incr as module$contents$test_files$basic$declaration$basic_incr}
 		export {x as module$contents$test_files$basic$declaration$basic_x}
+		export {y as module$contents$test_files$basic$declaration$basic_y}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$basic$declaration$basic {
 		export {module$contents$test_files$basic$declaration$basic_incr as incr}
 		export {module$contents$test_files$basic$declaration$basic_x as x}
+		export {module$contents$test_files$basic$declaration$basic_y as y}
 	}
 }

--- a/test_files/basic.declaration/basic.ts
+++ b/test_files/basic.declaration/basic.ts
@@ -1,2 +1,5 @@
 export const x = 1;
-export function incr(n) { return x + 1; }
+export function incr(n) {
+  return x + 1;
+}
+export const y = 1;

--- a/test_files/generics.declaration/generics.d.ts
+++ b/test_files/generics.declaration/generics.d.ts
@@ -19,27 +19,27 @@ export declare class DefaultGeneric<T extends {} = {}> {
 }
 declare global {
 	namespace ಠ_ಠ.clutz {
-		export {identity as module$contents$test_files$generics$declaration$generics_identity}
-		export {loggingIdentity as module$contents$test_files$generics$declaration$generics_loggingIdentity}
-		export {HasThing as module$contents$test_files$generics$declaration$generics_HasThing}
-		export {Lengthwise as module$contents$test_files$generics$declaration$generics_Lengthwise}
-		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber}
-		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber_Instance}
-		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer}
-		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer_Instance}
 		export {DefaultGeneric as module$contents$test_files$generics$declaration$generics_DefaultGeneric}
 		export {DefaultGeneric as module$contents$test_files$generics$declaration$generics_DefaultGeneric_Instance}
+		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber}
+		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber_Instance}
+		export {HasThing as module$contents$test_files$generics$declaration$generics_HasThing}
+		export {Lengthwise as module$contents$test_files$generics$declaration$generics_Lengthwise}
+		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer}
+		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer_Instance}
+		export {identity as module$contents$test_files$generics$declaration$generics_identity}
+		export {loggingIdentity as module$contents$test_files$generics$declaration$generics_loggingIdentity}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$generics$declaration$generics {
-		export {module$contents$test_files$generics$declaration$generics_identity as identity}
-		export {module$contents$test_files$generics$declaration$generics_loggingIdentity as loggingIdentity}
-		export {module$contents$test_files$generics$declaration$generics_HasThing as HasThing}
-		export {module$contents$test_files$generics$declaration$generics_Lengthwise as Lengthwise}
-		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber}
-		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber_Instance}
-		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer}
-		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer_Instance}
 		export {module$contents$test_files$generics$declaration$generics_DefaultGeneric as DefaultGeneric}
 		export {module$contents$test_files$generics$declaration$generics_DefaultGeneric as DefaultGeneric_Instance}
+		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber}
+		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber_Instance}
+		export {module$contents$test_files$generics$declaration$generics_HasThing as HasThing}
+		export {module$contents$test_files$generics$declaration$generics_Lengthwise as Lengthwise}
+		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer}
+		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer_Instance}
+		export {module$contents$test_files$generics$declaration$generics_identity as identity}
+		export {module$contents$test_files$generics$declaration$generics_loggingIdentity as loggingIdentity}
 	}
 }

--- a/test_files/interface_and_type.declaration/interface_and_type.d.ts
+++ b/test_files/interface_and_type.declaration/interface_and_type.d.ts
@@ -3,11 +3,11 @@ export interface Foo {
 export declare type Bar = {};
 declare global {
 	namespace ಠ_ಠ.clutz {
-		export {Foo as module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo}
 		export {Bar as module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar}
+		export {Foo as module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$interface_and_type$declaration$interface_and_type {
-		export {module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo as Foo}
 		export {module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar as Bar}
+		export {module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo as Foo}
 	}
 }


### PR DESCRIPTION
TypeScript 2.8 and 2.9 differ on the order of symbols returned
by getExportsOfModule().  To make the tests stable across these
versions, sort the symbols before iterating them.