### PR TITLE
Point to a pre-release version of rules_typescript.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.0.zip",
-    strip_prefix = "rules_typescript-0.15.0",
-    sha256 = "1aa75917330b820cb239b3c10a936a10f0a46fe215063d4492dd76dc6e1616f4",
+    url = "https://github.com/rkirov/rules_typescript/archive/v0.16.0.zip",
+    strip_prefix = "rules_typescript-0.16.0",
+    sha256 = "f5aedd3a792e5af19cd0c0f0318cb692e2989e816e896e794152d07808fccacd",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")


### PR DESCRIPTION
This is to fix #846, since we don't have push rights to
rules_typescript, for now just point to a custom fork for the repo.