### PR TITLE
use es6 form when generating export statement

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1464,9 +1464,9 @@ class Annotator extends ClosureRewriter {
     // exports).
     // tsickle must also still emit the `var` line above so that the type can be used within the
     // local module scope (Closure does not allow refering to "exports.Foo" within a module).
-    // With that, emit an additional "exports.foo = foo;" line assigning the unset variable into it.
+    // With that, emit an additional "export {foo};" to export the type.
     if (hasModifierFlag(node, ts.ModifierFlags.Export)) {
-      this.emit(`exports.${typeName} = ${typeName}\n`);
+      this.emit(`export {${typeName}};\n`);
     }
   }
 }


### PR DESCRIPTION
This produces equivalent output when targeting goog.module
(because it becomes an exports.foo = foo line) so no tests are
affected.

But when tsickle is emitting ES6, this stays as an export {}
statement, which is the proper output for that.

Note: apparently tsickle has no tests covering the ES6 output
mode(!), or this would've been caught earlier.

Fixes #848.