### PR TITLE
Only emit @extends for classes without `extends`.

### DIFF
--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -1,0 +1,30 @@
+/**
+ *
+ * @fileoverview Reproduces a problem where tsickle would emit "\\@extends
+ * {ClassInImplements}", conflicting the ES6 extends syntax, leading to
+ * incorrect optimization results.
+ *
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
+ */
+goog.module('test_files.extend_and_implement.extend_and_implement');
+var module = module || { id: 'test_files/extend_and_implement/extend_and_implement.ts' };
+class ClassInImplements {
+}
+if (false) {
+    /** @type {(undefined|string)} */
+    ClassInImplements.prototype.foo;
+}
+class ClassInExtends {
+    /**
+     * @return {string}
+     */
+    bar() {
+        return 'a';
+    }
+}
+class ExtendsAndImplementsClass extends ClassInExtends {
+}
+if (false) {
+    /** @type {string} */
+    ExtendsAndImplementsClass.prototype.foo;
+}

--- a/test_files/extend_and_implement/extend_and_implement.ts
+++ b/test_files/extend_and_implement/extend_and_implement.ts
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Reproduces a problem where tsickle would emit "\@extends
+ * {ClassInImplements}", conflicting the ES6 extends syntax, leading to
+ * incorrect optimization results.
+ */
+
+class ClassInImplements {
+  foo: string|undefined;
+}
+class ClassInExtends {
+  bar() {
+    return 'a';
+  }
+}
+class ExtendsAndImplementsClass extends ClassInExtends implements ClassInImplements {
+  foo: string;
+}


### PR DESCRIPTION
tsickle emits an `@extends` for classes implementing classes, to help
Closure track the type hierarchy. However for classes that have an
actual `class X extends Y` clause, this can cause Closure to get
confused about the type hierarchy, leading to incorrect optimization.

This change prevents emitting both `@extends` and `extends`, avoiding
the problem.