### PR TITLE
use prettier to format markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,29 @@
-Want to contribute?  Great! First, read this page (including the small print at
+Want to contribute? Great! First, read this page (including the small print at
 the end).
 
 ### Before you contribute
+
 Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement]
-(https://cla.developers.google.com/about/google-individual)
-(CLA), which you can do online.  The CLA is necessary mainly because you own the
+[Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual)
+(CLA), which you can do online. The CLA is necessary mainly because you own the
 copyright to your changes, even after your contribution becomes part of our
-codebase, so we need your permission to use and distribute your code.  We also
+codebase, so we need your permission to use and distribute your code. We also
 need to be sure of various other things—for instance that you'll tell us if you
-know that your code infringes on other people's patents.  You don't have to sign
+know that your code infringes on other people's patents. You don't have to sign
 the CLA until after you've submitted your code for review and a member has
 approved it, but you must do it before we can put your code into our codebase.
 Before you start working on a larger contribution, you should get in touch with
 us first through the issue tracker with your idea so that we can help out and
-possibly guide you.  Coordinating up front makes it much easier to avoid
+possibly guide you. Coordinating up front makes it much easier to avoid
 frustration later on.
 
 ### Code reviews
+
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose.
 
 ### The small print
+
 Contributions made by corporations are covered by a different agreement than
 the one above, the
-[Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+[Software Grant and Corporate Contributor License Agreement](https://cla.developers.google.com/about/google-corporate).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Tsickle - TypeScript to Closure Translator [![Linux build](https://travis-ci.org/angular/tsickle.svg?branch=master)](https://travis-ci.org/angular/tsickle) [![Windows build](https://ci.appveyor.com/api/projects/status/puxdblmlqbofqqt1/branch/master?svg=true)](https://ci.appveyor.com/project/alexeagle/tsickle/branch/master)
 
 Tsickle converts TypeScript code into a form acceptable to the [Closure
-Compiler].  This allows using TypeScript to transpile your sources, and then
+Compiler]. This allows using TypeScript to transpile your sources, and then
 using Closure Compiler to bundle and optimize them, while taking advantage of
 type information in Closure Compiler.
 
-[Closure Compiler]: https://github.com/google/closure-compiler/
+[closure compiler]: https://github.com/google/closure-compiler/
 
 ## What conversion means
 
@@ -35,12 +35,12 @@ to try it you should expect to spend some time debugging and reporting bugs.
 
 ### Project Setup
 
-Tsickle works by wrapping `tsc`.  To use it, you must set up your project such
+Tsickle works by wrapping `tsc`. To use it, you must set up your project such
 that it builds correctly when you run `tsc` from the command line, by
 configuring the settings in `tsconfig.json`.
 
 If you have complicated tsc command lines and flags in a build file (like a
-gulpfile etc.) Tsickle won't know about it.  Another reason it's nice to put
+gulpfile etc.) Tsickle won't know about it. Another reason it's nice to put
 everything in `tsconfig.json` is so your editor inherits all these settings as
 well.
 
@@ -51,15 +51,15 @@ specific options and use it as a TypeScript compiler.
 
 ### Differences from TypeScript
 
-Closure and TypeScript are not identical.  Tsickle hides most of the
+Closure and TypeScript are not identical. Tsickle hides most of the
 differences, but users must still be aware of some differences.
 
 #### `declare`
 
 Any declaration in a `.d.ts` file, as well as any declaration tagged with
 `declare ...`, is intepreted by Tsickle as a name that should be preserved
-through Closure compilation (i.e. not renamed into something shorter).  Use it
-any time the specific string names of your fields are significant.  That would
+through Closure compilation (i.e. not renamed into something shorter). Use it
+any time the specific string names of your fields are significant. That would
 most often happen when the object either coming from outside your program, or
 being passed out of the program.
 
@@ -73,9 +73,9 @@ Example:
 
 By adding `declare` to the interface (or if it were in a `.d.ts` file), Tsickle
 will inform Closure that it must use exactly the field name `.username` (and not
-e.g. `.a`) in the output JS.  This matters for this example because the input
+e.g. `.a`) in the output JS. This matters for this example because the input
 JSON probably uses the string `'username'` and not whatever name Closure would
-invent for it.  (Note: `declare` on an interface has no additional meaning in
+invent for it. (Note: `declare` on an interface has no additional meaning in
 pure TypeScript.)
 
 #### Exporting decorators
@@ -159,7 +159,7 @@ $ npm version minor -m 'rel: %s'
 This will update the version in `package.json`, commit the changes, and
 create a git tag.
 
-Push the branch and get it reviewed, but *do not merge*.  If you click
+Push the branch and get it reviewed, but _do not merge_. If you click
 the "rebase and merge" button in the Github UI it changes the commit,
 so the git tag that was created would point at the wrong commit.
 
@@ -172,7 +172,7 @@ $ git push origin v0.32.0
 
 Note that Github will block non-fast-forward pushes to master, so if
 there have been other intervening commits you'll need to recreate the
-release.  Once the versioned tag is pushed to Github the release (as
+release. Once the versioned tag is pushed to Github the release (as
 found on https://github.com/angular/tsickle/releases) will be
 implicitly created.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "glob": "7.1.2",
     "google-closure-compiler": "20161024.3.0",
     "jasmine": "3.1.0",
+    "prettier": "1.13.7",
     "tslint": "5.9.1",
     "typescript": "2.9.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,12 +207,6 @@ jasmine-core@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.1.0.tgz#a4785e135d5df65024dfc9224953df585bd2766c"
 
-jasmine-diff@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/jasmine-diff/-/jasmine-diff-0.1.3.tgz#93ccc2dcc41028c5ddd4606558074839f2deeaa8"
-  dependencies:
-    diff "^3.2.0"
-
 jasmine@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.1.0.tgz#2bd59fd7ec6ec0e8acb64e09f45a68ed2ad1952a"
@@ -264,6 +258,10 @@ path-is-absolute@^1.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+prettier@1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 replace-ext@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Extends check_format.js to run prettier on markdown files, and
updates all our markdown files to the prettier-formatted output.