### PR TITLE
Use diff-match-patch for a basic diff matcher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,17 @@
     "typescript": ">=2.4.2 <2.9"
   },
   "devDependencies": {
+    "@types/diff-match-patch": "^1.0.32",
     "@types/glob": "5.0.35",
     "@types/jasmine": "2.8.6",
     "@types/minimist": "1.2.0",
     "@types/mkdirp": "0.5.2",
     "@types/node": "^10.3.3",
     "clang-format": "1.2.2",
+    "diff-match-patch": "^1.0.1",
     "glob": "7.1.2",
     "google-closure-compiler": "20161024.3.0",
     "jasmine": "3.1.0",
-    "jasmine-diff": "^0.1.3",
     "tslint": "5.9.1",
     "typescript": "2.9.2"
   },

--- a/test/decorator_downlevel_transformer_test.ts
+++ b/test/decorator_downlevel_transformer_test.ts
@@ -71,7 +71,7 @@ describe('decorator_downlevel_transformer', () => {
   }
 
   function expectUnchanged(sourceText: string) {
-    expectTranslated(sourceText).toEqual(sourceText);
+    expectTranslated(sourceText).toEqualWithDiff(sourceText);
   }
 
   function expectTranslated(sourceText: string) {

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -77,7 +77,7 @@ function compareAgainstGolden(
       }
     }
   } else {
-    expect(output).toEqual(golden!);
+    expect(output).toEqualWithDiff(golden!);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/diff-match-patch@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.32.tgz#d9c3b8c914aa8229485351db4865328337a3d09f"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -134,6 +138,10 @@ commander@^2.12.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+diff-match-patch@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.1.tgz#d5f880213d82fbc124d2b95111fb3c033dbad7fa"
 
 diff@^3.2.0:
   version "3.5.0"


### PR DESCRIPTION
jasmine-diff is a much more general solution that (tries to) implement
object and array diffing, which tsickle does not use in its tests.

It's string-diff support turns out to be very limited. The diff
algorithm either does very basic unified diff, or a much too over-eager
inline diff. At the same time, jasmine-diff compares strings *after*
abbreviating them, causing incorrect diffs, or even error messages not
mentioning a diff at all.

This change adds a basic diff matcher based on diff-match-patch. It
still has a number of limitations, like not quite lining up line breaks
for removed and added lines. Even so, it's a substantial improvement
over jasmine-diff, and gets us back to actually readable test output.

from d0c1fcc