### PR TITLE
Undo temporary dependency on unleased TS bazel rules.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_reposi
 # Force developers to use the same Bazel version as Travis,
 # to prevent different local behavior than CI.
 # See travis_install.sh
-check_bazel_version("0.9.0")
+check_bazel_version("0.14.0")
 
 # NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
 # your npm dependencies. You must still run the package manager.
@@ -35,9 +35,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/rkirov/rules_typescript/archive/v0.16.0.zip",
-    strip_prefix = "rules_typescript-0.16.0",
-    sha256 = "f5aedd3a792e5af19cd0c0f0318cb692e2989e816e896e794152d07808fccacd",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.1.zip",
+    strip_prefix = "rules_typescript-0.15.1",
+    sha256 = "3792cc20ef13bb1d1d8b1760894c3320f02a87843e3a04fed7e8e454a75328b6",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -2,7 +2,7 @@
 mkdir tmp
 cd tmp
 # Update the check in WORKSPACE when upgrading Bazel.
-BAZEL_VERSION=0.13.0
+BAZEL_VERSION=0.14.0
 curl --location --compressed "https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh" > "bazel-$BAZEL_VERSION-installer-linux-x86_64.sh"
 chmod +x "bazel-$BAZEL_VERSION-installer-linux-x86_64.sh"
 "./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh" --user


### PR DESCRIPTION
Hack was added in https://github.com/angular/tsickle/commit/5474fb7b3439f93a7a48123fa2e996828b70512b.
Point to a proper new release.