### PR TITLE
pass through the is-es5 flag into golden tests

### DIFF
--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -131,7 +131,7 @@ testFn('golden tests with transformer', () => {
       }
       const allDiagnostics = new Set<ts.Diagnostic>();
       const transformerHost: tsickle.TsickleHost = {
-        es5Mode: true,
+        es5Mode: test.isEs5Target,
         googmodule: true,
         // See test_files/jsdoc_types/nevertyped.ts.
         typeBlackListPaths: new Set(['test_files/jsdoc_types/nevertyped.ts']),

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -177,6 +177,7 @@ export class GoldenFileTest {
     return /\.puretransform\b/.test(this.name);
   }
 
+  /** True if the test is testing es5 output; es6 output otherwise. */
   get isEs5Target(): boolean {
     return /\.es5\b/.test(this.name);
   }

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.abstract.abstract');
 var module = module || { id: 'test_files/abstract/abstract.ts' };
+module = module;
+exports = {};
 /**
  * @abstract
  */

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };
+module = module;
+exports = {};
 /** @type {?} */
 var fn3 = (a) => 12;

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };
+module = module;
+exports = {};
 /** @type {function(number): number} */
 var fn3 = (a) => 12;
 /** @type {function(?): ?} */

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.basic.untyped.basic.untyped');
 var module = module || { id: 'test_files/basic.untyped/basic.untyped.ts' };
+module = module;
+exports = {};
 /**
  * @param {?} arg1
  * @return {?}

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.class.untyped.class');
 var module = module || { id: 'test_files/class.untyped/class.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -14,6 +14,8 @@
 // other options.
 goog.module('test_files.class.class');
 var module = module || { id: 'test_files/class/class.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.clutz.no_externs.strip_clutz_type');
 var module = module || { id: 'test_files/clutz.no_externs/strip_clutz_type.ts' };
+module = module;
+exports = {};
 var goog_some_name_space_1 = goog.require('some.name.space');
 const tsickle_forward_declare_1 = goog.forwardDeclare("some.name.space");
 const tsickle_forward_declare_2 = goog.forwardDeclare("some.other");

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.coerce.coerce');
 var module = module || { id: 'test_files/coerce/coerce.ts' };
+module = module;
+exports = {};
 /**
  * @param {string} arg
  * @return {string}

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.comments.comments');
 var module = module || { id: 'test_files/comments/comments.ts' };
+module = module;
+exports = {};
 class Comments {
 }
 if (false) {

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };
+module = module;
+exports = {};
 /** @type {function(new: (!Document)): ?} */
 let x = Document;
 class X {

--- a/test_files/declare/declare_nondts.js
+++ b/test_files/declare/declare_nondts.js
@@ -4,3 +4,5 @@
  */
 goog.module('test_files.declare.declare_nondts');
 var module = module || { id: 'test_files/declare/declare_nondts.ts' };
+module = module;
+exports = {};

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };
+module = module;
+exports = {};
 /** @type {!ModuleGlobalClass} */
 let x;
 /** @type {!moduleGlobalNamespace.GlobalNamespaced} */

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -4,3 +4,5 @@
  */
 goog.module('test_files.declare_class_ns.declare_class_ns');
 var module = module || { id: 'test_files/declare_class_ns/declare_class_ns.ts' };
+module = module;
+exports = {};

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -4,3 +4,5 @@
  */
 goog.module('test_files.declare_class_overloads.declare_class_overloads');
 var module = module || { id: 'test_files/declare_class_overloads/declare_class_overloads.ts' };
+module = module;
+exports = {};

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -4,4 +4,6 @@
  */
 goog.module('test_files.declare_export.untyped.declare_export');
 var module = module || { id: 'test_files/declare_export.untyped/declare_export.ts' };
+module = module;
+exports = {};
 ;

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -14,6 +14,8 @@
 // Closure builtin Error type.
 goog.module('test_files.declare_export.declare_export');
 var module = module || { id: 'test_files/declare_export/declare_export.ts' };
+module = module;
+exports = {};
 /** @typedef {!ExportDeclaredIf} */
 exports.ExportDeclaredIf;
 /** @type {!ExportDeclaredIf} */

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };
+module = module;
+exports = {};
 var tslib_1 = goog.require('tslib');
 var default_export_1 = goog.require('test_files.decorator.default_export');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.decorator.default_export");

--- a/test_files/decorator/default_export.js
+++ b/test_files/decorator/default_export.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.decorator.default_export');
 var module = module || { id: 'test_files/decorator/default_export.ts' };
+module = module;
+exports = {};
 class DefaultExport {
 }
 exports.default = DefaultExport;

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.decorator.external');
 var module = module || { id: 'test_files/decorator/external.ts' };
+module = module;
+exports = {};
 var external2_1 = goog.require('test_files.decorator.external2');
 exports.ReexportedOtherClass = external2_1.OtherClass;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.decorator.external2");

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.decorator.external2');
 var module = module || { id: 'test_files/decorator/external2.ts' };
+module = module;
+exports = {};
 class OtherClass {
 }
 exports.OtherClass = OtherClass;

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.decorator.only_types');
 var module = module || { id: 'test_files/decorator/only_types.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');
 var module = module || { id: 'test_files/decorator_nested_scope/decorator_nested_scope.ts' };
+module = module;
+exports = {};
 class SomeService {
 }
 /**

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.default.default');
 var module = module || { id: 'test_files/default/default.ts' };
+module = module;
+exports = {};
 /**
  * @param {number} x
  * @param {string=} y

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.doc_params.doc_params');
 var module = module || { id: 'test_files/doc_params/doc_params.ts' };
+module = module;
+exports = {};
 class Foo {
     /**
      * @ngInject

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.enum.untyped.enum.untyped');
 var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };
+module = module;
+exports = {};
 /** @enum {number} */
 const EnumUntypedTest1 = {
     XYZ: 0, PI: 3.14159,

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.enum.enum');
 var module = module || { id: 'test_files/enum/enum.ts' };
+module = module;
+exports = {};
 /** @type {!Array<?>} */
 const EnumTestMissingSemi = [];
 /** @enum {number} */

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.enum.enum_user');
 var module = module || { id: 'test_files/enum/enum_user.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.enum.enum");
 /**
  * @record

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -8,6 +8,8 @@
 // exporting an enum's value, not that.
 goog.module('test_files.enum_value_literal_type.enum_value_literal_type');
 var module = module || { id: 'test_files/enum_value_literal_type/enum_value_literal_type.ts' };
+module = module;
+exports = {};
 /** @enum {number} */
 const ExportedEnum = {
     VALUE: 0,

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export.export');
 var module = module || { id: 'test_files/export/export.ts' };
+module = module;
+exports = {};
 var export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export2 = export_helper_1.export2;
 exports.export5 = export_helper_1.export5;

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export.export_helper');
 var module = module || { id: 'test_files/export/export_helper.ts' };
+module = module;
+exports = {};
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.
 var export_helper_2_1 = goog.require('test_files.export.export_helper_2');

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export.export_helper_2');
 var module = module || { id: 'test_files/export/export_helper_2.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.export2 = 3;
 /** @type {number} */

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export.export_helper_3');
 var module = module || { id: 'test_files/export/export_helper_3.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export.export_star_imported');
 var module = module || { id: 'test_files/export/export_star_imported.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export.export_helper");
 var export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export1 = export_helper_1.export1;

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.TypeAndValue = 1;

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export_declare_namespace.export_declare_namespace');
 var module = module || { id: 'test_files/export_declare_namespace/export_declare_namespace.ts' };
+module = module;
+exports = {};
 class ModuleType {
 }
 exports.ModuleType = ModuleType;

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export_declare_namespace.export_declare_namespace");
 /** @type {!exportedDeclaredNamespace.Used} */
 let x;

--- a/test_files/export_equals/export_equals.js
+++ b/test_files/export_equals/export_equals.js
@@ -4,6 +4,7 @@
  */
 goog.module('test_files.export_equals.export_equals');
 var module = module || { id: 'test_files/export_equals/export_equals.ts' };
+module = module;
 var someNamespace = goog.require('test_files.export_equals.namespace');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export_equals.namespace");
 exports = someNamespace;

--- a/test_files/export_equals/user.js
+++ b/test_files/export_equals/user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export_equals.user');
 var module = module || { id: 'test_files/export_equals/user.ts' };
+module = module;
+exports = {};
 var modPrefix = goog.require('test_files.export_equals.export_equals');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.export_equals.export_equals");
 console.log(new modPrefix.Clazz());

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.export_types_values.untyped.importer');
 var module = module || { id: 'test_files/export_types_values.untyped/importer.ts' };
+module = module;
+exports = {};
 var value_exporter_1 = goog.require('test_files.export_types_values.untyped.value_exporter');
 exports.Clazz = value_exporter_1.Clazz;

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };
+module = module;
+exports = {};
 /** @typedef {?} */
 exports.TypeDef;

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.export_types_values.untyped.value_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/value_exporter.ts' };
+module = module;
+exports = {};
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };
+module = module;
+exports = {};
 var tslib_1 = goog.require('tslib');
 /**
  * \@ExportDecoratedItems

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.extend_and_implement.extend_and_implement');
 var module = module || { id: 'test_files/extend_and_implement/extend_and_implement.ts' };
+module = module;
+exports = {};
 class ClassInImplements {
 }
 if (false) {

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -5,6 +5,8 @@
  */
 goog.module('test_files.fields.fields');
 var module = module || { id: 'test_files/fields/fields.ts' };
+module = module;
+exports = {};
 class FieldsTest {
     /**
      * @param {number} field3

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');
 var module = module || { id: 'test_files/fields_no_ctor/fields_no_ctor.ts' };
+module = module;
+exports = {};
 class NoCtor {
 }
 if (false) {

--- a/test_files/file_comment.puretransform/before_import.js
+++ b/test_files/file_comment.puretransform/before_import.js
@@ -5,5 +5,7 @@
  */
 goog.module('test_files.file_comment.puretransform.before_import');
 var module = module || { id: 'test_files/file_comment.puretransform/before_import.ts' };
+module = module;
+exports = {};
 var comment_before_var_1 = goog.require('test_files.file_comment.puretransform.comment_before_var');
 console.log(comment_before_var_1.y);

--- a/test_files/file_comment.puretransform/comment_before_class.js
+++ b/test_files/file_comment.puretransform/comment_before_class.js
@@ -5,6 +5,8 @@
  */
 goog.module('test_files.file_comment.puretransform.comment_before_class');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_class.ts' };
+module = module;
+exports = {};
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/file_comment.puretransform/comment_before_elided_import.js
+++ b/test_files/file_comment.puretransform/comment_before_elided_import.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.file_comment.puretransform.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_elided_import.ts' };
+module = module;
+exports = {};
 const x = null;
 console.log(x);

--- a/test_files/file_comment.puretransform/comment_before_var.js
+++ b/test_files/file_comment.puretransform/comment_before_var.js
@@ -5,4 +5,6 @@
  */
 goog.module('test_files.file_comment.puretransform.comment_before_var');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_var.ts' };
+module = module;
+exports = {};
 exports.y = 3;

--- a/test_files/file_comment.puretransform/comment_no_tag.js
+++ b/test_files/file_comment.puretransform/comment_no_tag.js
@@ -1,5 +1,7 @@
 /** A comment without any tags. */
 goog.module('test_files.file_comment.puretransform.comment_no_tag');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_no_tag.ts' };
+module = module;
+exports = {};
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment.puretransform/comment_with_text.js
+++ b/test_files/file_comment.puretransform/comment_with_text.js
@@ -4,4 +4,6 @@
  */
 goog.module('test_files.file_comment.puretransform.comment_with_text');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_with_text.ts' };
+module = module;
+exports = {};
 console.log('hello');

--- a/test_files/file_comment.puretransform/file_comment.js
+++ b/test_files/file_comment.puretransform/file_comment.js
@@ -1,5 +1,7 @@
 goog.module('test_files.file_comment.puretransform.file_comment');
 var module = module || { id: 'test_files/file_comment.puretransform/file_comment.ts' };
+module = module;
+exports = {};
 // This test verifies that initial comments don't confuse offsets.
 function foo() {
     return 'foo';

--- a/test_files/file_comment.puretransform/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment.puretransform/fileoverview_and_jsdoc.js
@@ -1,5 +1,7 @@
 goog.module('test_files.file_comment.puretransform.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_and_jsdoc.ts' };
+module = module;
+exports = {};
 /** @fileoverview A file. */
 /**
  * @noalias

--- a/test_files/file_comment.puretransform/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_add_suppress.js
@@ -1,5 +1,7 @@
 /** @fileoverview a comment without a suppress tag. */
 goog.module('test_files.file_comment.puretransform.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_add_suppress.ts' };
+module = module;
+exports = {};
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.file_comment.puretransform.fileoverview_comment_merge_suppress');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.ts' };
+module = module;
+exports = {};
 /** second comment here */
 console.log('code');

--- a/test_files/file_comment.puretransform/jsdoc_comment.js
+++ b/test_files/file_comment.puretransform/jsdoc_comment.js
@@ -1,5 +1,7 @@
 goog.module('test_files.file_comment.puretransform.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment.puretransform/jsdoc_comment.ts' };
+module = module;
+exports = {};
 /**
  * This comment belongs to the class below.
  */

--- a/test_files/file_comment.puretransform/multiple_comments.js
+++ b/test_files/file_comment.puretransform/multiple_comments.js
@@ -16,6 +16,8 @@
 /** Here's another trailing comment */
 goog.module('test_files.file_comment.puretransform.multiple_comments');
 var module = module || { id: 'test_files/file_comment.puretransform/multiple_comments.ts' };
+module = module;
+exports = {};
 function f() {
     // Make sure the globalThis suppression above is maintained.
     return this.x;

--- a/test_files/file_comment.puretransform/other_fileoverview_comments.js
+++ b/test_files/file_comment.puretransform/other_fileoverview_comments.js
@@ -1,5 +1,7 @@
 /** @modName {some_mod} */
 goog.module('test_files.file_comment.puretransform.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment.puretransform/other_fileoverview_comments.ts' };
+module = module;
+exports = {};
 // @modName also belongs in a fileoverview comment, so must be merged.
 console.log('hello');

--- a/test_files/file_comment.puretransform/side_effect_import.js
+++ b/test_files/file_comment.puretransform/side_effect_import.js
@@ -5,4 +5,6 @@
  */
 goog.module('test_files.file_comment.puretransform.side_effect_import');
 var module = module || { id: 'test_files/file_comment.puretransform/side_effect_import.ts' };
+module = module;
+exports = {};
 var tsickle_module_1_ = goog.require('test_files.file_comment.puretransform.file_comment');

--- a/test_files/file_comment/before_import.js
+++ b/test_files/file_comment/before_import.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.file_comment.before_import');
 var module = module || { id: 'test_files/file_comment/before_import.ts' };
+module = module;
+exports = {};
 var comment_before_var_1 = goog.require('test_files.file_comment.comment_before_var');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.file_comment.comment_before_var");
 console.log(comment_before_var_1.y);

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.file_comment.comment_before_class');
 var module = module || { id: 'test_files/file_comment/comment_before_class.ts' };
+module = module;
+exports = {};
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.file_comment.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment/comment_before_elided_import.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.file_comment.comment_before_class");
 /** @type {(null|!tsickle_forward_declare_1.Clazz)} */
 const x = null;

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -8,5 +8,7 @@
  */
 goog.module('test_files.file_comment.comment_before_var');
 var module = module || { id: 'test_files/file_comment/comment_before_var.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.y = 3;

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -5,5 +5,7 @@
 /** A comment without any tags. */
 goog.module('test_files.file_comment.comment_no_tag');
 var module = module || { id: 'test_files/file_comment/comment_no_tag.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -6,4 +6,6 @@
  */
 goog.module('test_files.file_comment.comment_with_text');
 var module = module || { id: 'test_files/file_comment/comment_with_text.ts' };
+module = module;
+exports = {};
 console.log('hello');

--- a/test_files/file_comment/export_star.js
+++ b/test_files/file_comment/export_star.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.file_comment.export_star');
 var module = module || { id: 'test_files/file_comment/export_star.ts' };
+module = module;
+exports = {};
 var comment_before_var_1 = goog.require('test_files.file_comment.comment_before_var');
 exports.y = comment_before_var_1.y;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.file_comment.comment_before_var");

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.file_comment.file_comment');
 var module = module || { id: 'test_files/file_comment/file_comment.ts' };
+module = module;
+exports = {};
 /**
  * @return {string}
  */

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };
+module = module;
+exports = {};
 /** *
  * @noalias
   @type {number} */

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -6,5 +6,7 @@
  */
 goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_merge_suppress.ts' };
+module = module;
+exports = {};
 /** second comment here */
 console.log('code');

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.file_comment.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment/jsdoc_comment.ts' };
+module = module;
+exports = {};
 /**
  * This comment belongs to the class below.
  */

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -18,6 +18,8 @@
 /** Here's another trailing comment */
 goog.module('test_files.file_comment.multiple_comments');
 var module = module || { id: 'test_files/file_comment/multiple_comments.ts' };
+module = module;
+exports = {};
 /**
  * @return {?}
  */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -5,5 +5,7 @@
  */
 goog.module('test_files.file_comment.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment/other_fileoverview_comments.ts' };
+module = module;
+exports = {};
 // @modName also belongs in a fileoverview comment, so must be merged.
 console.log('hello');

--- a/test_files/file_comment/side_effect_import.js
+++ b/test_files/file_comment/side_effect_import.js
@@ -8,4 +8,6 @@
  */
 goog.module('test_files.file_comment.side_effect_import');
 var module = module || { id: 'test_files/file_comment/side_effect_import.ts' };
+module = module;
+exports = {};
 var tsickle_module_1_ = goog.require('test_files.file_comment.file_comment');

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.functions.untyped.functions');
 var module = module || { id: 'test_files/functions.untyped/functions.ts' };
+module = module;
+exports = {};
 /**
  * @param {?} a
  * @return {?}

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.functions.functions');
 var module = module || { id: 'test_files/functions/functions.ts' };
+module = module;
+exports = {};
 /**
  * @param {number} a
  * @return {number}

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -6,6 +6,8 @@
  */
 goog.module('test_files.functions.two_jsdoc_blocks');
 var module = module || { id: 'test_files/functions/two_jsdoc_blocks.ts' };
+module = module;
+exports = {};
 /**
  * A comment.
  * @return {boolean}

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };
+module = module;
+exports = {};
 /** *
  * A function type that includes a generic type argument. Unsupported by
  * Closure, so tsickle should emit ?.

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.generic_local_var.generic_local_var');
 var module = module || { id: 'test_files/generic_local_var/generic_local_var.ts' };
+module = module;
+exports = {};
 /**
  * @template T
  */

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.generic_type_alias.generic_type_alias');
 var module = module || { id: 'test_files/generic_type_alias/generic_type_alias.ts' };
+module = module;
+exports = {};
 /** @typedef {!Array<?>} */
 exports.MyList;

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.implement_reexported_interface.exporter');
 var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.interface");
 goog.require("test_files.implement_reexported_interface.interface"); // force type-only module to be loaded
 /** @typedef {!tsickle_forward_declare_1.ExportedInterface} */

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.implement_reexported_interface.interface');
 var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -9,6 +9,8 @@
  */
 goog.module('test_files.implement_reexported_interface.user');
 var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.implement_reexported_interface.interface");
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.exporter");
 goog.require("test_files.implement_reexported_interface.exporter"); // force type-only module to be loaded

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 const FOO = 1;
 exports.FOO = FOO;

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_alias.importer');
 var module = module || { id: 'test_files/import_alias/importer.ts' };
+module = module;
+exports = {};
 var exporter_1 = goog.require('test_files.import_alias.exporter');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_alias.exporter");
 console.log(exporter_1.FOO);

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_default.exporter');
 var module = module || { id: 'test_files/import_default/exporter.ts' };
+module = module;
+exports = {};
 class default_1 {
 }
 exports.default = default_1;

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_default.import_default');
 var module = module || { id: 'test_files/import_default/import_default.ts' };
+module = module;
+exports = {};
 var exporter_1 = goog.require('test_files.import_default.exporter');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_default.exporter");
 // Make sure that regular TypeScript default imports are emitted as a .default

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_empty.import_empty');
 var module = module || { id: 'test_files/import_empty/import_empty.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_empty.imported");
 goog.require("test_files.import_empty.imported"); // force type-only module to be loaded
 console.log('hello');

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -4,3 +4,5 @@
  */
 goog.module('test_files.import_empty.imported');
 var module = module || { id: 'test_files/import_empty/imported.ts' };
+module = module;
+exports = {};

--- a/test_files/import_export_typedef_conflict/exporter.js
+++ b/test_files/import_export_typedef_conflict/exporter.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.import_export_typedef_conflict.exporter');
 var module = module || { id: 'test_files/import_export_typedef_conflict/exporter.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.x = 1;

--- a/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
+++ b/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.import_export_typedef_conflict.import_export_typedef_conflict');
 var module = module || { id: 'test_files/import_export_typedef_conflict/import_export_typedef_conflict.ts' };
+module = module;
+exports = {};
 var ConflictingName = goog.require('test_files.import_export_typedef_conflict.exporter');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_export_typedef_conflict.exporter");
 /** @typedef {number} */

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_from_goog.import_from_goog');
 var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' };
+module = module;
+exports = {};
 var goog_closure_Module_1 = goog.require('closure.Module');
 const tsickle_forward_declare_1 = goog.forwardDeclare("closure.Module");
 const tsickle_forward_declare_2 = goog.forwardDeclare("closure.OtherModule");

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_only_types.import_only_types');
 var module = module || { id: 'test_files/import_only_types/import_only_types.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_only_types.types_only");
 goog.require("test_files.import_only_types.types_only"); // force type-only module to be loaded
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.import_only_types.types_and_constenum");

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -7,6 +7,8 @@
 // containing only types and const enums must be "force loaded".
 goog.module('test_files.import_only_types.types_and_constenum');
 var module = module || { id: 'test_files/import_only_types/types_and_constenum.ts' };
+module = module;
+exports = {};
 /** @enum {number} */
 const ConstEnum = {
     BAR: 0,

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -5,6 +5,8 @@
 // Exports only types, but must still be goog.require'd for Closure Compiler.
 goog.module('test_files.import_only_types.types_only');
 var module = module || { id: 'test_files/import_only_types/types_only.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.valueExport = 1;
 /** @typedef {(string|number)} */

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -6,6 +6,8 @@
 // import in a type and in a value position.
 goog.module('test_files.import_prefixed.import_prefixed_mixed');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_mixed.ts' };
+module = module;
+exports = {};
 var exporter = goog.require('test_files.import_prefixed.exporter');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
 /** @type {(string|number)} */

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -8,6 +8,8 @@
 // type TypeExport.
 goog.module('test_files.import_prefixed.import_prefixed_types');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_types.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.import_prefixed.exporter");
 /** @type {(string|number)} */
 const someVar = 1;

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.a = 1;

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.index_import.has_index.relative');
 var module = module || { id: 'test_files/index_import/has_index/relative.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.index_import.has_index.index");
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.index_import.has_index.index");

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.b = 2;

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.index_import.user');
 var module = module || { id: 'test_files/index_import/user.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.index_import.has_index.index");
 var has_index_1 = goog.require('test_files.index_import.has_index.index');
 exports.a = has_index_1.a;

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.interface.implement_import');
 var module = module || { id: 'test_files/interface/implement_import.ts' };
+module = module;
+exports = {};
 var interface_1 = goog.require('test_files.interface.interface');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.interface.interface");
 /**

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.interface.interface');
 var module = module || { id: 'test_files/interface/interface.ts' };
+module = module;
+exports = {};
 /**
  * Used by implement_import.ts
  * @record

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.interface.interface_extends');
 var module = module || { id: 'test_files/interface/interface_extends.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.interface.interface_type_params');
 var module = module || { id: 'test_files/interface/interface_type_params.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -23,6 +23,8 @@
  */
 goog.module('test_files.jsdoc.jsdoc');
 var module = module || { id: 'test_files/jsdoc/jsdoc.ts' };
+module = module;
+exports = {};
 /**
  * @param {string} foo a string.
  * @param {string} baz

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.untyped.default');
 var module = module || { id: 'test_files/jsdoc_types.untyped/default.ts' };
+module = module;
+exports = {};
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.jsdoc_types.untyped.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types.untyped/jsdoc_types.ts' };
+module = module;
+exports = {};
 var module1 = goog.require('test_files.jsdoc_types.untyped.module1');
 var module2_1 = goog.require('test_files.jsdoc_types.untyped.module2');
 var module2_2 = module2_1;

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.untyped.module1');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module1.ts' };
+module = module;
+exports = {};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.untyped.module2');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module2.ts' };
+module = module;
+exports = {};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -6,6 +6,8 @@
  * suite runner so that its types are always {?}.*/
 goog.module('test_files.jsdoc_types.untyped.nevertyped');
 var module = module || { id: 'test_files/jsdoc_types.untyped/nevertyped.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.default');
 var module = module || { id: 'test_files/jsdoc_types/default.ts' };
+module = module;
+exports = {};
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.jsdoc_types.initialized_unknown');
 var module = module || { id: 'test_files/jsdoc_types/initialized_unknown.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
 goog.require("test_files.jsdoc_types.nevertyped"); // force type-only module to be loaded
 const initializedUntyped = {

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.jsdoc_types.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types/jsdoc_types.ts' };
+module = module;
+exports = {};
 var module1 = goog.require('test_files.jsdoc_types.module1');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module1");
 var module2_1 = goog.require('test_files.jsdoc_types.module2');

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.module1');
 var module = module || { id: 'test_files/jsdoc_types/module1.ts' };
+module = module;
+exports = {};
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsdoc_types.module2');
 var module = module || { id: 'test_files/jsdoc_types/module2.ts' };
+module = module;
+exports = {};
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -6,6 +6,8 @@
  * suite runner so that its types are always {?}.*/
 goog.module('test_files.jsdoc_types.nevertyped');
 var module = module || { id: 'test_files/jsdoc_types/nevertyped.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };
+module = module;
+exports = {};
 /** @type {!JSX.Element} */
 let simple = React.createElement("div", null);
 /** @type {string} */

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.methods.methods');
 var module = module || { id: 'test_files/methods/methods.ts' };
+module = module;
+exports = {};
 class HasMethods {
     /**
      * @return {void}

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };
+module = module;
+exports = {};
 // tslint:disable-next-line:no-namespace
 var Reflect;
 // tslint:disable-next-line:no-namespace

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };
+module = module;
+exports = {};
 /** @type {!decl.ns.one.NamespacedClass} */
 let user;

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.namespaced.export_enum_in_namespace');
 var module = module || { id: 'test_files/namespaced/export_enum_in_namespace.ts' };
+module = module;
+exports = {};
 // tslint:disable:no-namespace
 var foo;
 // tslint:disable:no-namespace

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -5,6 +5,8 @@
 // tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_namespace');
 var module = module || { id: 'test_files/namespaced/export_namespace.ts' };
+module = module;
+exports = {};
 var valueNamespace;
 (function (valueNamespace) {
     class ValueClass {

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.namespaced.local_namespace');
 var module = module || { id: 'test_files/namespaced/local_namespace.ts' };
+module = module;
+exports = {};
 var unexported;
 (function (unexported) {
     class Unexported {

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };
+module = module;
+exports = {};
 var export_namespace_1 = goog.require('test_files.namespaced.export_namespace');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.namespaced.export_namespace");
 /** @type {?} */

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.nonnull_generics.nonnull_generics');
 var module = module || { id: 'test_files/nonnull_generics/nonnull_generics.ts' };
+module = module;
+exports = {};
 /**
  * getOrDefault removes the |null branch from its input. In TypeScript, this works, but in Closure,
  * generics like T are always nullable, and there's no syntax to specify a non-nullable generic.

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.nullable.nullable');
 var module = module || { id: 'test_files/nullable/nullable.ts' };
+module = module;
+exports = {};
 class Primitives {
 }
 if (false) {

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.optional.optional');
 var module = module || { id: 'test_files/optional/optional.ts' };
+module = module;
+exports = {};
 /**
  * @param {number} x
  * @param {(undefined|string)=} y

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.parameter_properties.parameter_properties');
 var module = module || { id: 'test_files/parameter_properties/parameter_properties.ts' };
+module = module;
+exports = {};
 class ParamProps {
     /**
      * @param {string} publicExportedP

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.promiseconstructor.promiseconstructor');
 var module = module || { id: 'test_files/promiseconstructor/promiseconstructor.ts' };
+module = module;
+exports = {};
 /**
  * @param {(undefined|!PromiseConstructor)=} promiseCtor
  * @return {!Promise<void>}

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.promisectorlike.promisectorlike');
 var module = module || { id: 'test_files/promisectorlike/promisectorlike.ts' };
+module = module;
+exports = {};
 /**
  * @param {function(new: (!PromiseLike<?>), function(function((undefined|?|!PromiseLike<?>)=): void, function(?=): void): void): ?} ctorLike
  * @return {!Promise<string>}

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };
+module = module;
+exports = {};
 /** @type {!PromiseLike<string>} */
 let promiseLikeOfString;

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.quote_props.quote');
 var module = module || { id: 'test_files/quote_props/quote.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.static.static');
 var module = module || { id: 'test_files/static/static.ts' };
+module = module;
+exports = {};
 class Static {
 }
 // This should not become a stub declaration.

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.structural.untyped.structural.untyped');
 var module = module || { id: 'test_files/structural.untyped/structural.untyped.ts' };
+module = module;
+exports = {};
 class StructuralTest {
     /**
      * @return {?}

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.super.super');
 var module = module || { id: 'test_files/super/super.ts' };
+module = module;
+exports = {};
 class SuperTestBaseNoArg {
     constructor() { }
 }

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.this_type.this_type');
 var module = module || { id: 'test_files/this_type/this_type.ts' };
+module = module;
+exports = {};
 class SomeClass {
 }
 if (false) {

--- a/test_files/transitive_symbol_type_only/exporter.js
+++ b/test_files/transitive_symbol_type_only/exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.transitive_symbol_type_only.exporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/exporter.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/transitive_symbol_type_only/reexporter.js
+++ b/test_files/transitive_symbol_type_only/reexporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.transitive_symbol_type_only.reexporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/reexporter.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.transitive_symbol_type_only.exporter");
 goog.require("test_files.transitive_symbol_type_only.exporter"); // force type-only module to be loaded
 /** @typedef {(null|string|!tsickle_forward_declare_1.ExportedInterface)} */

--- a/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
+++ b/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
@@ -8,6 +8,8 @@
  */
 goog.module('test_files.transitive_symbol_type_only.transitive_symbol_type_only');
 var module = module || { id: 'test_files/transitive_symbol_type_only/transitive_symbol_type_only.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.transitive_symbol_type_only.exporter");
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.transitive_symbol_type_only.reexporter");
 goog.require("test_files.transitive_symbol_type_only.reexporter"); // force type-only module to be loaded

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -5,6 +5,8 @@
  */
 goog.module('test_files.type.type');
 var module = module || { id: 'test_files/type/type.ts' };
+module = module;
+exports = {};
 /** @type {?} */
 let typeAny;
 /** @type {!Array<?>} */

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_alias_imported.elided_comment');
 var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_exporter");
 /** @type {(null|!tsickle_forward_declare_2.X|!tsickle_forward_declare_1.Y)} */

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.type_alias_imported.export_constant');
 var module = module || { id: 'test_files/type_alias_imported/export_constant.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.type_alias_imported.type_alias_declare');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_declare.ts' };
+module = module;
+exports = {};
 /**
  * @record
  */

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.type_alias_imported.type_alias_default_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_default_exporter.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Z {

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_alias_imported.type_alias_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_exporter.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 goog.require("test_files.type_alias_imported.type_alias_declare"); // force type-only module to be loaded
 class Y {

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_alias_imported.type_alias_imported');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_imported.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.type_alias_imported.type_alias_declare");
 var export_constant_1 = goog.require('test_files.type_alias_imported.export_constant');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_alias_imported.export_constant");

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_and_value.module');
 var module = module || { id: 'test_files/type_and_value/module.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.TypeAndValue = 3;
 /** @type {number} */

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };
+module = module;
+exports = {};
 var conflict = goog.require('test_files.type_and_value.module');
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.type_and_value.module");
 /** @type {function(new: (!Document)): ?} */

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_guard_fn.type_guard_fn');
 var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };
+module = module;
+exports = {};
 /**
  * @param {!Object} a
  * @return {boolean}

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };
+module = module;
+exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("type_propaccess.nested.clazz");
 /** @type {(null|!tsickle_forward_declare_1.ClutzedClassWithNested.NestedClutzedClass)} */
 const x = null;

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };
+module = module;
+exports = {};
 /** @type {?} */
 var y = 3;
 /** @typedef {?} */

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 var y = 3;
 /** @typedef {{value: number, next: ?}} */

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -4,5 +4,7 @@
  */
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };
+module = module;
+exports = {};
 /** @type {number} */
 exports.__test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -6,6 +6,8 @@
 // See getIdentifierText() in tsickle.ts.
 goog.module('test_files.underscore.underscore');
 var module = module || { id: 'test_files/underscore/underscore.ts' };
+module = module;
+exports = {};
 var export_underscore_1 = goog.require('test_files.underscore.export_underscore');
 exports.__test = export_underscore_1.__test;
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.underscore.export_underscore");

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -7,6 +7,8 @@
  */
 goog.module('test_files.use_closure_externs.use_closure_externs');
 var module = module || { id: 'test_files/use_closure_externs/use_closure_externs.ts' };
+module = module;
+exports = {};
 console.log('work around TS dropping consecutive comments');
 /** @type {!NodeListOf<!HTMLParagraphElement>} */
 let x = document.getElementsByTagName('p');

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -4,6 +4,8 @@
  */
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };
+module = module;
+exports = {};
 /** @type {string} */
 var v1;
 /** @type {string} */


### PR DESCRIPTION
We have some tests that are marked for testing es5 emit, but
we failed to pass that flag through to the googmodule processor.
Fix this bug and rebaseline the tests.