### PR TITLE
Handle conditional and substitution types.

### DIFF
--- a/src/type-translator.ts
+++ b/src/type-translator.ts
@@ -314,7 +314,7 @@ export class TypeTranslator {
     // can emit a precise type.
     if (this.isForExterns && isModule && !isAmbient) return '?';
 
-    const lastFlag = ts.TypeFlags.IndexedAccess;
+    const lastFlag = ts.TypeFlags.Substitution;
     const mask = (lastFlag << 1) - 1;
     switch (type.flags & mask) {
       case ts.TypeFlags.Any:
@@ -361,6 +361,10 @@ export class TypeTranslator {
         return this.translateObject(type as ts.ObjectType);
       case ts.TypeFlags.Union:
         return this.translateUnion(type as ts.UnionType);
+      case ts.TypeFlags.Conditional:
+      case ts.TypeFlags.Substitution:
+        this.warn(`emitting ? for conditional/substitution type`);
+        return '?';
       case ts.TypeFlags.Intersection:
       case ts.TypeFlags.Index:
       case ts.TypeFlags.IndexedAccess:

--- a/test_files/conditional_type/conditional_type.js
+++ b/test_files/conditional_type/conditional_type.js
@@ -1,0 +1,11 @@
+// test_files/conditional_type/conditional_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
+ */
+goog.module('test_files.conditional_type.conditional_type');
+var module = module || { id: 'test_files/conditional_type/conditional_type.ts' };
+module = module;
+exports = {};
+/** @typedef {?} */
+exports.Filter;

--- a/test_files/conditional_type/conditional_type.ts
+++ b/test_files/conditional_type/conditional_type.ts
@@ -1,0 +1,1 @@
+export type Filter<T, U> = T extends U ? T : never;


### PR DESCRIPTION
These cannot be represented in Closure Compiler easily (at least without
emitting Type Transformation Language, which does not work on typedefs),
so just emit `?` for the time being, instead of crashing.

Fixes #865.