### PR TITLE
wrap interface declarations in if(false)

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -1326,10 +1326,14 @@ class Annotator extends ClosureRewriter {
     const name = getIdentifierText(iface.name);
     this.emit(`function ${name}() {}\n`);
 
-    const memberNamespace = [name, 'prototype'];
-    for (const elem of iface.members) {
-      const isOptional = elem.questionToken != null;
-      this.visitProperty(memberNamespace, elem, isOptional);
+    if (iface.members.length > 0) {
+      this.emit(`\nif (false) {\n`);
+      const memberNamespace = [name, 'prototype'];
+      for (const elem of iface.members) {
+        const isOptional = elem.questionToken != null;
+        this.visitProperty(memberNamespace, elem, isOptional);
+      }
+      this.emit(`}\n`);
     }
   }
 

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -10,8 +10,10 @@ exports = {};
  * @record
  */
 function Interface() { }
-/** @type {?} */
-Interface.prototype.interfaceFunc;
+if (false) {
+    /** @type {?} */
+    Interface.prototype.interfaceFunc;
+}
 class Super {
     /**
      * @return {?}

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -20,8 +20,10 @@ exports = {};
  * @record
  */
 function Interface() { }
-/** @type {function(): void} */
-Interface.prototype.interfaceFunc;
+if (false) {
+    /** @type {function(): void} */
+    Interface.prototype.interfaceFunc;
+}
 class Class {
     /**
      * @return {void}
@@ -49,8 +51,10 @@ if (false) {
  * @extends {Interface}
  */
 function InterfaceExtendsInterface() { }
-/** @type {function(): void} */
-InterfaceExtendsInterface.prototype.interfaceFunc2;
+if (false) {
+    /** @type {function(): void} */
+    InterfaceExtendsInterface.prototype.interfaceFunc2;
+}
 /** @type {!InterfaceExtendsInterface} */
 let interfaceExtendsInterface = {
     /**
@@ -66,8 +70,10 @@ let interfaceExtendsInterface = {
  * @record
  */
 function InterfaceExtendsClass() { }
-/** @type {function(): void} */
-InterfaceExtendsClass.prototype.interfaceFunc3;
+if (false) {
+    /** @type {function(): void} */
+    InterfaceExtendsClass.prototype.interfaceFunc3;
+}
 /**
  * @implements {Interface}
  */

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -14,5 +14,7 @@ exports = {};
  */
 function AnotherType() { }
 exports.AnotherType = AnotherType;
-/** @type {string} */
-AnotherType.prototype.field;
+if (false) {
+    /** @type {string} */
+    AnotherType.prototype.field;
+}

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -71,10 +71,12 @@ let constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
  */
 function InterfaceUsingConstEnum() { }
 exports.InterfaceUsingConstEnum = InterfaceUsingConstEnum;
-/** @type {ConstEnum} */
-InterfaceUsingConstEnum.prototype.field;
-/** @type {ConstEnum} */
-InterfaceUsingConstEnum.prototype.field2;
+if (false) {
+    /** @type {ConstEnum} */
+    InterfaceUsingConstEnum.prototype.field;
+    /** @type {ConstEnum} */
+    InterfaceUsingConstEnum.prototype.field2;
+}
 /** @enum {number} */
 const EnumWithNonConstValues = {
     Scheme: (x => x + 1)(3),

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -12,7 +12,9 @@ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.enum.enum");
  */
 function EnumUsingIf() { }
 exports.EnumUsingIf = EnumUsingIf;
-/** @type {tsickle_forward_declare_1.ConstEnum} */
-EnumUsingIf.prototype.field;
+if (false) {
+    /** @type {tsickle_forward_declare_1.ConstEnum} */
+    EnumUsingIf.prototype.field;
+}
 /** @type {tsickle_forward_declare_1.ConstEnum} */
 const fieldUsingConstEnum = 0 /* EMITTED_ENUM_VALUE */;

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -28,8 +28,10 @@ exports.export2 = 3;
  */
 function Bar() { }
 exports.Bar = Bar;
-/** @type {number} */
-Bar.prototype.barField;
+if (false) {
+    /** @type {number} */
+    Bar.prototype.barField;
+}
 /** @type {number} */
 exports.export5 = 3;
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.export.export_helper_2");

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -19,8 +19,10 @@ exports.TypeDef;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {string} */
-Interface.prototype.x;
+if (false) {
+    /** @type {string} */
+    Interface.prototype.x;
+}
 /** @enum {number} */
 const ConstEnum = {
     AValue: 1,

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -11,5 +11,7 @@ exports = {};
  */
 function Foo() { }
 exports.Foo = Foo;
-/** @type {string} */
-Foo.prototype.fooStr;
+if (false) {
+    /** @type {string} */
+    Foo.prototype.fooStr;
+}

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -11,5 +11,7 @@ exports = {};
  */
 function ExportedInterface() { }
 exports.ExportedInterface = ExportedInterface;
-/** @type {string} */
-ExportedInterface.prototype.fooStr;
+if (false) {
+    /** @type {string} */
+    ExportedInterface.prototype.fooStr;
+}

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -12,8 +12,10 @@ exports = {};
  */
 function Foo() { }
 exports.Foo = Foo;
-/** @type {string} */
-Foo.prototype.x;
+if (false) {
+    /** @type {string} */
+    Foo.prototype.x;
+}
 /** @typedef {number} */
 exports.Bar;
 /** @typedef {function(): void} */

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -12,10 +12,12 @@ exports = {};
  */
 function Point() { }
 exports.Point = Point;
-/** @type {number} */
-Point.prototype.x;
-/** @type {number} */
-Point.prototype.y;
+if (false) {
+    /** @type {number} */
+    Point.prototype.x;
+    /** @type {number} */
+    Point.prototype.y;
+}
 /**
  * Used by implement_import.ts
  */
@@ -41,23 +43,25 @@ usePoint({ x: 1, y: 1 });
  * @record
  */
 function TrickyInterface() { }
-/* TODO: handle strange member:
-[offset: number]: number;
-*/
-/** @type {number} */
-TrickyInterface.prototype.foo;
-/* TODO: handle strange member:
-(x: number): __ yuck __
-      number;
-*/
-/** @type {(undefined|string)} */
-TrickyInterface.prototype.foobar;
-/** @type {?|undefined} */
-TrickyInterface.prototype.optAny;
-/**
- * \@param a some string value
- * \@return some number value
- * @override
- * @type {function(string): number}
- */
-TrickyInterface.prototype.hasSomeParamJsDoc;
+if (false) {
+    /* TODO: handle strange member:
+    [offset: number]: number;
+    */
+    /** @type {number} */
+    TrickyInterface.prototype.foo;
+    /* TODO: handle strange member:
+    (x: number): __ yuck __
+          number;
+    */
+    /** @type {(undefined|string)} */
+    TrickyInterface.prototype.foobar;
+    /** @type {?|undefined} */
+    TrickyInterface.prototype.optAny;
+    /**
+     * \@param a some string value
+     * \@return some number value
+     * @override
+     * @type {function(string): number}
+     */
+    TrickyInterface.prototype.hasSomeParamJsDoc;
+}

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -10,20 +10,26 @@ exports = {};
  * @record
  */
 function ParentInterface() { }
-/** @type {number} */
-ParentInterface.prototype.x;
+if (false) {
+    /** @type {number} */
+    ParentInterface.prototype.x;
+}
 /**
  * @record
  * @extends {ParentInterface}
  */
 function SubType() { }
-/** @type {number} */
-SubType.prototype.y;
+if (false) {
+    /** @type {number} */
+    SubType.prototype.y;
+}
 /**
  * @record
  * @extends {ParentInterface}
  * @extends {SubType}
  */
 function SubMulti() { }
-/** @type {number} */
-SubMulti.prototype.z;
+if (false) {
+    /** @type {number} */
+    SubMulti.prototype.z;
+}

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -10,15 +10,19 @@ exports = {};
  * @record
  */
 function UpperBound() { }
-/** @type {number} */
-UpperBound.prototype.x;
+if (false) {
+    /** @type {number} */
+    UpperBound.prototype.x;
+}
 // unsupported: template constraints.
 /**
  * @record
  * @template T, U
  */
 function WithTypeParam() { }
-/** @type {T} */
-WithTypeParam.prototype.tea;
-/** @type {U} */
-WithTypeParam.prototype.you;
+if (false) {
+    /** @type {T} */
+    WithTypeParam.prototype.tea;
+    /** @type {U} */
+    WithTypeParam.prototype.you;
+}

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -14,5 +14,10 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {?} */
-Interface.prototype.x;
+if (false) {
+    /** @type {?} */
+    Interface.prototype.x;
+    /* TODO: handle strange member:
+    "quoted-bad-name": string;
+    */
+}

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -17,8 +17,10 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {?} */
-Interface.prototype.x;
+if (false) {
+    /** @type {?} */
+    Interface.prototype.x;
+}
 /**
  * @template T
  */

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -13,5 +13,7 @@ exports = {};
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-/** @type {?} */
-NeverTyped.prototype.foo;
+if (false) {
+    /** @type {?} */
+    NeverTyped.prototype.foo;
+}

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -14,5 +14,10 @@ exports.Class = Class;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {number} */
-Interface.prototype.x;
+if (false) {
+    /** @type {number} */
+    Interface.prototype.x;
+    /* TODO: handle strange member:
+    "quoted-bad-name": string;
+    */
+}

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -17,8 +17,10 @@ exports.ClassTwo = ClassTwo;
  */
 function Interface() { }
 exports.Interface = Interface;
-/** @type {number} */
-Interface.prototype.x;
+if (false) {
+    /** @type {number} */
+    Interface.prototype.x;
+}
 /**
  * @template T
  */

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -13,13 +13,17 @@ exports = {};
  */
 function NeverTyped() { }
 exports.NeverTyped = NeverTyped;
-/** @type {number} */
-NeverTyped.prototype.foo;
+if (false) {
+    /** @type {number} */
+    NeverTyped.prototype.foo;
+}
 /**
  * @record
  * @template T
  */
 function NeverTypedTemplated() { }
 exports.NeverTypedTemplated = NeverTypedTemplated;
-/** @type {T} */
-NeverTypedTemplated.prototype.foo;
+if (false) {
+    /** @type {T} */
+    NeverTypedTemplated.prototype.foo;
+}

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -14,6 +14,11 @@ exports = {};
  * @record
  */
 function Quoted() { }
+if (false) {
+    /* TODO: handle strange member:
+    [k: string]: number;
+    */
+}
 /** @type {!Quoted} */
 let quoted = {};
 console.log(quoted["hello"]);
@@ -26,13 +31,15 @@ quoted["hello"] = 1;
  * @extends {Quoted}
  */
 function QuotedMixed() { }
-/** @type {number} */
-QuotedMixed.prototype.foo;
-/* TODO: handle strange member:
-'invalid-identifier': number;
-*/
-/** @type {number} */
-QuotedMixed.prototype.quotedIdent;
+if (false) {
+    /** @type {number} */
+    QuotedMixed.prototype.foo;
+    /* TODO: handle strange member:
+    'invalid-identifier': number;
+    */
+    /** @type {number} */
+    QuotedMixed.prototype.quotedIdent;
+}
 /** @type {!QuotedMixed} */
 let quotedMixed = { foo: 1, 'invalid-identifier': 2, 'quotedIdent': 3 };
 console.log(quotedMixed.foo);

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -57,8 +57,10 @@ class SuperTestDerivedNoCTorOneArg extends SuperTestBaseOneArg {
  * @record
  */
 function SuperTestInterface() { }
-/** @type {number} */
-SuperTestInterface.prototype.foo;
+if (false) {
+    /** @type {number} */
+    SuperTestInterface.prototype.foo;
+}
 /**
  * @implements {SuperTestInterface}
  */

--- a/test_files/transitive_symbol_type_only/exporter.js
+++ b/test_files/transitive_symbol_type_only/exporter.js
@@ -11,5 +11,7 @@ exports = {};
  */
 function ExportedInterface() { }
 exports.ExportedInterface = ExportedInterface;
-/** @type {number} */
-ExportedInterface.prototype.x;
+if (false) {
+    /** @type {number} */
+    ExportedInterface.prototype.x;
+}

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -14,5 +14,7 @@ exports = {};
  */
 function X() { }
 exports.X = X;
-/** @type {string} */
-X.prototype.x;
+if (false) {
+    /** @type {string} */
+    X.prototype.x;
+}


### PR DESCRIPTION
In our upcoming world of transformers, it's easier if we consistently
always wrap interface member declarations in an if(false) block.

This partially rolls back some of 249273f6417ea3696934c5b71abbbf4b202ce612,
which dropped function wrapper in favor of either using if(false) or
no wrapper at all for interfaces, so now we consistently use if(false).