### PR TITLE
Fix resolving index shorthands.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -703,7 +703,7 @@ export function jsdocTransformer(
         if (!sym) return importDecl;
         // Write the export declaration here so that forward declares come after it, and
         // fileoverview comments do not get moved behind statements.
-        const importPath = googmodule.resolveIndexShorthand(
+        const importPath = googmodule.resolveModuleName(
             {options: tsOptions, host: tsHost}, sourceFile.fileName,
             (importDecl.moduleSpecifier as ts.StringLiteral).text);
 


### PR DESCRIPTION
TypeScript supports sophisticated path mapping schemes, including
implicitly resolving an import of `foo` to `foo/index`.

The code in `resolveIndexShorthand` correctly resolves the module to a
path, but then in some situation returns a path that's relative to the
calling code. The callers (at least by now) however expect a path they
can hand to `pathToModuleName`, which must be an absolute or
root-relative file path, but not a `../..` relative path.

The code previously tried to handle several situations (identical names,
relative paths, stripping extensions), but those no longer make sense
given the call paths, and removing them does not cause any test to fail.
This allowed some code simplification.