### PR TITLE
Support exporting local type aliases.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -795,8 +795,6 @@ export function jsdocTransformer(
         if (host.untyped) return exportDecl;
 
         const result: ts.Node[] = [exportDecl];
-        const typeTranslator =
-            moduleTypeTranslator.newTypeTranslator(ts.getOriginalNode(exportDecl));
         for (const [exportedName, sym] of typesToExport) {
           let aliasedSymbol = sym;
           if (sym.flags & ts.SymbolFlags.Alias) {
@@ -805,13 +803,8 @@ export function jsdocTransformer(
           const isTypeAlias = (aliasedSymbol.flags & ts.SymbolFlags.Value) === 0 &&
               (aliasedSymbol.flags & (ts.SymbolFlags.TypeAlias | ts.SymbolFlags.Interface)) !== 0;
           if (!isTypeAlias) continue;
-          const typeName = moduleTypeTranslator.symbolsToAliasedNames.get(aliasedSymbol);
-          if (!typeName) {
-            moduleTypeTranslator.error(
-                ts.getOriginalNode(exportDecl), `cannot find alias for re-exported symbol`);
-            continue;
-          }
-          // Leading newline prevents the typedef from being swallowed.
+          const typeName =
+              moduleTypeTranslator.symbolsToAliasedNames.get(aliasedSymbol) || aliasedSymbol.name;
           const stmt = ts.createStatement(
               ts.createPropertyAccess(ts.createIdentifier('exports'), exportedName));
           addCommentOn(stmt, [{tagName: 'typedef', type: '!' + typeName}]);

--- a/test_files/export_local_type/export_local_type.js
+++ b/test_files/export_local_type/export_local_type.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Regression test to ensure local type symbols can be exported.
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
+ */
+goog.module('test_files.export_local_type.export_local_type');
+var module = module || { id: 'test_files/export_local_type/export_local_type.ts' };
+module = module;
+exports = {};
+/**
+ * @record
+ */
+function LocalInterface() { }
+if (false) {
+    /** @type {string} */
+    LocalInterface.prototype.field;
+}
+/** @typedef {!LocalInterface} */
+exports.LocalInterface; // re-export typedef
+/** @typedef {!LocalInterface} */
+exports.AliasedName; // re-export typedef

--- a/test_files/export_local_type/export_local_type.ts
+++ b/test_files/export_local_type/export_local_type.ts
@@ -1,0 +1,7 @@
+/** @fileoverview Regression test to ensure local type symbols can be exported. */
+
+interface LocalInterface {
+  field: string;
+}
+
+export {LocalInterface, LocalInterface as AliasedName};


### PR DESCRIPTION
The error reporting mechanism here was plain wrong, it is totally fine
to export symbols that do not have an alias, because they are defined
locally or globally.