### PR TITLE
 Fail on duplicated and run in file comments. 

### DIFF
--- a/src/externs.ts
+++ b/src/externs.ts
@@ -29,7 +29,7 @@ import * as path from 'path';
 import * as jsdoc from './jsdoc';
 import {AnnotatorHost, escapeForComment, isValidClosurePropertyName, maybeAddHeritageClauses, maybeAddTemplateClause} from './jsdoc_transformer';
 import {ModuleTypeTranslator} from './module_type_translator';
-import {getEntityNameText, getIdentifierText, hasModifierFlag, isDtsFileName, reportError} from './transformer_util';
+import {getEntityNameText, getIdentifierText, hasModifierFlag, isDtsFileName, reportDiagnostic} from './transformer_util';
 import * as ts from './typescript';
 
 /**
@@ -194,7 +194,7 @@ export function generateExterns(
       emit(`${fqn} = function(${paramsStr}) {};\n`);
     } else {
       if (name.kind !== ts.SyntaxKind.Identifier) {
-        reportError(diagnostics, name, 'Non-namespaced computed name in externs');
+        reportDiagnostic(diagnostics, name, 'Non-namespaced computed name in externs');
       }
       emit(`function ${name.getText()}(${paramsStr}) {}\n`);
     }
@@ -238,7 +238,7 @@ export function generateExterns(
       decl: ts.InterfaceDeclaration|ts.ClassDeclaration, namespace: ReadonlyArray<string>) {
     const name = decl.name;
     if (!name) {
-      reportError(diagnostics, decl, 'anonymous type in externs');
+      reportDiagnostic(diagnostics, decl, 'anonymous type in externs');
       return;
     }
     const typeName = namespace.concat([name.getText()]).join('.');
@@ -344,7 +344,7 @@ export function generateExterns(
    * covered.
    */
   function errorUnimplementedKind(node: ts.Node, where: string) {
-    reportError(diagnostics, node, `${ts.SyntaxKind[node.kind]} not implemented in ${where}`);
+    reportDiagnostic(diagnostics, node, `${ts.SyntaxKind[node.kind]} not implemented in ${where}`);
   }
 
   function visitor(node: ts.Node, namespace: ReadonlyArray<string>) {
@@ -430,7 +430,7 @@ export function generateExterns(
         const fnDecl = node as ts.FunctionDeclaration;
         const name = fnDecl.name;
         if (!name) {
-          reportError(diagnostics, fnDecl, 'anonymous function in externs');
+          reportDiagnostic(diagnostics, fnDecl, 'anonymous function in externs');
           break;
         }
         // Gather up all overloads of this function.

--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -65,13 +65,12 @@ export function transformFileoverviewCommentFactory(diagnostics: ts.Diagnostic[]
   return (): (sourceFile: ts.SourceFile) => ts.SourceFile => {
     function checkNoFileoverviewComments(
         context: ts.Node, comments: jsdoc.SynthesizedCommentWithOriginal[], message: string) {
-      for (let j = 0; j < comments.length; j++) {
-        const c = comments[j];
-        const parse = jsdoc.parse(c);
+      for (const comment of comments) {
+        const parse = jsdoc.parse(comment);
         if (parse !== null && parse.tags.some(t => FILEOVERVIEW_COMMENT_MARKERS.has(t.tagName))) {
           // Report a warning; this should not break compilation in third party code.
           reportDiagnostic(
-              diagnostics, context, message, c.originalRange, ts.DiagnosticCategory.Warning);
+              diagnostics, context, message, comment.originalRange, ts.DiagnosticCategory.Warning);
         }
       }
     }
@@ -130,8 +129,8 @@ export function transformFileoverviewCommentFactory(diagnostics: ts.Diagnostic[]
 
       // Closure Compiler considers the *last* comment with @fileoverview (or @externs or
       // @nocompile) that has not been attached to some other tree node to be the file overview
-      // comment, and only applies @suppress tags from it. AJD considers *any* comment mentioning
-      // @fileoverview.
+      // comment, and only applies @suppress tags from it. Google-internal tooling considers *any*
+      // comment mentioning @fileoverview.
       let fileoverviewIdx = -1;
       let tags: jsdoc.Tag[] = [];
       for (let i = fileComments.length - 1; i >= 0; i--) {

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -15,7 +15,7 @@
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
 import {AnnotatorHost, isAmbient} from './jsdoc_transformer';
-import {createSingleQuoteStringLiteral, debugWarn, getIdentifierText, hasModifierFlag} from './transformer_util';
+import {createSingleQuoteStringLiteral, getIdentifierText, hasModifierFlag, reportError, reportWarning} from './transformer_util';
 import * as typeTranslator from './type_translator';
 import * as ts from './typescript';
 
@@ -120,24 +120,11 @@ export class ModuleTypeTranslator {
   ) {}
 
   debugWarn(context: ts.Node, messageText: string) {
-    debugWarn(this.host, context, messageText);
-  }
-
-  addDiagnostic(diagnostic: ts.Diagnostic) {
-    this.diagnostics.push(diagnostic);
+    reportWarning(this.host, context, messageText);
   }
 
   error(node: ts.Node, messageText: string) {
-    const diagnostic: ts.Diagnostic = {
-      file: this.sourceFile,
-      // Cannot use getStart as node might be synthesized.
-      start: node.pos >= 0 ? node.pos : 0,
-      length: node.end - node.pos,
-      messageText,
-      category: ts.DiagnosticCategory.Error,
-      code: 0,
-    };
-    this.addDiagnostic(diagnostic);
+    reportError(this.diagnostics, node, messageText);
   }
 
   /**

--- a/src/quoting_transformer.ts
+++ b/src/quoting_transformer.ts
@@ -7,7 +7,7 @@
  */
 
 import {AnnotatorHost, isValidClosurePropertyName} from './jsdoc_transformer';
-import {createSingleQuoteStringLiteral, reportWarning} from './transformer_util';
+import {createSingleQuoteStringLiteral, reportDebugWarning} from './transformer_util';
 import * as ts from './typescript';
 
 /**
@@ -48,7 +48,7 @@ export function quotingTransformer(
           // Properties containing non-JS identifier names can only be accessed with quotes.
           if (!isValidClosurePropertyName(propName)) break;
           const symName = typeChecker.symbolToString(quotedPropSym);
-          reportWarning(
+          reportDebugWarning(
               host, eae,
               `Declared property ${symName} accessed with quotes. ` +
                   `This can lead to renaming bugs. A better fix is to use 'declare interface' ` +
@@ -74,7 +74,7 @@ export function quotingTransformer(
           // the index access in another location.
           if (propSym) break;
 
-          reportWarning(
+          reportDebugWarning(
               host, pae,
               typeChecker.typeToString(t) +
                   ` has a string index type but is accessed using dotted access. ` +

--- a/src/quoting_transformer.ts
+++ b/src/quoting_transformer.ts
@@ -7,7 +7,7 @@
  */
 
 import {AnnotatorHost, isValidClosurePropertyName} from './jsdoc_transformer';
-import {createSingleQuoteStringLiteral, debugWarn} from './transformer_util';
+import {createSingleQuoteStringLiteral, reportWarning} from './transformer_util';
 import * as ts from './typescript';
 
 /**
@@ -48,7 +48,7 @@ export function quotingTransformer(
           // Properties containing non-JS identifier names can only be accessed with quotes.
           if (!isValidClosurePropertyName(propName)) break;
           const symName = typeChecker.symbolToString(quotedPropSym);
-          debugWarn(
+          reportWarning(
               host, eae,
               `Declared property ${symName} accessed with quotes. ` +
                   `This can lead to renaming bugs. A better fix is to use 'declare interface' ` +
@@ -74,7 +74,7 @@ export function quotingTransformer(
           // the index access in another location.
           if (propSym) break;
 
-          debugWarn(
+          reportWarning(
               host, pae,
               typeChecker.typeToString(t) +
                   ` has a string index type but is accessed using dotted access. ` +

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -192,13 +192,14 @@ export function createMultiLineComment(original: ts.Node, text: string) {
 export function reportDebugWarning(
     host: {logWarning ? (d: ts.Diagnostic) : void}, node: ts.Node, messageText: string) {
   if (!host.logWarning) return;
-  host.logWarning(createDiagnostic(node, ts.DiagnosticCategory.Warning, messageText));
+  host.logWarning(createDiagnostic(
+      node, messageText, /* textRange */ undefined, ts.DiagnosticCategory.Warning));
 }
 
 /**
  * Creates and reports a diagnostic by adding it to the given array.
  *
- * This is used for erros and warnings in tsickle's input. Emit errors (the default) if tsickle
+ * This is used for errors and warnings in tsickle's input. Emit errors (the default) if tsickle
  * cannot emit a correct result given the input. Emit warnings for questionable input if there's a
  * good chance that the output will work.
  *
@@ -211,18 +212,18 @@ export function reportDebugWarning(
 export function reportDiagnostic(
     diagnostics: ts.Diagnostic[], node: ts.Node, messageText: string, textRange?: ts.TextRange,
     category = ts.DiagnosticCategory.Error) {
-  diagnostics.push(createDiagnostic(node, category, messageText, textRange));
+  diagnostics.push(createDiagnostic(node, messageText, textRange, category));
 }
 
 function createDiagnostic(
-    node: ts.Node, category: ts.DiagnosticCategory, messageText: string,
-    textRange?: ts.TextRange): ts.Diagnostic {
-  // Cannot use getStart as node might be synthesized.
+    node: ts.Node, messageText: string, textRange: ts.TextRange|undefined,
+    category: ts.DiagnosticCategory): ts.Diagnostic {
   let start, length: number;
   if (textRange) {
     start = textRange.pos;
     length = textRange.end - textRange.pos;
   } else {
+    // Only use getStart if node has a valid pos, as it might be synthesized.
     start = node.pos >= 0 ? node.getStart() : 0;
     length = node.end - node.pos;
   }

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -9,7 +9,7 @@
 import {decoratorDownlevelTransformer} from './decorator_downlevel_transformer';
 import {enumTransformer} from './enum_transformer';
 import {generateExterns} from './externs';
-import {transformFileoverviewComment} from './fileoverview_comment_transformer';
+import {transformFileoverviewCommentFactory} from './fileoverview_comment_transformer';
 import * as googmodule from './googmodule';
 import {AnnotatorHost, jsdocTransformer, removeTypeAssertions} from './jsdoc_transformer';
 import {ModulesManifest} from './modules_manifest';
@@ -91,7 +91,7 @@ export function emitWithTsickle(
   const tsickleSourceTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
   if (host.transformTypesToClosure) {
     // Only add @suppress {checkTypes} comments when also adding type annotations.
-    tsickleSourceTransformers.push(transformFileoverviewComment);
+    tsickleSourceTransformers.push(transformFileoverviewCommentFactory(tsickleDiagnostics));
     tsickleSourceTransformers.push(
         jsdocTransformer(host, tsOptions, tsHost, typeChecker, tsickleDiagnostics));
     if (!host.disableAutoQuoting) {

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview added by tsickle
+ * @fileoverview A file.
  * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');

--- a/test_files/file_comment/fileoverview_and_jsdoc.ts
+++ b/test_files/file_comment/fileoverview_and_jsdoc.ts
@@ -1,5 +1,6 @@
 /** @fileoverview A file. */
-/** 
+
+/**
  * @noalias
  */
 const aVariable = 1;

--- a/test_files/file_comment/fileoverview_in_comment_text.js
+++ b/test_files/file_comment/fileoverview_in_comment_text.js
@@ -1,0 +1,17 @@
+/**
+ *
+ * @fileoverview Tests that mere mentions of file overview tags in comment bodies don't get
+ * reported as errors.
+ *
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
+ */
+goog.module('test_files.file_comment.fileoverview_in_comment_text');
+var module = module || { id: 'test_files/file_comment/fileoverview_in_comment_text.ts' };
+module = module;
+exports = {};
+/**
+ * This is a function comment that talks about \@fileoverview, but isn't such a comment.
+ * @return {void}
+ */
+function foo() { }
+exports.foo = foo;

--- a/test_files/file_comment/fileoverview_in_comment_text.ts
+++ b/test_files/file_comment/fileoverview_in_comment_text.ts
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview Tests that mere mentions of file overview tags in comment bodies don't get
+ * reported as errors.
+ */
+
+/**
+ * This is a function comment that talks about @fileoverview, but isn't such a comment.
+ */
+export function foo() {}

--- a/test_files/file_comment/latecomment.js
+++ b/test_files/file_comment/latecomment.js
@@ -1,3 +1,4 @@
+// test_files/file_comment/latecomment.ts(3,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
@@ -8,4 +9,5 @@ module = module;
 exports = {};
 /** @type {number} */
 const someVariable = 1;
-someVariable + 2;
+/** @fileoverview This file overview comment appears after the first statement in the file. */
+console.log(someVariable + 2);

--- a/test_files/file_comment/latecomment.ts
+++ b/test_files/file_comment/latecomment.ts
@@ -2,6 +2,6 @@ const someVariable = 1;
 
 /** @fileoverview This file overview comment appears after the first statement in the file. */
 
-someVariable + 2;
+console.log(someVariable + 2);
 
 export {};

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -1,3 +1,4 @@
+// test_files/file_comment/multiple_comments.ts(8,1): warning TS0: duplicate file level comment
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -6,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 /**
- * @fileoverview This comment is ignore by Closure compiler.
+ * @fileoverview This comment is ignored by Closure compiler.
  * @suppress {undefinedVars}
  */
 /**

--- a/test_files/file_comment/multiple_comments.ts
+++ b/test_files/file_comment/multiple_comments.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 /**
- * @fileoverview This comment is ignore by Closure compiler.
+ * @fileoverview This comment is ignored by Closure compiler.
  * @suppress {undefinedVars}
  */
 /**

--- a/test_files/file_comment/run_in_comment.js
+++ b/test_files/file_comment/run_in_comment.js
@@ -1,0 +1,14 @@
+// test_files/file_comment/run_in_comment.ts(1,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
+ */
+goog.module('test_files.file_comment.run_in_comment');
+var module = module || { id: 'test_files/file_comment/run_in_comment.ts' };
+module = module;
+exports = {};
+/**
+ * @pintomodule Comment is not separated from file body as it should be.
+ * @type {number}
+ */
+exports.x = 1;

--- a/test_files/file_comment/run_in_comment.ts
+++ b/test_files/file_comment/run_in_comment.ts
@@ -1,0 +1,2 @@
+/** @pintomodule Comment is not separated from file body as it should be. */
+export const x = 1;


### PR DESCRIPTION
In TypeScript, file level comments are comments that are separated from
the file body with an empty line. In Closure, file level comments are
comments marked with a particular (often load bearing) JSDoc tag, e.g.
`@fileoverview` or `@pintomodule`.

If a TypeScript contains such a Closure file level comment in a comment
that is *not* a TypeScript file level comment, TypeScript will often not
emit the comment at all, e.g. because it was placed on an interface or
type import that will not be emitted. That violates user expectations,
as their (load bearing) comment is now silently gone.

This change has tsickle report hard errors whenever it encounters a file
comment that's either not properly separated from the file body, is
duplicated, or appears after the initial statement in the body of the
file, so that the situation can be discovered and fixed early by the
user.