### PR TITLE
rename disableAutoQuoting option to enableAutoQuoting

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -59,9 +59,9 @@ export interface AnnotatorHost {
    */
   convertIndexImportShorthand?: boolean;
   /**
-   * If true, do not modify quotes around property accessors.
+   * If true, modify quotes around property accessors to match the type declaration.
    */
-  disableAutoQuoting?: boolean;
+  enableAutoQuoting?: boolean;
   /**
    * Whether tsickle should insert goog.provide() calls into the externs generated for `.d.ts` files
    * that are external modules.

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,8 @@ import {ModulesManifest} from './tsickle';
 
 /** Tsickle settings passed on the command line. */
 export interface Settings {
-  /** If provided, do not modify quoting of property accesses. */
-  disableAutoQuoting?: boolean;
+  /** If provided, modify quoting of property accesses to match the type declaration. */
+  enableAutoQuoting?: boolean;
 
   /** If provided, path to save externs to. */
   externsPath?: string;
@@ -42,7 +42,7 @@ example:
 tsickle flags are:
   --externs=PATH        save generated Closure externs.js to PATH
   --typed               [experimental] attempt to provide Closure types instead of {?}
-  --disableAutoQuoting  do not automatically apply quotes to property accesses
+  --enableAutoQuoting   automatically apply quotes to property accesses
 `);
 }
 
@@ -69,8 +69,8 @@ function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: str
       case 'verbose':
         settings.verbose = true;
         break;
-      case 'disableAutoQuoting':
-        settings.disableAutoQuoting = true;
+      case 'enableAutoQuoting':
+        settings.enableAutoQuoting = true;
         break;
       case '_':
         // This is part of the minimist API, and holds args after the '--'.
@@ -171,7 +171,7 @@ export function toClosureJS(
     transformDecorators: true,
     transformTypesToClosure: true,
     typeBlackListPaths: new Set(),
-    disableAutoQuoting: settings.disableAutoQuoting,
+    enableAutoQuoting: settings.enableAutoQuoting,
     untyped: false,
     logWarning: (warning) => console.error(ts.formatDiagnostics([warning], compilerHost)),
     options,

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -94,7 +94,7 @@ export function emitWithTsickle(
     tsickleSourceTransformers.push(transformFileoverviewCommentFactory(tsickleDiagnostics));
     tsickleSourceTransformers.push(
         jsdocTransformer(host, tsOptions, tsHost, typeChecker, tsickleDiagnostics));
-    if (!host.disableAutoQuoting) {
+    if (host.enableAutoQuoting) {
       tsickleSourceTransformers.push(quotingTransformer(host, typeChecker, tsickleDiagnostics));
     }
     tsickleSourceTransformers.push(enumTransformer(typeChecker, tsickleDiagnostics));

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -142,6 +142,7 @@ testFn('golden tests with transformer', () => {
         addDtsClutzAliases: test.isDeclarationTest,
         untyped: test.isUntypedTest,
         provideExternalModuleDtsNamespace: !test.hasShim,
+        enableAutoQuoting: test.isQuotingTest,
         logWarning: (diag: ts.Diagnostic) => {
           allDiagnostics.add(diag);
         },

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -177,6 +177,10 @@ export class GoldenFileTest {
     return /\.puretransform\b/.test(this.name);
   }
 
+  get isQuotingTest(): boolean {
+    return /^quote_/.test(this.name);
+  }
+
   /** True if the test is testing es5 output; es6 output otherwise. */
   get isEs5Target(): boolean {
     return /\.es5\b/.test(this.name);

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,6 +1,4 @@
 // test_files/enum/enum.ts(2,7): warning TS0: should not emit a 'never' type
-// test_files/enum/enum.ts(8,33): warning TS0: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
-// test_files/enum/enum.ts(15,22): warning TS0: Declared property XYZ accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc


### PR DESCRIPTION
This feature is experimental and doesn't work well (see #683 for example) so it should be opt-in rather than opt-out.

BREAKING CHANGE:
If you used --disableAutoQuoting, you can just remove that option. Otherwise, if you rely on auto-quoting, you must add --enableAutoQuoting to your tsickle options.