### PR TITLE
consistently use absolute paths

### DIFF
--- a/src/cli_support.ts
+++ b/src/cli_support.ts
@@ -6,12 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as assert from 'assert';
 import * as path from 'path';
 
-// Postprocess generated JS.
+/**
+ * asserts that the given fileName is an absolute path.
+ *
+ * The TypeScript API works in absolute paths, so we must be careful to resolve
+ * paths before handing them over to TypeScript.
+ */
+export function assertAbsolute(fileName: string) {
+  assert(path.isAbsolute(fileName), `expected ${JSON.stringify(fileName)} to be absolute`);
+}
+
+/**
+ * Takes a context (ts.SourceFile.fileName of the current file) and the import URL of an ES6
+ * import and generates a googmodule module name for the imported module.
+ */
 export function pathToModuleName(
     rootModulePath: string, context: string, fileName: string): string {
-  fileName = fileName.replace(/\.[tj]s$/, '');
+  fileName = fileName.replace(/(\.d)?\.[tj]s$/, '');
 
   if (fileName[0] === '.') {
     // './foo' or '../foo'.
@@ -19,8 +33,16 @@ export function pathToModuleName(
     fileName = path.join(path.dirname(context), fileName);
   }
 
-  // Ensure consistency by naming all modules after their absolute paths
-  fileName = path.resolve(fileName);
+  // TODO(evanm): various tests assume they can import relative paths like
+  // 'foo/bar' and have them interpreted as root-relative; preserve that here.
+  // Fix this by removing the next line.
+  if (!path.isAbsolute(fileName)) fileName = path.join(rootModulePath, fileName);
+
+  // TODO(evanm): various tests assume they can pass in a 'fileName' like
+  // 'goog:foo.bar' and have this function do something reasonable.
+
+  // For correctness, the above must have produced an absolute path.
+  // assertAbsolute(fileName);
 
   if (rootModulePath) {
     fileName = path.relative(rootModulePath, fileName);

--- a/src/externs.ts
+++ b/src/externs.ts
@@ -109,10 +109,11 @@ const EXTERNS_HEADER = `/**
  * Concatenate all generated externs definitions together into a string, including a file comment
  * header.
  */
-export function getGeneratedExterns(externs: {[fileName: string]: string}): string {
+export function getGeneratedExterns(
+    rootDir: string, externs: {[fileName: string]: string}): string {
   let allExterns = EXTERNS_HEADER;
   for (const fileName of Object.keys(externs)) {
-    allExterns += `// externs from ${fileName}:\n`;
+    allExterns += `// externs from ${path.relative(rootDir, fileName)}:\n`;
     allExterns += externs[fileName];
   }
   return allExterns;

--- a/src/externs.ts
+++ b/src/externs.ts
@@ -108,9 +108,11 @@ const EXTERNS_HEADER = `/**
 /**
  * Concatenate all generated externs definitions together into a string, including a file comment
  * header.
+ *
+ * @param rootDir Project root.  Emitted comments will reference paths relative to this root.
+ *    This param is effectively required, but made optional here until Angular is fixed.
  */
-export function getGeneratedExterns(
-    rootDir: string, externs: {[fileName: string]: string}): string {
+export function getGeneratedExterns(externs: {[fileName: string]: string}, rootDir = ''): string {
   let allExterns = EXTERNS_HEADER;
   for (const fileName of Object.keys(externs)) {
     allExterns += `// externs from ${path.relative(rootDir, fileName)}:\n`;
@@ -124,14 +126,9 @@ export function getGeneratedExterns(
  *
  * The mangled name is safe to use as a JavaScript identifier. It is used as a globally unique
  * prefix to scope symbols in externs file (see code below).
- *
- * @param contextFileName if given is used as the context file path to resolve the source file's
- *     name against.
  */
-export function moduleNameAsIdentifier(
-    host: AnnotatorHost, fileName: string, contextFileName?: string): string {
-  const resolved = resolveModuleName(host, contextFileName || '', fileName);
-  return host.pathToModuleName('', resolved).replace(/\./g, '$');
+export function moduleNameAsIdentifier(host: AnnotatorHost, fileName: string): string {
+  return host.pathToModuleName('', fileName).replace(/\./g, '$');
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,7 @@ export function toClosureJS(
   const absoluteFileNames = fileNames.map(i => path.resolve(i));
 
   const compilerHost = ts.createCompilerHost(options);
-  const program = ts.createProgram(fileNames, options, compilerHost);
+  const program = ts.createProgram(absoluteFileNames, options, compilerHost);
   const filesToProcess = new Set(absoluteFileNames);
   const rootModulePath = options.rootDir || getCommonParentDirectory(absoluteFileNames);
   const transformerHost: tsickle.TsickleHost = {
@@ -164,7 +164,8 @@ export function toClosureJS(
       return !filesToProcess.has(path.resolve(fileName));
     },
     shouldIgnoreWarningsForPath: (fileName: string) => false,
-    pathToModuleName: cliSupport.pathToModuleName.bind(null, rootModulePath),
+    pathToModuleName: (context, fileName) =>
+        cliSupport.pathToModuleName(rootModulePath, context, fileName),
     fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
     es5Mode: true,
     googmodule: true,
@@ -223,7 +224,7 @@ function main(args: string[]): number {
     mkdirp.sync(path.dirname(settings.externsPath));
     fs.writeFileSync(
         settings.externsPath,
-        tsickle.getGeneratedExterns(config.options.rootDir || '', result.externs));
+        tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));
   }
   return 0;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,7 +221,9 @@ function main(args: string[]): number {
 
   if (settings.externsPath) {
     mkdirp.sync(path.dirname(settings.externsPath));
-    fs.writeFileSync(settings.externsPath, tsickle.getGeneratedExterns(result.externs));
+    fs.writeFileSync(
+        settings.externsPath,
+        tsickle.getGeneratedExterns(config.options.rootDir || '', result.externs));
   }
   return 0;
 }

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as path from 'path';
+
+import {assertAbsolute} from './cli_support';
 import {decoratorDownlevelTransformer} from './decorator_downlevel_transformer';
 import {enumTransformer} from './enum_transformer';
 import {generateExterns} from './externs';
@@ -16,9 +19,9 @@ import {ModulesManifest} from './modules_manifest';
 import {quotingTransformer} from './quoting_transformer';
 import {isDtsFileName} from './transformer_util';
 import * as ts from './typescript';
+
 // Retained here for API compatibility.
 export {getGeneratedExterns} from './externs';
-
 export {FileMap, ModulesManifest} from './modules_manifest';
 
 export interface TsickleHost extends googmodule.GoogModuleProcessorHost, AnnotatorHost {
@@ -86,6 +89,10 @@ export function emitWithTsickle(
     targetSourceFile?: ts.SourceFile, writeFile?: ts.WriteFileCallback,
     cancellationToken?: ts.CancellationToken, emitOnlyDtsFiles?: boolean,
     customTransformers: EmitTransformers = {}): EmitResult {
+  for (const sf of program.getSourceFiles()) {
+    assertAbsolute(sf.fileName);
+  }
+
   let tsickleDiagnostics: ts.Diagnostic[] = [];
   const typeChecker = program.getTypeChecker();
   const tsickleSourceTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
@@ -129,6 +136,7 @@ export function emitWithTsickle(
       (fileName: string, content: string, writeByteOrderMark: boolean,
        onError: ((message: string) => void)|undefined,
        sourceFiles: ReadonlyArray<ts.SourceFile>) => {
+        assertAbsolute(fileName);
         if (host.addDtsClutzAliases && isDtsFileName(fileName) && sourceFiles) {
           // Only bundle emits pass more than one source file for .d.ts writes. Bundle emits however
           // are not supported by tsickle, as we cannot annotate them for Closure in any meaningful

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -154,15 +154,10 @@ export function emitWithTsickle(
       if (isDts && host.shouldSkipTsickleProcessing(sourceFile.fileName)) {
         continue;
       }
-      // fileName might be absolute, which would cause emits different by checkout location or
-      // non-deterministic output for build systems that use hashed work directories (bazel).
-      // fileNameToModuleId gives the logical, base path relative ID for the given fileName, which
-      // avoids this issue.
-      const moduleId = host.fileNameToModuleId(sourceFile.fileName);
       const {output, diagnostics} = generateExterns(
           typeChecker, sourceFile, host, /* moduleResolutionHost */ host.host, tsOptions);
       if (output) {
-        externs[moduleId] = output;
+        externs[sourceFile.fileName] = output;
       }
       if (diagnostics) {
         tsickleDiagnostics.push(...diagnostics);

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -344,7 +344,7 @@ export class TypeTranslator {
     const fileName = ambientModuleDeclaration ?
         ambientModuleDeclaration.name.text :
         ts.getOriginalNode(declarations[0]).getSourceFile().fileName;
-    const mangled = moduleNameAsIdentifier(this.host, fileName, this.node.getSourceFile().fileName);
+    const mangled = moduleNameAsIdentifier(this.host, fileName);
     return mangled + '.';
   }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -20,6 +20,10 @@ ts_library(
         "tsickle_test.ts",
         "type_translator_test.ts",
     ],
+    # Unit tests run the TS compiler, which attempts to module-resolve 'tslib'
+    # when configured with --importHelpers.  So the tests must have tslib.d.ts
+    # available as a runtime data dep.
+    data = ["//:node_modules"],
     tsconfig = "//:tsconfig.json",
     deps = [
         ":test_support",

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as path from 'path';
+
 import {toClosureJS} from '../src/main';
 import * as tsickle from '../src/tsickle';
 
@@ -16,33 +18,36 @@ describe('toClosureJS', () => {
     testSupport.addDiffMatchers();
   });
   it('creates externs, adds type comments and rewrites imports', () => {
+    // Note: normally all paths that interact with the TS API must be absolute,
+    // but this test is testing main.ts, which has its own logic for making
+    // paths absolute.
     const filePaths = [
       'test_files/underscore/export_underscore.ts',
       'test_files/underscore/underscore.ts',
     ];
+    // files is a map of rootDir-relative output paths to their contents.
+    // We make the paths relative here so that the test assertions below can
+    // look them up by their relative paths.
     const files = new Map<string, string>();
     const result = toClosureJS(
         testSupport.compilerOptions, filePaths, {isTyped: true},
         (filePath: string, contents: string) => {
-          files.set(filePath, contents);
+          files.set(path.relative(testSupport.compilerOptions.rootDir!, filePath), contents);
         });
 
-    if (result.diagnostics.length || true) {
-      // result.diagnostics.forEach(v => console.log(JSON.stringify(v)));
-      expect(testSupport.formatDiagnostics(result.diagnostics)).toBe('');
-    }
+    testSupport.expectDiagnosticsEmpty(result.diagnostics);
 
-    expect(tsickle.getGeneratedExterns(testSupport.compilerOptions.rootDir!, result.externs))
+    expect(tsickle.getGeneratedExterns(result.externs, testSupport.compilerOptions.rootDir!))
         .toContain(`/** @const */
 var __NS = {};
 /** @type {number} */
 __NS.__ns1;`);
 
-    const underscoreDotJs = files.get('./test_files/underscore/underscore.js');
+    const underscoreDotJs = files.get('test_files/underscore/underscore.js');
     expect(underscoreDotJs).toContain(`goog.module('test_files.underscore.underscore')`);
     expect(underscoreDotJs).toContain(`/** @type {string} */`);
 
-    const exportUnderscoreDotJs = files.get('./test_files/underscore/export_underscore.js');
+    const exportUnderscoreDotJs = files.get('test_files/underscore/export_underscore.js');
     expect(exportUnderscoreDotJs)
         .toContain(`goog.module('test_files.underscore.export_underscore')`);
   });

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -32,7 +32,8 @@ describe('toClosureJS', () => {
       expect(testSupport.formatDiagnostics(result.diagnostics)).toBe('');
     }
 
-    expect(tsickle.getGeneratedExterns(result.externs)).toContain(`/** @const */
+    expect(tsickle.getGeneratedExterns(testSupport.compilerOptions.rootDir!, result.externs))
+        .toContain(`/** @const */
 var __NS = {};
 /** @type {number} */
 __NS.__ns1;`);

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -212,7 +212,9 @@ testFn('golden tests with transformer', () => {
             filteredExterns[fileName] = externs[fileName];
           }
         }
-        if (anyExternsGenerated) allExterns = getGeneratedExterns(filteredExterns);
+        if (anyExternsGenerated) {
+          allExterns = getGeneratedExterns(tsCompilerOptions.rootDir!, filteredExterns);
+        }
       }
       compareAgainstGolden(allExterns, test.externsPath, test);
       for (const [outputPath, output] of tscOutput) {


### PR DESCRIPTION
Two commits, can be reviewed separately.

This is part of my yak shave for running tsickle tests in google3, but it also came up in an unrelated yak shave, so I may as well submit it.  If the approach looks good to you I'll need to test it against g3 and verify I didn't break any assumptions there as well.