### PR TITLE
translate the empty object type {} as *

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -715,9 +715,21 @@ export class TypeTranslator {
         }
         return `!Object<${keyType},${this.translate(valType)}>`;
       } else if (!callable && !indexable) {
-        // Special-case the empty object {} because Closure doesn't like it.
-        // TODO(evanm): revisit this if it is a problem.
-        return '!Object';
+        // The object has no members.  This is the TS type '{}',
+        // which means "any value other than null or undefined".
+        // What is this in Closure's type system?
+        //
+        // First, {!Object} is wrong because it is not a supertype of
+        // {string} or {number}.  This would mean you cannot assign a
+        // number to a variable of TS type {}.
+        //
+        // We get closer with {*}, aka the ALL type.  This one better
+        // captures the typical use of the TS {}, which users use for
+        // "I don't care".
+        //
+        // {*} unfortunately does include null/undefined, so it's a closer
+        // match for TS 3.0's 'unknown'.
+        return '*';
       }
     }
 

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -146,7 +146,7 @@ const c = 'c';
  * as this breaks their closure plugin :-(
  *
  * @polymerBehavior
- * @type {!Object}
+ * @type {*}
  */
 const somePolymerBehavior = {};
 /**

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -23,10 +23,17 @@ let typeObject = { a: 3, b: 'b' };
 let typeObjectIndexable;
 /** @type {?} */
 let typeObjectMixedIndexProperty;
-/** @type {!Object} */
+/** @type {*} */
 let typeObjectEmpty;
 /** @type {!Object} */
 let typeNonPrimitive;
+// Verify assignability into these supertypes.
+typeObjectEmpty = 1;
+typeObjectEmpty = 'a';
+typeObjectEmpty = new Date();
+typeObjectEmpty = {};
+typeNonPrimitive = {};
+typeNonPrimitive = new Date();
 /** @type {!Array<?>} */
 let typeTuple = [1, 2];
 /** @type {!Array<?>} */
@@ -49,7 +56,7 @@ let typeFunc = function () { };
 let typeFunc2 = function (a, b) { return ''; };
 /** @type {function(number, function(number): string): string} */
 let typeFunc3 = function (x, cb) { return ''; };
-/** @type {function(number, (undefined|!Object)=): string} */
+/** @type {function(number, (undefined|*)=): string} */
 let typeFuncOptionalArg;
 /** @type {function(number, ...number): void} */
 let typeFuncVarArgs;

--- a/test_files/type/type.ts
+++ b/test_files/type/type.ts
@@ -15,6 +15,14 @@ let typeObjectMixedIndexProperty: {a:number, [key:string]: number};
 let typeObjectEmpty: {};
 let typeNonPrimitive: object;
 
+// Verify assignability into these supertypes.
+typeObjectEmpty = 1;
+typeObjectEmpty = 'a';
+typeObjectEmpty = new Date();
+typeObjectEmpty = {};
+typeNonPrimitive = {};
+typeNonPrimitive = new Date();
+
 let typeTuple: [number, number] = [1, 2];
 let typeComplexTuple: [string, true|{a:string}] = ['', true];
 let typeTupleTuple: [[number, number]] = [[1, 2]];

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -7,7 +7,7 @@ var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };
 module = module;
 exports = {};
 /**
- * @param {!Object} a
+ * @param {*} a
  * @return {boolean}
  */
 function isBoolean(a) {


### PR DESCRIPTION
{} in TypeScript means "any value other than null or undefined".
We translated this as Closure {!Object}, but {*} better captures
this.

See the comments for more reasoning.