### PR TITLE
replace a stray reference to runfiles to use rootDir()

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -233,8 +233,7 @@ export class GoldenFileTest {
 }
 
 export function goldenTests(): GoldenFileTest[] {
-  assert(process.env['RUNFILES']);
-  const basePath = path.join(process.env['RUNFILES']!, 'tsickle', 'test_files');
+  const basePath = path.join(rootDir(), 'test_files');
   const testNames = fs.readdirSync(basePath);
 
   const testDirs = testNames.map(testName => path.join(basePath, testName))


### PR DESCRIPTION
I refactored this code to rely on a rootDir() helper, but overlooked
one user.  Making all code use the same helper helps with importing
this code into Google, because we need to remap all the paths.