### PR TITLE
Do not forwardDeclare blacklisted types.

### DIFF
--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -218,6 +218,9 @@ export class ModuleTypeTranslator {
     if (this.host.untyped) return;
     // Already imported? Do not emit a duplicate forward declare.
     if (this.forwardDeclaredModules.has(moduleSymbol)) return;
+    if (this.host.typeBlackListPaths && this.host.typeBlackListPaths.has(importPath)) {
+      return;  // Do not emit goog.forwardDeclare or goog.require for blacklisted paths.
+    }
     const nsImport = googmodule.extractGoogNamespaceImport(importPath);
     const forwardDeclarePrefix = `tsickle_forward_declare_${++this.forwardDeclareCounter}`;
     const moduleNamespace = nsImport !== null ?
@@ -294,7 +297,6 @@ export class ModuleTypeTranslator {
       this.error(decl, `declaration from module used in ambient type: ${sym.name}`);
       return;
     }
-
     // Actually import the symbol.
     const sourceFile = decl.getSourceFile();
     if (sourceFile === ts.getOriginalNode(this.sourceFile)) return;

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -5,13 +5,11 @@
  *
  * @suppress {checkTypes,extraRequire,missingReturn,uselessCode} checked by tsc
  */
+// This should not have a type annotation.
 goog.module('test_files.jsdoc_types.initialized_unknown');
 var module = module || { id: 'test_files/jsdoc_types/initialized_unknown.ts' };
 module = module;
 exports = {};
-const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
-goog.require('test_files.jsdoc_types.nevertyped'); // force type-only module to be loaded
-// This should not have a type annotation.
 const initializedUntyped = {
     foo: 1
 };

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -9,8 +9,6 @@ exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module1");
 const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.module2");
 const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.default");
-const tsickle_forward_declare_4 = goog.forwardDeclare("test_files.jsdoc_types.nevertyped");
-goog.require('test_files.jsdoc_types.nevertyped'); // force type-only module to be loaded
 /**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.


### PR DESCRIPTION
Their types cannot be referenced, but neither can their modules.