### PR TITLE
add flag for goog.requireType instead of goog.forwardDeclare

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -261,7 +261,7 @@ export class TypeTranslator {
       }
       let symbol = identifier.symbol;
       // When writing a symbol, check if there is an alias for it in the current scope that should
-      // take precedence, e.g. from a goog.forwardDeclare.
+      // take precedence, e.g. from a goog.requireType.
       if (symbol.flags & ts.SymbolFlags.Alias) {
         symbol = this.typeChecker.getAliasedSymbol(symbol);
       }


### PR DESCRIPTION
goog.requireType more closely matches the semantics of a TypeScript
type import.

As part of this change, clean up a few of the comments in the area
and simplify the code a bit.