### PR TITLE
clang-format one test

### DIFF
--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -6,43 +6,43 @@ goog.module('test_files.jsdoc_types.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types/jsdoc_types.ts' };
 module = module;
 exports = {};
-const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.module1");
-const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.module2");
-const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.default");
+const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.jsdoc_types.default");
+const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.jsdoc_types.module1");
+const tsickle_forward_declare_3 = goog.forwardDeclare("test_files.jsdoc_types.module2");
 /**
  * This test tests importing a type across module boundaries,
  * ensuring that the type gets the proper name in JSDoc comments.
  */
+const default_1 = goog.require('test_files.jsdoc_types.default');
 const module1 = goog.require('test_files.jsdoc_types.module1');
 const module2_1 = goog.require('test_files.jsdoc_types.module2');
-const default_1 = goog.require('test_files.jsdoc_types.default');
 // Check that imported types get the proper names in JSDoc.
-/** @type {!tsickle_forward_declare_1.Class} */
+/** @type {!tsickle_forward_declare_2.Class} */
 let useNamespacedClass = new module1.Class();
-/** @type {!tsickle_forward_declare_1.Class} */
+/** @type {!tsickle_forward_declare_2.Class} */
 let useNamespacedClassAsType;
-/** @type {!tsickle_forward_declare_1.Interface} */
+/** @type {!tsickle_forward_declare_2.Interface} */
 let useNamespacedType;
 // Should be references to the symbols in module2, perhaps via locals.
-/** @type {!tsickle_forward_declare_2.ClassOne} */
+/** @type {!tsickle_forward_declare_3.ClassOne} */
 let useLocalClass = new module2_1.ClassOne();
-/** @type {!tsickle_forward_declare_2.ClassOne} */
+/** @type {!tsickle_forward_declare_3.ClassOne} */
 let useLocalClassRenamed = new module2_1.ClassOne();
-/** @type {!tsickle_forward_declare_2.ClassTwo} */
+/** @type {!tsickle_forward_declare_3.ClassTwo} */
 let useLocalClassRenamedTwo = new module2_1.ClassTwo();
-/** @type {!tsickle_forward_declare_2.ClassOne} */
+/** @type {!tsickle_forward_declare_3.ClassOne} */
 let useLocalClassAsTypeRenamed;
-/** @type {!tsickle_forward_declare_2.Interface} */
+/** @type {!tsickle_forward_declare_3.Interface} */
 let useLocalInterface;
-/** @type {!tsickle_forward_declare_2.ClassWithParams<number>} */
+/** @type {!tsickle_forward_declare_3.ClassWithParams<number>} */
 let useClassWithParams;
 // This is purely a value; it doesn't need renaming.
 /** @type {number} */
 let useLocalValue = module2_1.value;
 // Check a default import.
-/** @type {!tsickle_forward_declare_3.default} */
+/** @type {!tsickle_forward_declare_1.default} */
 let useDefaultClass = new default_1.default();
-/** @type {!tsickle_forward_declare_3.default} */
+/** @type {!tsickle_forward_declare_1.default} */
 let useDefaultClassAsType;
 // NeverTyped should be {?}, even in typed mode.
 /** @type {?} */

--- a/test_files/jsdoc_types/jsdoc_types.ts
+++ b/test_files/jsdoc_types/jsdoc_types.ts
@@ -3,9 +3,9 @@
  * ensuring that the type gets the proper name in JSDoc comments.
  */
 
-import * as module1 from './module1';
-import {ClassOne, value, ClassOne as RenamedClassOne, ClassTwo as RenamedClassTwo, Interface, ClassWithParams} from './module2';
 import DefaultClass from './default';
+import * as module1 from './module1';
+import {ClassOne, ClassOne as RenamedClassOne, ClassTwo as RenamedClassTwo, ClassWithParams, Interface, value} from './module2';
 import {NeverTyped, NeverTypedTemplated} from './nevertyped';
 
 // Check that imported types get the proper names in JSDoc.


### PR DESCRIPTION
clang-format wants to reorder the imports in this test, which affects
the variable names in the emit.  Rebaseline it.