### PR TITLE
Refactor `symbolToString`.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -194,7 +194,7 @@ export function maybeAddHeritageClauses(
         continue;
       }
       // typeToClosure includes nullability modifiers, so call symbolToString directly here.
-      docTags.push({tagName, type: typeTranslator.symbolToString(alias, true)});
+      docTags.push({tagName, type: typeTranslator.symbolToString(alias) || 'InexpressibleType'});
     }
   }
 }


### PR DESCRIPTION
- drop the now unused `fqn` parameter.
- push logic to use `?` to usages of `symbolToString`. Whether to emit
  a `?` depends on the use site (e.g. heritage clauses, `!?`), so the
  method should return `string|undefined` and have users choose what to
  do.