### PR TITLE
restore 'implements class' hack

### DIFF
--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,9 +1,4 @@
 // test_files/class/class.ts(44,1): warning TS0: omitting interface deriving from class: Class
-// test_files/class/class.ts(52,1): warning TS0: omitting @implements of a class: Class
-// test_files/class/class.ts(55,1): warning TS0: omitting @implements of a class: AbstractClass
-// test_files/class/class.ts(76,1): warning TS0: omitting @implements of a class: Class
-// test_files/class/class.ts(79,1): warning TS0: omitting @implements of a class: AbstractClass
-// test_files/class/class.ts(98,1): warning TS0: omitting @implements of a class: Class
 // test_files/class/class.ts(124,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 // test_files/class/class.ts(126,1): warning TS0: omitting heritage reference to a type/value conflict: Zone
 // test_files/class/class.ts(130,1): warning TS0: omitting heritage reference to a type/value conflict: ZoneAlias
@@ -98,7 +93,7 @@ class ClassImplementsInterface {
     interfaceFunc() { }
 }
 /**
- * @implements {InexpressibleType}
+ * @extends {Class}
  */
 class ClassImplementsClass {
     /**
@@ -107,7 +102,7 @@ class ClassImplementsClass {
     classFunc() { }
 }
 /**
- * @implements {InexpressibleType}
+ * @extends {AbstractClass}
  */
 class ClassImplementsAbstractClass {
     /**
@@ -149,7 +144,7 @@ class AbstractClassImplementsInterface {
 }
 /**
  * @abstract
- * @implements {InexpressibleType}
+ * @extends {Class}
  */
 class AbstractClassImplementsClass {
     /**
@@ -159,7 +154,7 @@ class AbstractClassImplementsClass {
 }
 /**
  * @abstract
- * @implements {InexpressibleType}
+ * @extends {AbstractClass}
  */
 class AbstractClassImplementsAbstractClass {
     // Note: because this class *implements* AbstractClass, it must also implement
@@ -192,7 +187,7 @@ class AbstractClassExtendsAbstractClass extends AbstractClass {
 }
 /**
  * @implements {Interface}
- * @implements {InexpressibleType}
+ * @extends {Class}
  */
 class ImplementsTypeAlias {
     /**

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,4 +1,3 @@
-// test_files/interface/implement_import.ts(7,1): warning TS0: omitting @implements of a class: User
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingReturn,uselessCode} checked by tsc
@@ -29,7 +28,7 @@ if (false) {
     MyPoint.prototype.y;
 }
 /**
- * @implements {InexpressibleType}
+ * @extends {tsickle_forward_declare_1.User}
  */
 class ImplementsUser {
     /**


### PR DESCRIPTION
tsickle previously converted
  class X implements OtherClass
into
  class X extends OtherClass
in some situations.

In e466dc5f I removed this behavior, but it appears we have code that
actually relies on this.  I now think this behavior was a mistake but for
now let's preserve our behavior so that we can get the other benefits of
this change.