### PR TITLE
fix: don't add comments in json files

### DIFF
--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -84,6 +84,10 @@ export function transformFileoverviewCommentFactory(diagnostics: ts.Diagnostic[]
     }
 
     return (sourceFile: ts.SourceFile) => {
+      if (sourceFile.fileName.toLowerCase().endsWith('.json')) {
+        return sourceFile;
+      }
+
       const text = sourceFile.getFullText();
 
       let fileComments: ts.SynthesizedComment[] = [];


### PR DESCRIPTION
TypeScript 2.9 introduced the `resolveJsonModule` feature, however `tsickle` will parse json files add the overview comment will will make them invalid json files.

Example:
```
/**
 * @fileoverview added by tsickle
 * @suppress {checkTypes,extraRequire,uselessCode} checked by tsc
 */
{
    "fo": true
}
```

This change will make sure that `.json` files are not parsed.