### PR TITLE
do not merge jsdoc tags with the same name with flag --noTagMerge

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -61,6 +61,10 @@ export interface AnnotatorHost {
    */
   enableAutoQuoting?: boolean;
   /**
+   * If true, JSDoc tags with the same name are not merged.
+   */
+  noTagMerge?: boolean;
+  /**
    * Whether tsickle should insert goog.provide() calls into the externs generated for `.d.ts` files
    * that are external modules.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ export interface Settings {
 
   /** If true, log internal debug warnings to the console. */
   verbose?: boolean;
+
+  noTagMerge?: boolean;
 }
 
 function usage() {
@@ -43,6 +45,7 @@ tsickle flags are:
   --externs=PATH        save generated Closure externs.js to PATH
   --typed               [experimental] attempt to provide Closure types instead of {?}
   --enableAutoQuoting   automatically apply quotes to property accesses
+  --noTagMerge          do not merge JSDoc tags with the same name
 `);
 }
 
@@ -66,6 +69,8 @@ function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: str
       case 'typed':
         settings.isTyped = true;
         break;
+      case 'noTagMerge':
+        settings.noTagMerge = true;
       case 'verbose':
         settings.verbose = true;
         break;
@@ -174,6 +179,7 @@ export function toClosureJS(
     typeBlackListPaths: new Set(),
     enableAutoQuoting: settings.enableAutoQuoting,
     untyped: false,
+    noTagMerge: settings.noTagMerge,
     logWarning: (warning) => console.error(ts.formatDiagnostics([warning], compilerHost)),
     options,
     host: compilerHost,

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -383,12 +383,12 @@ export class ModuleTypeTranslator {
     const typeChecker = this.typeChecker;
     const noTagMerge = this.host.noTagMerge;
 
-    // const tagsByName = new Map<string, jsdoc.Tag>();
     const newDoc: jsdoc.Tag[] = [];
     function addTag(tag: jsdoc.Tag) {
       if (noTagMerge) {
         newDoc.push(tag);
-      } else {  // De-duplicate tags and docs found for the fnDecls.
+      } else {
+        // De-duplicate tags and docs found for the fnDecls.
         const existingIndex = newDoc.findIndex((t) => t.tagName === tag.tagName);
         if (existingIndex > -1) {
           newDoc[existingIndex] = jsdoc.merge([newDoc[existingIndex], tag]);

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -35,6 +35,7 @@ describe('emitWithTsickle', () => {
       transformDecorators: true,
       transformTypesToClosure: true,
       untyped: true,
+      noTagMerge: false,
       logWarning: (diag: ts.Diagnostic) => {},
       shouldSkipTsickleProcessing: (fileName) => {
         assertAbsolute(fileName);
@@ -102,6 +103,24 @@ describe('emitWithTsickle', () => {
         {es5Mode: false, googmodule: false});
 
     expect(jsSources['b.js']).toContain(`export { Foo } from './a';`);
+  });
+
+  it('should not merge JSDoc tags with --noMergeTag flag', () => {
+    const tsSources = {
+      'a.ts': `
+        /**
+         *  @example
+         *   example 1
+         *  @example
+         *   example 2
+        */
+        function test() {}
+      `
+    };
+    const jsSources = emitWithTsickle(tsSources, {}, {noTagMerge: true});
+    const jsContent = jsSources['a.js'];
+    const count = (jsContent.match(/@example/g) || []).length;
+    expect(count).toEqual(2);
   });
 
   describe('regressions', () => {


### PR DESCRIPTION
Currently JSDoc tags with the same names are merged in the output externs. 
For example, 

```javascript
/**
 *  @example
 *   example 1
 *  @example
 *   example 2
*/
function test() {}
```
becomes
```javascript
/**
 * \@example
 *   example 1 /
 *   example 2
 * @return {void}
 */
function test() { }
```
Notice that @example tags are merged.

This PR adds a new flag --noTagMerge. If set to true, JSDoc tags with the same name will not be merged. This is to address an issue I opened earlier: https://github.com/angular/tsickle/issues/907
With this change, and command  `tsickle --noTagMerge --externs=output.js`
 the output will look like:
```javascript
/**
 * \@example 
 *   example 1
 * \@example 
 *   example 2
 * @return {void}
 */
function test() {}
```

I wanted to add a test case, but I couldn't find any place for module_type_translator.ts. Please let me know how I can do it properly, and I will add the test case.