### PR TITLE
emit @private/@protected on abstract methods

### DIFF
--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -420,9 +420,16 @@ export class ModuleTypeTranslator {
         addTag(tag);
       }
 
+      const flags = ts.getCombinedModifierFlags(fnDecl);
       // Add @abstract on "abstract" declarations.
-      if (hasModifierFlag(fnDecl, ts.ModifierFlags.Abstract)) {
+      if (flags & ts.ModifierFlags.Abstract) {
         addTag({tagName: 'abstract'});
+      }
+      // Add @protected/@private if present.
+      if (flags & ts.ModifierFlags.Protected) {
+        addTag({tagName: 'protected'});
+      } else if (flags & ts.ModifierFlags.Private) {
+        addTag({tagName: 'private'});
       }
 
       // Add any @template tags.

--- a/test_files/protected/protected.js
+++ b/test_files/protected/protected.js
@@ -16,6 +16,16 @@ class Protected {
         this.anotherPrivate = anotherPrivate;
         this.anotherProtected = anotherProtected;
     }
+    /**
+     * @private
+     * @return {void}
+     */
+    privateMethod() { }
+    /**
+     * @protected
+     * @return {void}
+     */
+    protectedMethod() { }
 }
 if (false) {
     /**
@@ -38,4 +48,17 @@ if (false) {
      * @protected
      */
     Protected.prototype.anotherProtected;
+}
+/**
+ * @abstract
+ */
+class Abstract {
+}
+if (false) {
+    /**
+     * @abstract
+     * @protected
+     * @return {void}
+     */
+    Abstract.prototype.foo = function () { };
 }

--- a/test_files/protected/protected.ts
+++ b/test_files/protected/protected.ts
@@ -5,9 +5,15 @@ export {};
 class Protected {
   private privateMember: string;
   protected protectedMember: string;
+  private privateMethod() {}
+  protected protectedMethod() {}
 
   constructor(
       private anotherPrivate: string,
       protected anotherProtected: string,
   ) {}
+}
+
+abstract class Abstract {
+  protected abstract foo(): void;
 }


### PR DESCRIPTION
For various reasons, abstract methods (which have no body)
go down a different code path than the code that handles non-abstract
methods, so my previous change to handle @private/@protected missed
these.