### PR TITLE
remove circular import dependencies

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -5,6 +5,7 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 ts_library(
     name = "src",
     srcs = [
+        "annotator_host.ts",
         "cli_support.ts",
         "decorator_downlevel_transformer.ts",
         "decorators.ts",

--- a/src/annotator_host.ts
+++ b/src/annotator_host.ts
@@ -54,3 +54,13 @@ export interface AnnotatorHost {
   /** Used together with the host for file name -> module name resolution. */
   options: ts.CompilerOptions;
 }
+
+/**
+ * Returns a mangled version of the module name (resolved file name) for source file.
+ *
+ * The mangled name is safe to use as a JavaScript identifier. It is used as a globally unique
+ * prefix to scope symbols in externs file (see externs.ts).
+ */
+export function moduleNameAsIdentifier(host: AnnotatorHost, fileName: string): string {
+  return host.pathToModuleName('', fileName).replace(/\./g, '$');
+}

--- a/src/annotator_host.ts
+++ b/src/annotator_host.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * AnnotatorHost contains host properties for the JSDoc-annotation process.
+ * It's used by a bunch of different tsickle modules, including the type
+ * translators, the externs generator, and the main JSDoc transformer.
+ *
+ * Contrast this with the GoogModuleProcessorHost, the separate host used for
+ * the goog.module() translation process.
+ *
+ * TODO(evmar): consider breaking this into more scoped hosts for the different
+ * modules, rather than one massive list of all possible needed functionality.
+ */
+export interface AnnotatorHost {
+  /**
+   * If provided a function that logs an internal warning.
+   * These warnings are not actionable by an end user and should be hidden
+   * by default.
+   */
+  logWarning?: (warning: ts.Diagnostic) => void;
+  pathToModuleName: (context: string, importPath: string) => string;
+  /**
+   * If true, convert every type to the Closure {?} type, which means
+   * "don't check types".
+   */
+  untyped?: boolean;
+  /** If provided, a set of paths whose types should always generate as {?}. */
+  typeBlackListPaths?: Set<string>;
+  /**
+   * Convert shorthand "/index" imports to full path (include the "/index").
+   * Annotation will be slower because every import must be resolved.
+   */
+  convertIndexImportShorthand?: boolean;
+  /**
+   * If true, modify quotes around property accessors to match the type declaration.
+   */
+  enableAutoQuoting?: boolean;
+  /**
+   * Whether tsickle should insert goog.provide() calls into the externs generated for `.d.ts` files
+   * that are external modules.
+   */
+  provideExternalModuleDtsNamespace?: boolean;
+
+  /** host allows resolving file names to modules. */
+  host: ts.ModuleResolutionHost;
+  /** Used together with the host for file name -> module name resolution. */
+  options: ts.CompilerOptions;
+}

--- a/src/enum_transformer.ts
+++ b/src/enum_transformer.ts
@@ -21,8 +21,7 @@
 
 import * as ts from 'typescript';
 
-import {isAmbient} from './jsdoc_transformer';
-import {createSingleQuoteStringLiteral, getIdentifierText, hasModifierFlag} from './transformer_util';
+import {createSingleQuoteStringLiteral, getIdentifierText, hasModifierFlag, isAmbient} from './transformer_util';
 
 /** isInNamespace returns true if any of node's ancestors is a namespace (ModuleDeclaration). */
 function isInNamespace(node: ts.Node) {

--- a/src/externs.ts
+++ b/src/externs.ts
@@ -58,7 +58,7 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {AnnotatorHost} from './annotator_host';
+import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
 import {getEnumType} from './enum_transformer';
 import {extractGoogNamespaceImport, resolveModuleName} from './googmodule';
 import * as jsdoc from './jsdoc';
@@ -120,16 +120,6 @@ export function getGeneratedExterns(externs: {[fileName: string]: string}, rootD
     allExterns += externs[fileName];
   }
   return allExterns;
-}
-
-/**
- * Returns a mangled version of the module name (resolved file name) for source file.
- *
- * The mangled name is safe to use as a JavaScript identifier. It is used as a globally unique
- * prefix to scope symbols in externs file (see code below).
- */
-export function moduleNameAsIdentifier(host: AnnotatorHost, fileName: string): string {
-  return host.pathToModuleName('', fileName).replace(/\./g, '$');
 }
 
 /**

--- a/src/externs.ts
+++ b/src/externs.ts
@@ -58,10 +58,11 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {AnnotatorHost} from './annotator_host';
 import {getEnumType} from './enum_transformer';
 import {extractGoogNamespaceImport, resolveModuleName} from './googmodule';
 import * as jsdoc from './jsdoc';
-import {AnnotatorHost, escapeForComment, maybeAddHeritageClauses, maybeAddTemplateClause} from './jsdoc_transformer';
+import {escapeForComment, maybeAddHeritageClauses, maybeAddTemplateClause} from './jsdoc_transformer';
 import {ModuleTypeTranslator} from './module_type_translator';
 import {getEntityNameText, getIdentifierText, hasModifierFlag, isDtsFileName, reportDiagnostic} from './transformer_util';
 import {isValidClosurePropertyName} from './type_translator';

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -81,18 +81,6 @@ function addCommentOn(node: ts.Node, tags: jsdoc.Tag[], escapeExtraTags?: Set<st
   return comment;
 }
 
-/** @return true if node has the specified modifier flag set. */
-export function isAmbient(node: ts.Node): boolean {
-  let current: ts.Node|undefined = node;
-  while (current) {
-    if (transformerUtil.hasModifierFlag(current as ts.Declaration, ts.ModifierFlags.Ambient)) {
-      return true;
-    }
-    current = current.parent;
-  }
-  return false;
-}
-
 type HasTypeParameters =
     ts.InterfaceDeclaration|ts.ClassLikeDeclaration|ts.TypeAliasDeclaration|ts.SignatureDeclaration;
 
@@ -124,7 +112,7 @@ export function maybeAddHeritageClauses(
       //
       // However for ambient declarations, we only emit externs, and in those we do need to
       // add "@extends {Foo}" as they use ES5 syntax.
-      if (!isAmbient(decl)) continue;
+      if (!transformerUtil.isAmbient(decl)) continue;
     }
 
     // Otherwise, if we get here, we need to emit some jsdoc.
@@ -959,7 +947,7 @@ export function jsdocTransformer(
       }
 
       function visitor(node: ts.Node): ts.Node|ts.Node[] {
-        if (isAmbient(node)) {
+        if (transformerUtil.isAmbient(node)) {
           if (!transformerUtil.hasModifierFlag(node as ts.Declaration, ts.ModifierFlags.Export)) {
             return node;
           }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -28,6 +28,7 @@
 
 import * as ts from 'typescript';
 
+import {AnnotatorHost} from './annotator_host';
 import {hasExportingDecorator} from './decorators';
 import {moduleNameAsIdentifier} from './externs';
 import * as googmodule from './googmodule';
@@ -35,43 +36,6 @@ import * as jsdoc from './jsdoc';
 import {ModuleTypeTranslator} from './module_type_translator';
 import * as transformerUtil from './transformer_util';
 import {isValidClosurePropertyName} from './type_translator';
-
-/** AnnotatorHost contains host properties for the JSDoc-annotation process. */
-export interface AnnotatorHost {
-  /**
-   * If provided a function that logs an internal warning.
-   * These warnings are not actionable by an end user and should be hidden
-   * by default.
-   */
-  logWarning?: (warning: ts.Diagnostic) => void;
-  pathToModuleName: (context: string, importPath: string) => string;
-  /**
-   * If true, convert every type to the Closure {?} type, which means
-   * "don't check types".
-   */
-  untyped?: boolean;
-  /** If provided, a set of paths whose types should always generate as {?}. */
-  typeBlackListPaths?: Set<string>;
-  /**
-   * Convert shorthand "/index" imports to full path (include the "/index").
-   * Annotation will be slower because every import must be resolved.
-   */
-  convertIndexImportShorthand?: boolean;
-  /**
-   * If true, modify quotes around property accessors to match the type declaration.
-   */
-  enableAutoQuoting?: boolean;
-  /**
-   * Whether tsickle should insert goog.provide() calls into the externs generated for `.d.ts` files
-   * that are external modules.
-   */
-  provideExternalModuleDtsNamespace?: boolean;
-
-  /** host allows resolving file names to modules. */
-  host: ts.ModuleResolutionHost;
-  /** Used together with the host for file name -> module name resolution. */
-  options: ts.CompilerOptions;
-}
 
 function addCommentOn(node: ts.Node, tags: jsdoc.Tag[], escapeExtraTags?: Set<string>) {
   const comment = jsdoc.toSynthesizedComment(tags, escapeExtraTags);

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -28,9 +28,8 @@
 
 import * as ts from 'typescript';
 
-import {AnnotatorHost} from './annotator_host';
+import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
 import {hasExportingDecorator} from './decorators';
-import {moduleNameAsIdentifier} from './externs';
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
 import {ModuleTypeTranslator} from './module_type_translator';

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -16,7 +16,7 @@ import * as ts from 'typescript';
 
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
-import {AnnotatorHost, isAmbient} from './jsdoc_transformer';
+import {AnnotatorHost} from './jsdoc_transformer';
 import {createSingleQuoteStringLiteral, getIdentifierText, hasModifierFlag, reportDebugWarning, reportDiagnostic} from './transformer_util';
 import * as typeTranslator from './type_translator';
 

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -14,9 +14,9 @@
 
 import * as ts from 'typescript';
 
+import {AnnotatorHost} from './annotator_host';
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
-import {AnnotatorHost} from './jsdoc_transformer';
 import {createSingleQuoteStringLiteral, getIdentifierText, hasModifierFlag, reportDebugWarning, reportDiagnostic} from './transformer_util';
 import * as typeTranslator from './type_translator';
 

--- a/src/quoting_transformer.ts
+++ b/src/quoting_transformer.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {AnnotatorHost} from './jsdoc_transformer';
+import {AnnotatorHost} from './annotator_host';
 import {createSingleQuoteStringLiteral, reportDebugWarning} from './transformer_util';
 import {isValidClosurePropertyName} from './type_translator';
 

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -13,6 +13,18 @@ export function hasModifierFlag(declaration: ts.Declaration, flag: ts.ModifierFl
   return (ts.getCombinedModifierFlags(declaration) & flag) !== 0;
 }
 
+/** @return true if node has the specified modifier flag set. */
+export function isAmbient(node: ts.Node): boolean {
+  let current: ts.Node|undefined = node;
+  while (current) {
+    if (hasModifierFlag(current as ts.Declaration, ts.ModifierFlags.Ambient)) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
 /** Returns true if fileName is a .d.ts file. */
 export function isDtsFileName(fileName: string): boolean {
   return fileName.endsWith('.d.ts');

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -8,13 +8,14 @@
 
 import * as ts from 'typescript';
 
+import {AnnotatorHost} from './annotator_host';
 import {assertAbsolute} from './cli_support';
 import {decoratorDownlevelTransformer} from './decorator_downlevel_transformer';
 import {enumTransformer} from './enum_transformer';
 import {generateExterns} from './externs';
 import {transformFileoverviewCommentFactory} from './fileoverview_comment_transformer';
 import * as googmodule from './googmodule';
-import {AnnotatorHost, jsdocTransformer, removeTypeAssertions} from './jsdoc_transformer';
+import {jsdocTransformer, removeTypeAssertions} from './jsdoc_transformer';
 import {ModulesManifest} from './modules_manifest';
 import {quotingTransformer} from './quoting_transformer';
 import {isDtsFileName} from './transformer_util';

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -10,8 +10,8 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {moduleNameAsIdentifier} from './externs';
-import {AnnotatorHost, isAmbient} from './jsdoc_transformer';
-import {getIdentifierText, hasModifierFlag} from './transformer_util';
+import {AnnotatorHost} from './jsdoc_transformer';
+import {getIdentifierText, hasModifierFlag, isAmbient} from './transformer_util';
 
 /**
  * TypeScript allows you to write identifiers quoted, like:

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -9,8 +9,7 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {AnnotatorHost} from './annotator_host';
-import {moduleNameAsIdentifier} from './externs';
+import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
 import {getIdentifierText, hasModifierFlag, isAmbient} from './transformer_util';
 
 /**

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -9,8 +9,8 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {AnnotatorHost} from './annotator_host';
 import {moduleNameAsIdentifier} from './externs';
-import {AnnotatorHost} from './jsdoc_transformer';
 import {getIdentifierText, hasModifierFlag, isAmbient} from './transformer_util';
 
 /**


### PR DESCRIPTION
The great refactoring of tsickle into transformers made it have a bunch of circular imports.  These are illegal if we want tsickle to run under a Closure-compiled webpage.

This series of commits untangles the circularity and can be reviewed separately.