### PR TITLE
clean up use of hosts

### DIFF
--- a/src/annotator_host.ts
+++ b/src/annotator_host.ts
@@ -49,8 +49,9 @@ export interface AnnotatorHost {
    */
   provideExternalModuleDtsNamespace?: boolean;
 
-  /** host allows resolving file names to modules. */
-  host: ts.ModuleResolutionHost;
+  /** Used resolving file names to modules. */
+  moduleResolutionHost: ts.ModuleResolutionHost;
+
   /** Used together with the host for file name -> module name resolution. */
   options: ts.CompilerOptions;
 }

--- a/src/externs.ts
+++ b/src/externs.ts
@@ -612,8 +612,8 @@ export function generateExterns(
             // file, so effectively this augments any existing module.
 
             const importName = (decl.name as ts.StringLiteral).text;
-            const importedModuleName = resolveModuleName(
-                {host: moduleResolutionHost, options}, sourceFile.fileName, importName);
+            const importedModuleName =
+                resolveModuleName({moduleResolutionHost, options}, sourceFile.fileName, importName);
             const mangled = moduleNameAsIdentifier(host, importedModuleName);
             emit(`// Derived from: declare module "${importName}"\n`);
             namespace = [mangled];

--- a/src/googmodule.ts
+++ b/src/googmodule.ts
@@ -32,7 +32,7 @@ export interface GoogModuleProcessorHost {
   convertIndexImportShorthand?: boolean;
 
   options: ts.CompilerOptions;
-  host: ts.ModuleResolutionHost;
+  moduleResolutionHost: ts.ModuleResolutionHost;
 }
 
 /**
@@ -135,11 +135,13 @@ const TS_EXTENSIONS = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
  * before generating `goog.module` names.
  */
 export function resolveModuleName(
-    {options, host}: {options: ts.CompilerOptions, host: ts.ModuleResolutionHost},
+    {options, moduleResolutionHost}:
+        {options: ts.CompilerOptions, moduleResolutionHost: ts.ModuleResolutionHost},
     pathOfImportingFile: string, imported: string): string {
   // The strategy taken here is to use ts.resolveModuleName() to resolve the import to
   // a specific path, which resolves any /index and path mappings.
-  const resolved = ts.resolveModuleName(imported, pathOfImportingFile, options, host);
+  const resolved =
+      ts.resolveModuleName(imported, pathOfImportingFile, options, moduleResolutionHost);
   if (!resolved || !resolved.resolvedModule) return imported;
   const resolvedModule = resolved.resolvedModule.resolvedFileName;
 

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -732,7 +732,7 @@ export function jsdocTransformer(
         // Write the export declaration here so that forward declares come after it, and
         // fileoverview comments do not get moved behind statements.
         const importPath = googmodule.resolveModuleName(
-            {options: tsOptions, host: tsHost}, sourceFile.fileName,
+            {options: tsOptions, moduleResolutionHost: tsHost}, sourceFile.fileName,
             (importDecl.moduleSpecifier as ts.StringLiteral).text);
 
         moduleTypeTranslator.forwardDeclare(

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -417,9 +417,10 @@ export function removeTypeAssertions(): ts.TransformerFactory<ts.SourceFile> {
  * JSDoc annotations.
  */
 export function jsdocTransformer(
-    host: AnnotatorHost, tsOptions: ts.CompilerOptions, tsHost: ts.CompilerHost,
-    typeChecker: ts.TypeChecker, diagnostics: ts.Diagnostic[]):
-    (context: ts.TransformationContext) => ts.Transformer<ts.SourceFile> {
+    host: AnnotatorHost, tsOptions: ts.CompilerOptions,
+    moduleResolutionHost: ts.ModuleResolutionHost, typeChecker: ts.TypeChecker,
+    diagnostics: ts.Diagnostic[]): (context: ts.TransformationContext) =>
+    ts.Transformer<ts.SourceFile> {
   return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
     return (sourceFile: ts.SourceFile) => {
       const moduleTypeTranslator = new ModuleTypeTranslator(
@@ -732,7 +733,7 @@ export function jsdocTransformer(
         // Write the export declaration here so that forward declares come after it, and
         // fileoverview comments do not get moved behind statements.
         const importPath = googmodule.resolveModuleName(
-            {options: tsOptions, moduleResolutionHost: tsHost}, sourceFile.fileName,
+            {options: tsOptions, moduleResolutionHost}, sourceFile.fileName,
             (importDecl.moduleSpecifier as ts.StringLiteral).text);
 
         moduleTypeTranslator.forwardDeclare(

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,7 +176,7 @@ export function toClosureJS(
     untyped: false,
     logWarning: (warning) => console.error(ts.formatDiagnostics([warning], compilerHost)),
     options,
-    host: compilerHost,
+    moduleResolutionHost: compilerHost,
   };
   const diagnostics = ts.getPreEmitDiagnostics(program);
   if (diagnostics.length > 0) {

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -168,8 +168,8 @@ export function emitWithTsickle(
       if (isDts && host.shouldSkipTsickleProcessing(sourceFile.fileName)) {
         continue;
       }
-      const {output, diagnostics} = generateExterns(
-          typeChecker, sourceFile, host, /* moduleResolutionHost */ host.host, tsOptions);
+      const {output, diagnostics} =
+          generateExterns(typeChecker, sourceFile, host, host.moduleResolutionHost, tsOptions);
       if (output) {
         externs[sourceFile.fileName] = output;
       }

--- a/test/decorator_downlevel_transformer_test.ts
+++ b/test/decorator_downlevel_transformer_test.ts
@@ -53,7 +53,7 @@ describe('decorator_downlevel_transformer', () => {
       es5Mode: false,
       untyped: false,
       options: testSupport.compilerOptions,
-      host,
+      moduleResolutionHost: host,
     };
 
     const files = new Map<string, string>();

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -161,7 +161,7 @@ testFn('golden tests with transformer', () => {
           return fileName.replace(/^\.\//, '');
         },
         options: tsCompilerOptions,
-        host: tsHost,
+        moduleResolutionHost: tsHost,
       };
 
       /**

--- a/test/googmodule_test.ts
+++ b/test/googmodule_test.ts
@@ -30,7 +30,7 @@ function processES5(fileName: string, content: string, {
         cliSupport.pathToModuleName(rootDir, context, fileName),
     es5Mode: isES5,
     options: testSupport.compilerOptions,
-    host: tsHost,
+    moduleResolutionHost: tsHost,
     isJsTranspilation,
   };
   const program = ts.createProgram([fileName], options, tsHost);
@@ -439,8 +439,8 @@ describe('resolveIndexShorthand', () => {
   });
 
   function expectResolve(context: string, target: string) {
-    const resolved =
-        googmodule.resolveModuleName({options: opts, host: resolutionHost}, context, target);
+    const resolved = googmodule.resolveModuleName(
+        {options: opts, moduleResolutionHost: resolutionHost}, context, target);
     return expect(resolved);
   }
 

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -405,7 +405,7 @@ export function compileWithTransfromer(
     es5Mode: false,
     untyped: false,
     options: compilerOptions,
-    host: tsHost,
+    moduleResolutionHost: tsHost,
   };
 
   const files = new Map<string, string>();

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -49,7 +49,7 @@ describe('emitWithTsickle', () => {
       fileNameToModuleId: (fileName) => fileName.replace(/^\.\//, ''),
       ...tsickleHostOverride,
       options: tsCompilerOptions,
-      host: tsHost,
+      moduleResolutionHost: tsHost,
     };
     const jsSources: {[fileName: string]: string} = {};
     tsickle.emitWithTsickle(


### PR DESCRIPTION
I noticed some code was passing a CompilerHost when it didn't need to.  These separate CLs clean it up a bit.