### PR TITLE
don't dereference aliases in heritage clauses

### DIFF
--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,7 +1,8 @@
 // test_files/class/class.ts(44,1): warning TS0: omitting interface deriving from class: Class
+// test_files/class/class.ts(98,1): warning TS0: omitting heritage of type alias: TypeAlias
 // test_files/class/class.ts(124,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 // test_files/class/class.ts(126,1): warning TS0: omitting heritage reference to a type/value conflict: Zone
-// test_files/class/class.ts(130,1): warning TS0: omitting heritage reference to a type/value conflict: ZoneAlias
+// test_files/class/class.ts(130,1): warning TS0: omitting heritage of type alias: ZoneAlias
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -186,7 +187,7 @@ class AbstractClassExtendsClass extends Class {
 class AbstractClassExtendsAbstractClass extends AbstractClass {
 }
 /**
- * @implements {Interface}
+ * @implements {InexpressibleType}
  * @extends {Class}
  */
 class ImplementsTypeAlias {

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -5,6 +5,9 @@
  * would then crash Closure Compiler as it creates a union type, which is unexpected for super
  * interfaces.
  *
+ * Note also that the output .js should not directly reference the 'interface' module, because this
+ * module does not import from it.
+ *
  * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.user');
@@ -13,9 +16,8 @@ module = module;
 exports = {};
 const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.implement_reexported_interface.exporter");
 goog.require('test_files.implement_reexported_interface.exporter'); // force type-only module to be loaded
-const tsickle_forward_declare_2 = goog.forwardDeclare("test_files.implement_reexported_interface.interface");
 /**
- * @implements {tsickle_forward_declare_2.ExportedInterface}
+ * @implements {tsickle_forward_declare_1.ExportedInterface}
  */
 class Test {
     constructor() {

--- a/test_files/implement_reexported_interface/user.ts
+++ b/test_files/implement_reexported_interface/user.ts
@@ -3,6 +3,9 @@
  * tsickle would define re-exports as just "ExportedInterface", not "!ExportedInterface", which
  * would then crash Closure Compiler as it creates a union type, which is unexpected for super
  * interfaces.
+ *
+ * Note also that the output .js should not directly reference the 'interface' module, because this
+ * module does not import from it.
  */
 
 import {ExportedInterface} from './exporter';

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -1,4 +1,4 @@
-// test_files/partial/partial.ts(7,1): warning TS0: omitting heritage reference to a type literal: Partial<Base>
+// test_files/partial/partial.ts(7,1): warning TS0: omitting heritage of type alias: Partial<Base>
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc


### PR DESCRIPTION
If A implements B, we shouldn't refer to the type of the B symbol
directly, rather than attempting to resolve B to some other symbol,
because that other symbol may refer to a module that hasn't been
imported.