### PR TITLE
Allow patch level TypeScript peer-dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "source-map": "^0.7.3"
   },
   "peerDependencies": {
-    "typescript": "3.1.3"
+    "typescript": "~3.1.3"
   },
   "devDependencies": {
     "@types/diff-match-patch": "^1.0.32",


### PR DESCRIPTION
Previously, tsickle required a precise peer-dependency version of
`3.1.3`. With this patch, tsickle allows any patch level upgrade to
TypeScript, e.g. 3.1.6.