### PR TITLE
adjust tslib path handling in tests

### DIFF
--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {assertAbsolute, pathToModuleName} from '../src/cli_support';
+import {assertAbsolute} from '../src/cli_support';
 import {getGeneratedExterns} from '../src/externs';
 import {normalizeLineEndings} from '../src/jsdoc';
 import * as tsickle from '../src/tsickle';
@@ -153,7 +153,7 @@ testFn('golden tests with transformer', () => {
         shouldSkipTsickleProcessing: (fileName) => !tsSources.has(fileName),
         shouldIgnoreWarningsForPath: () => false,
         pathToModuleName: (context, importPath) => {
-          return pathToModuleName(tsCompilerOptions.rootDir!, context, importPath);
+          return testSupport.pathToModuleName(tsCompilerOptions.rootDir!, context, importPath);
         },
         fileNameToModuleId: (fileName) => {
           assertAbsolute(fileName);


### PR DESCRIPTION
These changes make us able to run the tsickle test suite in the
Google-internal environment, which handles tslib in a funky way.

1) To find the underlying source tree for adjusting goldens, use
   a path to something other than tslib, since it's found at a
   different path.
2) When generating module names for paths, special-case tslib, so
   that the golden files always reference it with the same name.