### PR TITLE
back off on mapping back to source dir if paths aren't as expected

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -215,20 +215,6 @@ export class GoldenFileTest {
   }
 }
 
-/**
- * Compute the absolute path to the source tree, outside of any bazel sandbox redirection.
- *
- * To update test golden files (including deleting them when necessary), we need the real path to
- * the source tree.
- */
-export function getSourceRoot(): string {
-  // The trick used here is to dereference a symlink for a file that is known to be present in
-  // runfiles, then map the resulting path back the containing directory.
-  const pathInSourceTree = 'src/closure_externs.js';
-  const dereferencedPath = fs.readlinkSync(path.join(rootDir(), pathInSourceTree));
-  return dereferencedPath.substr(0, dereferencedPath.length - pathInSourceTree.length - 1);
-}
-
 export function goldenTests(): GoldenFileTest[] {
   const basePath = path.join(rootDir(), 'test_files');
   const testNames = fs.readdirSync(basePath);


### PR DESCRIPTION
This handles the case where we're remotely executing on a
content-addressed file system, where the paths end up just being
long strings of hex.  There's no source directory to map back to
anyway in that case.