### PR TITLE
drop defn and emit of InexpressibleType

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -77,13 +77,3 @@ var PromiseConstructorLike;
 
 /** @typedef {?} */
 var SymbolConstructor;
-
-/**
- * This type is used as a marker in locations where TypeScript knows the type
- * but we cannot express that type in the Closure system.
- *
- * It's used in 'implements' clauses so that a person debugging the emitted JS
- * can see that tsickle saw the type but ignored it.
- * @record
- */
-class InexpressibleType {}

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -83,15 +83,7 @@ export function maybeAddHeritageClauses(
       const heritage = heritageName(isExtends, hasExtends, expr);
       // heritageName may return null, indicating that the clause is something inexpressible
       // in Closure, e.g. "class Foo implements Partial<Bar>".
-      if (!heritage) {
-        // For 'extends' clauses that means we cannot emit anything at all.
-        if (!isExtends) {
-          docTags.push({
-            tagName: isExtends ? 'extends' : 'implements',
-            type: 'InexpressibleType',
-          });
-        }
-      } else {
+      if (heritage) {
         docTags.push({
           tagName: heritage.tagName,
           type: heritage.parentName,

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -221,18 +221,12 @@ abstractClassVar = new ClassExtendsAbstractClass();
  * @return {void}
  */
 function Zone() { }
-/**
- * @implements {InexpressibleType}
- */
 class ZoneImplementsInterface {
 }
 if (false) {
     /** @type {string} */
     ZoneImplementsInterface.prototype.zone;
 }
-/**
- * @implements {InexpressibleType}
- */
 class ZoneImplementsAlias {
 }
 if (false) {

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -25,9 +25,6 @@ class ClassInExtends {
         return 'a';
     }
 }
-/**
- * @implements {InexpressibleType}
- */
 class ExtendsAndImplementsClass extends ClassInExtends {
 }
 if (false) {

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -53,7 +53,6 @@ let useNeverTyped2;
 let useNeverTypedTemplated;
 /**
  * Note: JSDoc should not reference NeverTyped because the type is blacklisted.
- * @implements {InexpressibleType}
  */
 class ImplementsNeverTyped {
 }
@@ -63,7 +62,6 @@ if (false) {
 }
 /**
  * @template T
- * @implements {InexpressibleType}
  */
 class ImplementsNeverTypedTemplated {
 }

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -15,9 +15,6 @@ if (false) {
     /** @type {string} */
     Base.prototype.foo;
 }
-/**
- * @implements {InexpressibleType}
- */
 class Derived {
     /**
      * @return {void}


### PR DESCRIPTION
When tsickle cannot express the implements/extends of a type, it
would emit some
  @implements {InexpressibleType}
as a hint to humans.

I now see this was a bad idea, because it is visible to Closure
compiler and fails in situations where e.g. a class has multiple
of these.  Additionally, we shouldn't be dumping new Closure types
like InexpressibleType into the global namespace in the first place.

I have another change that changes our emit for inexpressible types,
but this smaller change first just deletes this unneeded comment,
because even this comment itself causes some build failures.