### PR TITLE
Emit enum types with a `!`.

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -499,7 +499,13 @@ export class TypeTranslator {
       this.warn(`EnumLiteralType without a symbol`);
       return '?';
     }
-    return this.symbolToString(enumLiteralBaseType.symbol) || '?';
+    const name = this.symbolToString(enumLiteralBaseType.symbol);
+    if (!name) return '?';
+    // In Closure, enum types are non-null by default, so we wouldn't need to emit the `!` here.
+    // However that's confusing to users, to the point that style guides and linters require to
+    // *always* specify the nullability modifier. To be consistent with that style, include it here
+    // as well.
+    return '!' + name;
   }
 
   // translateObject translates a ts.ObjectType, which is the type of all

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -18,26 +18,28 @@ EnumTest1[EnumTest1.XYZ] = 'XYZ';
 EnumTest1[EnumTest1.PI] = 'PI';
 // Verify that the resulting TypeScript still allows you to index into the enum with all the various
 // ways allowed of enums.
-/** @type {EnumTest1} */
+/** @type {!EnumTest1} */
 let enumTestValue = EnumTest1.XYZ;
-/** @type {EnumTest1} */
+/** @type {!EnumTest1} */
 let enumTestValue2 = EnumTest1['XYZ'];
 /** @type {string} */
 let enumNumIndex = EnumTest1[(/** @type {number} */ ((/** @type {?} */ (null))))];
 /** @type {number} */
 let enumStrIndex = EnumTest1[(/** @type {string} */ ((/** @type {?} */ (null))))];
+/** @type {(null|!EnumTest1)} */
+let nullableEnum = null;
 /**
- * @param {EnumTest1} val
+ * @param {!EnumTest1} val
  * @return {void}
  */
 function enumTestFunction(val) { }
 enumTestFunction(enumTestValue);
-/** @type {EnumTest1} */
+/** @type {!EnumTest1} */
 let enumTestLookup = EnumTest1["XYZ"];
 /** @type {?} */
 let enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
 // Verify that unions of enum members and other values are handled correctly.
-/** @type {(boolean|EnumTest1)} */
+/** @type {(boolean|!EnumTest1)} */
 let enumUnionType = EnumTest1.XYZ;
 /** @enum {number} */
 const EnumTest2 = {
@@ -46,7 +48,7 @@ const EnumTest2 = {
 exports.EnumTest2 = EnumTest2;
 EnumTest2[EnumTest2.XYZ] = 'XYZ';
 EnumTest2[EnumTest2.PI] = 'PI';
-/** @type {EnumTest2} */
+/** @type {!EnumTest2} */
 let variableUsingExportedEnum;
 /** @enum {number} */
 const ComponentIndex = {
@@ -65,7 +67,7 @@ const ConstEnum = {
     EMITTED_ENUM_VALUE_2: 1,
 };
 exports.ConstEnum = ConstEnum;
-/** @type {ConstEnum} */
+/** @type {!ConstEnum} */
 let constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
 /**
  * @record
@@ -73,9 +75,9 @@ let constEnumValue = 0 /* EMITTED_ENUM_VALUE */;
 function InterfaceUsingConstEnum() { }
 exports.InterfaceUsingConstEnum = InterfaceUsingConstEnum;
 if (false) {
-    /** @type {ConstEnum} */
+    /** @type {!ConstEnum} */
     InterfaceUsingConstEnum.prototype.field;
-    /** @type {ConstEnum} */
+    /** @type {!ConstEnum} */
     InterfaceUsingConstEnum.prototype.field2;
 }
 /** @enum {number} */

--- a/test_files/enum/enum.ts
+++ b/test_files/enum/enum.ts
@@ -8,6 +8,7 @@ let enumTestValue: EnumTest1 = EnumTest1.XYZ;
 let enumTestValue2: EnumTest1 = EnumTest1['XYZ'];
 let enumNumIndex: string = EnumTest1[null as any as number];
 let enumStrIndex: number = EnumTest1[null as any as string];
+let nullableEnum: EnumTest1|null = null;
 
 function enumTestFunction(val: EnumTest1) {}
 enumTestFunction(enumTestValue);

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -13,8 +13,8 @@ const tsickle_forward_declare_1 = goog.forwardDeclare("test_files.enum.enum");
 function EnumUsingIf() { }
 exports.EnumUsingIf = EnumUsingIf;
 if (false) {
-    /** @type {tsickle_forward_declare_1.ConstEnum} */
+    /** @type {!tsickle_forward_declare_1.ConstEnum} */
     EnumUsingIf.prototype.field;
 }
-/** @type {tsickle_forward_declare_1.ConstEnum} */
+/** @type {!tsickle_forward_declare_1.ConstEnum} */
 const fieldUsingConstEnum = 0 /* EMITTED_ENUM_VALUE */;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -18,5 +18,5 @@ const ExportedEnum = {
 exports.ExportedEnum = ExportedEnum;
 ExportedEnum[ExportedEnum.VALUE] = 'VALUE';
 ExportedEnum[ExportedEnum.OTHERVALUE] = 'OTHERVALUE';
-/** @type {ExportedEnum} */
+/** @type {!ExportedEnum} */
 exports.x = ExportedEnum.VALUE;


### PR DESCRIPTION
In Closure, enum types are non-null by default - so emitting `/** @type
{MyEnum} */` without a `!` creates a non-nullable type. That's
surprising and outlawed in style guides. For consistency, adjust
tsickle's emit to that style.

Fixes #951.