### PR TITLE
Handle single-value enums.

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -499,7 +499,18 @@ export class TypeTranslator {
       this.warn(`EnumLiteralType without a symbol`);
       return '?';
     }
-    const name = this.symbolToString(enumLiteralBaseType.symbol);
+    let symbol = enumLiteralBaseType.symbol;
+    if (enumLiteralBaseType === type) {
+      // TypeScript's API will return the same EnumLiteral type if the enum only has a single member
+      // value. See https://github.com/Microsoft/TypeScript/issues/28869.
+      // In that case, take the parent symbol of the enum member, which should be the enum
+      // declaration.
+      // tslint:disable-next-line:no-any working around a TS API deficiency.
+      const parent: ts.Symbol|undefined = (symbol as any).parent;
+      if (!parent) return '?';
+      symbol = parent;
+    }
+    const name = this.symbolToString(symbol);
     if (!name) return '?';
     // In Closure, enum types are non-null by default, so we wouldn't need to emit the `!` here.
     // However that's confusing to users, to the point that style guides and linters require to

--- a/test_files/single_value_enum/single_value_enum.js
+++ b/test_files/single_value_enum/single_value_enum.js
@@ -1,0 +1,33 @@
+/**
+ *
+ * @fileoverview Regression test for single valued enums. TypeScript's getBaseTypeOfLiteralType
+ * returns the EnumLiteral type for SingleValuedEnum.C below, instead of SingleValuedEnum directly.
+ * Previously, tsickle would then emit the type as `SingleValuedEnum.C`, which is illegal in
+ * Closure.
+ *
+ * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.single_value_enum.single_value_enum');
+var module = module || { id: 'test_files/single_value_enum/single_value_enum.ts' };
+module = module;
+exports = {};
+/** @enum {number} */
+const FirstEnum = {
+    A: 0,
+    B: 1,
+};
+exports.FirstEnum = FirstEnum;
+FirstEnum[FirstEnum.A] = 'A';
+FirstEnum[FirstEnum.B] = 'B';
+/** @enum {number} */
+const SingleValuedEnum = {
+    C: 0,
+};
+exports.SingleValuedEnum = SingleValuedEnum;
+SingleValuedEnum[SingleValuedEnum.C] = 'C';
+/** @typedef {!SingleValuedEnum} */
+exports.AliasSingleValueEnum;
+/** @type {(null|!SingleValuedEnum)} */
+exports.useSingleValueEnum = null;
+/** @typedef {(!SingleValuedEnum|!FirstEnum)} */
+exports.UnionOfEnums;

--- a/test_files/single_value_enum/single_value_enum.ts
+++ b/test_files/single_value_enum/single_value_enum.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Regression test for single valued enums. TypeScript's getBaseTypeOfLiteralType
+ * returns the EnumLiteral type for SingleValuedEnum.C below, instead of SingleValuedEnum directly.
+ * Previously, tsickle would then emit the type as `SingleValuedEnum.C`, which is illegal in
+ * Closure.
+ */
+
+export enum FirstEnum {
+  A,
+  B,
+}
+
+export enum SingleValuedEnum {
+  C
+}
+
+export type AliasSingleValueEnum = SingleValuedEnum;
+export let useSingleValueEnum: SingleValuedEnum|null = null;
+export type UnionOfEnums = FirstEnum|SingleValuedEnum;


### PR DESCRIPTION
For enums that only have a single value, TypeScript's
getBaseTypeOfLiteralType returns the EnumLiteral type for that value
instead of the type for the enum. Previously, this caused tsickle to
emit a type name representing the single enum value, not the enum type,
which is illegal in Closure.

This change works around the problem by first trying the proper API, and
then falling back to using the `symbol.parent` if we still get an
`EnumLiteral` type returned.

See also https://github.com/Microsoft/TypeScript/issues/28869.