### PR TITLE
Handle rest parameters with template constraints.

### DIFF
--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -87,6 +87,34 @@ TestSplat3(1, 2);
  */
 function defaultBeforeRequired(x = 1, y, ...z) { }
 defaultBeforeRequired(undefined, 2, 'h', 3);
+// The array reference below happens on the template parameter constraint, not on the parameter
+// itself. Make sure tsickle unwraps the right type.
+/**
+ * @template T
+ * @param {...string} str
+ * @return {number}
+ */
+function templatedBoundRestArg(...str) {
+    return str.length;
+}
+// But only do so if the parameter is not an array reference type by itself.
+/**
+ * @template T
+ * @param {...T} str
+ * @return {number}
+ */
+function templatedBoundRestArg2(...str) {
+    return str.length;
+}
+// Also handle the case where it's both.
+/**
+ * @template T
+ * @param {...T} str
+ * @return {number}
+ */
+function templatedBoundRestArg3(...str) {
+    return str.length;
+}
 /**
  * @template T
  * @param {T} t

--- a/test_files/functions/functions.ts
+++ b/test_files/functions/functions.ts
@@ -34,6 +34,20 @@ TestSplat3(1, 2);
 function defaultBeforeRequired(x = 1, y: number, ...z: any[]) {}
 defaultBeforeRequired(undefined, 2, 'h', 3);
 
+// The array reference below happens on the template parameter constraint, not on the parameter
+// itself. Make sure tsickle unwraps the right type.
+function templatedBoundRestArg<T extends string[]>(...str: T) {
+  return str.length;
+}
+// But only do so if the parameter is not an array reference type by itself.
+function templatedBoundRestArg2<T extends string>(...str: T[]) {
+  return str.length;
+}
+// Also handle the case where it's both.
+function templatedBoundRestArg3<T extends number[]>(...str: T[]) {
+  return str.length;
+}
+
 function templated<T>(t: T): number {
   return 1;
 }


### PR DESCRIPTION
Rest parameters must be array types in TypeScript. tsickle unwraps them
to emit the underlying type for Closure. However the Array type in
TypeScript may be expressed in a template parameter constraints, instead
of the parameter itself:

    function f<T extends SomeType[]>(... ts: T) {}

Handle this specific case by resolving the template parameter
constraint, then emitting the underlying type nested in it.

Fixes #944.