### PR TITLE
Remove _Instance redirections for clutz symbols.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -255,12 +255,6 @@ function addClutzAliases(
         `\t\texport {${symbol.name} as module$contents$${clutzModuleName}_${symbol.name}}\n`;
     nestedSymbols +=
         `\t\texport {module$contents$${clutzModuleName}_${symbol.name} as ${symbol.name}}\n`;
-    if (symbol.flags & ts.SymbolFlags.Class) {
-      globalSymbols += `\t\texport {${symbol.name} as module$contents$${clutzModuleName}_${
-          symbol.name}_Instance}\n`;
-      nestedSymbols += `\t\texport {module$contents$${clutzModuleName}_${symbol.name} as ${
-          symbol.name}_Instance}\n`;
-    }
   }
 
   dtsFileContent += 'declare global {\n';

--- a/test_files/class.declaration/class.d.ts
+++ b/test_files/class.declaration/class.d.ts
@@ -3,10 +3,8 @@ export declare class Foo {
 declare global {
 	namespace ಠ_ಠ.clutz {
 		export {Foo as module$contents$test_files$class$declaration$class_Foo}
-		export {Foo as module$contents$test_files$class$declaration$class_Foo_Instance}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$class$declaration$class {
 		export {module$contents$test_files$class$declaration$class_Foo as Foo}
-		export {module$contents$test_files$class$declaration$class_Foo as Foo_Instance}
 	}
 }

--- a/test_files/generics.declaration/generics.d.ts
+++ b/test_files/generics.declaration/generics.d.ts
@@ -20,25 +20,19 @@ export declare class DefaultGeneric<T extends {} = {}> {
 declare global {
 	namespace ಠ_ಠ.clutz {
 		export {DefaultGeneric as module$contents$test_files$generics$declaration$generics_DefaultGeneric}
-		export {DefaultGeneric as module$contents$test_files$generics$declaration$generics_DefaultGeneric_Instance}
 		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber}
-		export {GenericNumber as module$contents$test_files$generics$declaration$generics_GenericNumber_Instance}
 		export {HasThing as module$contents$test_files$generics$declaration$generics_HasThing}
 		export {Lengthwise as module$contents$test_files$generics$declaration$generics_Lengthwise}
 		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer}
-		export {LengthwiseContainer as module$contents$test_files$generics$declaration$generics_LengthwiseContainer_Instance}
 		export {identity as module$contents$test_files$generics$declaration$generics_identity}
 		export {loggingIdentity as module$contents$test_files$generics$declaration$generics_loggingIdentity}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$generics$declaration$generics {
 		export {module$contents$test_files$generics$declaration$generics_DefaultGeneric as DefaultGeneric}
-		export {module$contents$test_files$generics$declaration$generics_DefaultGeneric as DefaultGeneric_Instance}
 		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber}
-		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber_Instance}
 		export {module$contents$test_files$generics$declaration$generics_HasThing as HasThing}
 		export {module$contents$test_files$generics$declaration$generics_Lengthwise as Lengthwise}
 		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer}
-		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer_Instance}
 		export {module$contents$test_files$generics$declaration$generics_identity as identity}
 		export {module$contents$test_files$generics$declaration$generics_loggingIdentity as loggingIdentity}
 	}


### PR DESCRIPTION
Since
https://github.com/angular/clutz/commit/b86a51c6ec5d910c7d7b177fcefe8c3c1ae28eb8
clutz no longer splits classes into _Instance and static side.