### PR TITLE
suppress checkTypes in our closure externs patch

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -9,7 +9,10 @@
 /**
  * @fileoverview Extern definitions for types missing in the Closure externs,
  * but used in TypeScript platform `.d.ts`.
+ * We suppress checkTypes to handle the scenario where a user doesn't use the
+ * Closure externs (e.g. in a service worker).
  * @externs
+ * @suppress {checkTypes}
  */
 
 /** @typedef {!IArrayLike} */


### PR DESCRIPTION
Recall closure_externs.js is for the case where TS will refer to types
from its library dts like HTMLTableHeaderCellElement, which don't exist
in the Closure externs.

Some users of tsickle don't use the standard Closure externs at all,
which means the aliases defined here resolve to undefined types.  In
those cases in principle the users could configure TS to also not include
the lib dts files.

We don't handle this well in tsickle.  Suppressing checkTypes here at
least makes the resulting types {?} rather than a compilation error.