### PR TITLE
 Emit generic types in method bodies. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -254,29 +254,44 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20180716.0.1",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20180716.0.1.tgz",
-      "integrity": "sha1-SN6ysd/kwRity3DdEEz0+iuVCNc=",
+      "version": "20181125.0.1",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20181125.0.1.tgz",
+      "integrity": "sha512-OMA8eu33V9ObuaBVrt4kKPNZnylKwDXVeb/QixCCCpOerWFM4UlZG/FSJcA4WF8x6WR4pa7N3ivCZbx2+ey8oA==",
       "dev": true,
       "requires": {
         "chalk": "^1.0.0",
-        "google-closure-compiler-linux": "^20180716.0.0",
-        "google-closure-compiler-osx": "^20180716.0.0",
+        "google-closure-compiler-java": "^20181125.0.1",
+        "google-closure-compiler-js": "^20181125.0.1",
+        "google-closure-compiler-linux": "^20181125.0.1",
+        "google-closure-compiler-osx": "^20181125.0.1",
+        "minimist": "^1.2.0",
         "vinyl": "^2.0.1",
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
+    "google-closure-compiler-java": {
+      "version": "20181125.0.1",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20181125.0.1.tgz",
+      "integrity": "sha512-UURFLSpdizI40C7cJ8wAzedZww8hjoWnwW4YKLVsTkenvdI1qe1WsWohGUNxPUJoHODVExJHfTtBlfcigesGKg==",
+      "dev": true
+    },
+    "google-closure-compiler-js": {
+      "version": "20181125.0.1",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20181125.0.1.tgz",
+      "integrity": "sha512-3+K8b18kWP6CR+qyYwa6DxN9QuijYZvBYpK8L1Va8urXvbDY07x1hA6tKeiEfHmd19pAp7MUW2Ivv2aquDAozw==",
+      "dev": true
+    },
     "google-closure-compiler-linux": {
-      "version": "20180716.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20180716.0.0.tgz",
-      "integrity": "sha512-Lb/z7QCd4IKLBp39BCs+yhwsM7/5P9uLwZhR4D1RulwzOrj8GIz7hg26hqRSz88m/+dJMwKRRgV2XGw53e3D4A==",
+      "version": "20181125.0.1",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20181125.0.1.tgz",
+      "integrity": "sha512-yPejZG9x5fIsygo6qG8NbusY4uQ9865I4664KbQ9jJbJitySORzu1/V4QoUM23efrNI4loDGt6gqDGQ1kR7dTw==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-osx": {
-      "version": "20180716.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20180716.0.0.tgz",
-      "integrity": "sha1-VpHAdYBXjf6jIF6QpqKWjSO4W9k=",
+      "version": "20181125.0.1",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20181125.0.1.tgz",
+      "integrity": "sha512-jORcziwwlcl/VVeEJLPoPyOB0GyMSeFhzq+B9jaG3ge1q1K2Pcj0fu5rD1QMKuKx70Y3cHWbOXAQVan/jnmLKQ==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clang-format": "^1.2.4",
     "diff-match-patch": "^1.0.1",
     "glob": "7.1.2",
-    "google-closure-compiler": "20180716.0.1",
+    "google-closure-compiler": "^20181125.0.1",
     "jasmine": "3.1.0",
     "prettier": "1.14.0",
     "source-map-support": "^0.5.6",

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -552,7 +552,6 @@ export function jsdocTransformer(
         const mjsdoc = moduleTypeTranslator.getMutableJSDoc(fnDecl);
         mjsdoc.tags = tags;
         mjsdoc.updateComment();
-        moduleTypeTranslator.blacklistTypeParameters(fnDecl, fnDecl.typeParameters);
 
         const contextThisTypeBackup = contextThisType;
         contextThisType = thisReturnType;

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -363,11 +363,6 @@ export class ModuleTypeTranslator {
     return [[], null];
   }
 
-  blacklistTypeParameters(
-      context: ts.Node, decls: ReadonlyArray<ts.TypeParameterDeclaration>|undefined) {
-    this.newTypeTranslator(context).blacklistTypeParameters(this.symbolsToAliasedNames, decls);
-  }
-
   /**
    * Creates the jsdoc for methods, including overloads.
    * If overloaded, merges the signatures in the list of SignatureDeclarations into a single jsdoc.

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -852,7 +852,7 @@ export class TypeTranslator {
         this.warn(`type parameter with no symbol`);
         continue;
       }
-      this.symbolsToAliasedNames.set(sym, '?');
+      blacklist.set(sym, '?');
     }
   }
 }

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -24,9 +24,10 @@ class Container {
     method(u) {
         /** @type {T} */
         const myT = this.tField;
-        // Closure Compiler's Old Type Inference does not support using generic
-        // method parameters as local symbols, so myU must be emitted as ?.
-        /** @type {?} */
+        // Closure Compiler previously did not accept local variables using generic
+        // types within a generic method's scope. This test now serves as a
+        // regression test for the inverse, i.e. that tsickle now emits the type.
+        /** @type {U} */
         const myU = u;
         console.log(myT, myU);
     }

--- a/test_files/generic_local_var/generic_local_var.ts
+++ b/test_files/generic_local_var/generic_local_var.ts
@@ -3,8 +3,9 @@ class Container<T> {
   constructor(private tField: T) {}
   method<U>(u: U) {
     const myT: T = this.tField;
-    // Closure Compiler's Old Type Inference does not support using generic
-    // method parameters as local symbols, so myU must be emitted as ?.
+    // Closure Compiler previously did not accept local variables using generic
+    // types within a generic method's scope. This test now serves as a
+    // regression test for the inverse, i.e. that tsickle now emits the type.
     const myU: U = u;
     console.log(myT, myU);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,24 +194,35 @@ glob@7.1.2, glob@^7.0.0, glob@^7.0.6, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-google-closure-compiler-linux@^20180716.0.0:
-  version "20180716.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20180716.0.0.tgz#b0dc9aa4751085b46002d6a300146df73fa87d35"
+google-closure-compiler-java@^20181125.0.1:
+  version "20181125.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20181125.0.1.tgz#4def6bc712f01acb0df22a0ec1c39271ba8b6f07"
 
-google-closure-compiler-osx@^20180716.0.0:
-  version "20180716.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20180716.0.0.tgz#5691c07580578dfea3205e90a6a2968d23b85bd9"
+google-closure-compiler-js@^20181125.0.1:
+  version "20181125.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20181125.0.1.tgz#ed06f6bab66acfe0d187e0262114c92c5569e2f0"
 
-google-closure-compiler@20180716.0.1:
-  version "20180716.0.1"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20180716.0.1.tgz#48deb2b1dfe4c118adcb70dd104cf4fa2b9508d7"
+google-closure-compiler-linux@^20181125.0.1:
+  version "20181125.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20181125.0.1.tgz#231ad4d1988068488a4d2f60e7b1647323199822"
+
+google-closure-compiler-osx@^20181125.0.1:
+  version "20181125.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20181125.0.1.tgz#d188dd31a866ba2c4ae041050c3da86d882c3894"
+
+google-closure-compiler@^20181125.0.1:
+  version "20181125.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20181125.0.1.tgz#ef2d7be2b6bc1025e770964264e904130f881d49"
   dependencies:
     chalk "^1.0.0"
+    google-closure-compiler-java "^20181125.0.1"
+    google-closure-compiler-js "^20181125.0.1"
+    minimist "^1.2.0"
     vinyl "^2.0.1"
     vinyl-sourcemaps-apply "^0.2.0"
   optionalDependencies:
-    google-closure-compiler-linux "^20180716.0.0"
-    google-closure-compiler-osx "^20180716.0.0"
+    google-closure-compiler-linux "^20181125.0.1"
+    google-closure-compiler-osx "^20181125.0.1"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -408,9 +419,9 @@ tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
-typescript@~3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+typescript@3.2.0-rc:
+  version "3.2.0-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.0-rc.tgz#7c3816f1c761b096f4f1712382e872f4da8f263e"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Previously, Closure Compiler did not support referencing generic types
within method bodies. This has been fixed in Closure Compiler (though
it's unclear how much they are type checked), so this change reverts
the workaround.

There are several other locations using the `blacklistTypeParameters`
(signatures, anonymous types, type aliases), so the code is retained for
those use cases.