### PR TITLE
fix: adjust enum transpile to generate var if not const enum

### DIFF
--- a/src/enum_transformer.ts
+++ b/src/enum_transformer.ts
@@ -108,6 +108,7 @@ export function enumTransformer(typeChecker: ts.TypeChecker, diagnostics: ts.Dia
 
       const name = node.name.getText();
       const isExported = hasModifierFlag(node, ts.ModifierFlags.Export);
+      const isConstEnum = hasModifierFlag(node, ts.ModifierFlags.Const);
       const enumType = getEnumType(typeChecker, node);
 
       const values: ts.PropertyAssignment[] = [];
@@ -154,7 +155,8 @@ export function enumTransformer(typeChecker: ts.TypeChecker, diagnostics: ts.Dia
                   name, undefined,
                   ts.createObjectLiteral(
                       ts.setTextRange(ts.createNodeArray(values, true), node.members), true))],
-              /* create a const var */ ts.NodeFlags.Const));
+              /* create a const var if const enum else use basic var declaration */
+              isConstEnum ? ts.NodeFlags.Const : ts.NodeFlags.None));
       const comment: ts.SynthesizedComment = {
         kind: ts.SyntaxKind.MultiLineCommentTrivia,
         text: `* @enum {${enumType}} `,

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -7,13 +7,13 @@ var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };
 module = module;
 exports = {};
 /** @enum {number} */
-const EnumUntypedTest1 = {
+var EnumUntypedTest1 = {
     XYZ: 0, PI: 3.14159,
 };
 EnumUntypedTest1[EnumUntypedTest1.XYZ] = 'XYZ';
 EnumUntypedTest1[EnumUntypedTest1.PI] = 'PI';
 /** @enum {number} */
-const EnumUntypedTest2 = {
+var EnumUntypedTest2 = {
     XYZ: 0, PI: 3.14159,
 };
 exports.EnumUntypedTest2 = EnumUntypedTest2;

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -11,7 +11,7 @@ exports = {};
 /** @type {!Array<?>} */
 const EnumTestMissingSemi = [];
 /** @enum {number} */
-const EnumTest1 = {
+var EnumTest1 = {
     XYZ: 0, PI: 3.14159,
 };
 EnumTest1[EnumTest1.XYZ] = 'XYZ';
@@ -42,7 +42,7 @@ let enumTestLookup2 = EnumTest1["xyz".toUpperCase()];
 /** @type {(boolean|!EnumTest1)} */
 let enumUnionType = EnumTest1.XYZ;
 /** @enum {number} */
-const EnumTest2 = {
+var EnumTest2 = {
     XYZ: 0, PI: 3.14159,
 };
 exports.EnumTest2 = EnumTest2;
@@ -51,7 +51,7 @@ EnumTest2[EnumTest2.PI] = 'PI';
 /** @type {!EnumTest2} */
 let variableUsingExportedEnum;
 /** @enum {number} */
-const ComponentIndex = {
+var ComponentIndex = {
     Scheme: 1,
     UserInfo: 2,
     Domain: 0,
@@ -81,26 +81,26 @@ if (false) {
     InterfaceUsingConstEnum.prototype.field2;
 }
 /** @enum {number} */
-const EnumWithNonConstValues = {
+var EnumWithNonConstValues = {
     Scheme: (x => x + 1)(3),
     UserInfoRenamed: 2,
 };
 EnumWithNonConstValues[EnumWithNonConstValues.Scheme] = 'Scheme';
 EnumWithNonConstValues[EnumWithNonConstValues.UserInfoRenamed] = 'UserInfoRenamed';
 /** @enum {string} */
-const StringEnum = {
+var StringEnum = {
     STR: 'abc',
     OTHER_STR: 'xyz',
 };
 /** @enum {number} */
-const StringKeyEnum = {
+var StringKeyEnum = {
     'string key': 1,
     'string key 2': 0,
 };
 StringKeyEnum[StringKeyEnum['string key']] = 'string key';
 StringKeyEnum[StringKeyEnum['string key 2']] = 'string key 2';
 /** @enum {?} */
-const MixedEnum = {
+var MixedEnum = {
     STR: 'abc',
     NUM: 3,
     'string key': 4,
@@ -108,7 +108,7 @@ const MixedEnum = {
 MixedEnum[MixedEnum.NUM] = 'NUM';
 MixedEnum[MixedEnum['string key']] = 'string key';
 /** @enum {number} */
-const EnumWithJSDoc = {
+var EnumWithJSDoc = {
     /** @export */ MEMBER_WITH_JSDOC: 0,
 };
 exports.EnumWithJSDoc = EnumWithJSDoc;

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -11,7 +11,7 @@ var module = module || { id: 'test_files/enum_value_literal_type/enum_value_lite
 module = module;
 exports = {};
 /** @enum {number} */
-const ExportedEnum = {
+var ExportedEnum = {
     VALUE: 0,
     OTHERVALUE: 1,
 };

--- a/test_files/single_value_enum/single_value_enum.js
+++ b/test_files/single_value_enum/single_value_enum.js
@@ -12,7 +12,7 @@ var module = module || { id: 'test_files/single_value_enum/single_value_enum.ts'
 module = module;
 exports = {};
 /** @enum {number} */
-const FirstEnum = {
+var FirstEnum = {
     A: 0,
     B: 1,
 };
@@ -20,7 +20,7 @@ exports.FirstEnum = FirstEnum;
 FirstEnum[FirstEnum.A] = 'A';
 FirstEnum[FirstEnum.B] = 'B';
 /** @enum {number} */
-const SingleValuedEnum = {
+var SingleValuedEnum = {
     C: 0,
 };
 exports.SingleValuedEnum = SingleValuedEnum;


### PR DESCRIPTION
matches tsc output to correctly support declaration merging.

This would close this [issue](https://github.com/angular/tsickle/issues/961) I opened in reference to supporting declaration merging. It adjusts any enum that is not a `const enum` to use the `var` declaration after transpile instead of the `const` declaration so that declaration merging works correctly. Since declaration merging is not possible with a `const enum`, those are left with the `const` declaration. Updated the appropriate test files to reflect this change.