### PR TITLE
Emit types for arrow/function expressions.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -554,7 +554,9 @@ export function jsdocTransformer(
         mjsdoc.updateComment();
 
         const contextThisTypeBackup = contextThisType;
-        contextThisType = thisReturnType;
+        // Arrow functions retain their context `this` type. All others reset the this type to
+        // either none (if not specified) or the type given in a fn(this: T, ...) declaration.
+        if (!ts.isArrowFunction(fnDecl)) contextThisType = thisReturnType;
         const result = ts.visitEachChild(fnDecl, visitor, context);
         contextThisType = contextThisTypeBackup;
         return result;

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -537,7 +537,7 @@ export function jsdocTransformer(
       }
 
       /** Function declarations are emitted as they are, with only JSDoc added. */
-      function visitFunctionLikeDeclaration(fnDecl: ts.FunctionLikeDeclaration) {
+      function visitFunctionLikeDeclaration<T extends ts.FunctionLikeDeclaration>(fnDecl: T): T {
         if (!fnDecl.body) {
           // Two cases: abstract methods and overloaded methods/functions.
           // Abstract methods are handled in emitTypeAnnotationsHandler.
@@ -918,6 +918,13 @@ export function jsdocTransformer(
             return visitInterfaceDeclaration(node as ts.InterfaceDeclaration);
           case ts.SyntaxKind.HeritageClause:
             return visitHeritageClause(node as ts.HeritageClause);
+          case ts.SyntaxKind.ArrowFunction:
+          case ts.SyntaxKind.FunctionExpression:
+            // Inserting a comment before an expression can trigger automatic semicolon insertion,
+            // e.g. if the function below is the expression in a `return` statement. Parenthesizing
+            // prevents ASI, as long as the opening paren remains on the same line (which it does).
+            return ts.createParen(
+                visitFunctionLikeDeclaration(node as ts.ArrowFunction | ts.FunctionExpression));
           case ts.SyntaxKind.Constructor:
           case ts.SyntaxKind.FunctionDeclaration:
           case ts.SyntaxKind.MethodDeclaration:

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -391,6 +391,8 @@ export class TypeTranslator {
     switch (type.flags & mask) {
       case ts.TypeFlags.Any:
         return '?';
+      case ts.TypeFlags.Unknown:
+        return '*';
       case ts.TypeFlags.String:
       case ts.TypeFlags.StringLiteral:
         return 'string';

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -5,11 +5,17 @@
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');
 var module = module || { id: 'test_files/arrow_fn.es5/arrow_fn_es5.ts' };
 /** @type {function(): void} */
-var foo = function () {
+var foo = (/**
+ * @return {void}
+ */
+function () {
     // this comment must not get inserted between the return and expression in ES5 (ASI).
     return console.log('foo');
-};
+});
 /** @type {function(): void} */
-var bar = function () {
+var bar = (/**
+ * @return {void}
+ */
+function () {
     console.log('bar');
-};
+});

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -7,4 +7,8 @@ var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' }
 module = module;
 exports = {};
 /** @type {?} */
-var fn3 = (a) => 12;
+var fn3 = (/**
+ * @param {?} a
+ * @return {?}
+ */
+(a) => 12);

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -7,13 +7,29 @@ var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };
 module = module;
 exports = {};
 /** @type {function(number): number} */
-var fn3 = (a) => 12;
+var fn3 = (/**
+ * @param {number} a
+ * @return {number}
+ */
+(a) => 12);
 /** @type {function(?): ?} */
-var fn4 = (a) => a + 12;
+var fn4 = (/**
+ * @param {?} a
+ * @return {?}
+ */
+(a) => a + 12);
 /** @type {function(number): number} */
-exports.fn5 = (a = 10) => a;
+exports.fn5 = (/**
+ * @param {number=} a
+ * @return {number}
+ */
+(a = 10) => a);
 /**
  * \@param a this must be escaped, as Closure bails on it.
  * @type {function(number): number}
  */
-const fn6 = (a = 10) => a;
+const fn6 = (/**
+ * @param {number=} a
+ * @return {number}
+ */
+(a = 10) => a);

--- a/test_files/automatic_semicolon_insertion/asi.js
+++ b/test_files/automatic_semicolon_insertion/asi.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.automatic_semicolon_insertion.asi');
+var module = module || { id: 'test_files/automatic_semicolon_insertion/asi.ts' };
+module = module;
+exports = {};
+/**
+ * @return {function(number): number}
+ */
+function mustParenthesizeCommentedReturnFn() {
+    return (/**
+     * @param {number} x
+     * @return {number}
+     */
+    (x) => x + 1);
+}
+exports.mustParenthesizeCommentedReturnFn = mustParenthesizeCommentedReturnFn;

--- a/test_files/automatic_semicolon_insertion/asi.ts
+++ b/test_files/automatic_semicolon_insertion/asi.ts
@@ -1,0 +1,3 @@
+export function mustParenthesizeCommentedReturnFn() {
+  return (x: number) => x + 1;
+}

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -35,11 +35,17 @@ if (false) {
 }
 // These two declarations should not have a @type annotation,
 // regardless of untyped.
-(function () {
+((/**
+ * @return {?}
+ */
+function () {
     // With a type annotation:
     let { a, b } = { a: '', b: 0 };
-})();
-(function () {
+}))();
+((/**
+ * @return {?}
+ */
+function () {
     // Without a type annotation:
     let { a, b } = { a: null, b: null };
-})();
+}))();

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -82,7 +82,11 @@ if (false) {
 }
 /** @enum {number} */
 const EnumWithNonConstValues = {
-    Scheme: (x => x + 1)(3),
+    Scheme: ((/**
+     * @param {number} x
+     * @return {number}
+     */
+    x => x + 1))(3),
     UserInfoRenamed: 2,
 };
 EnumWithNonConstValues[EnumWithNonConstValues.Scheme] = 'Scheme';

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -12,13 +12,23 @@ const tslib_1 = goog.require('tslib');
  * @return {function(?, (string|symbol)): void}
  */
 function exportingDecorator() {
-    return function (target, name) { };
+    return (/**
+     * @param {?} target
+     * @param {(string|symbol)} name
+     * @return {void}
+     */
+    function (target, name) { });
 }
 /**
  * @return {function(?, (string|symbol)): void}
  */
 function nonExportingDecorator() {
-    return function (target, name) { };
+    return (/**
+     * @param {?} target
+     * @param {(string|symbol)} name
+     * @return {void}
+     */
+    function (target, name) { });
 }
 class MyClass {
     /**

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -11,6 +11,10 @@ exports = {};
  * Closure, so tsickle should emit ?.
  * @type {function(?): ?}
  */
-let genericFnType = (x) => x;
+let genericFnType = (/**
+ * @param {T} x
+ * @return {T}
+ */
+(x) => x);
 /** @type {function(new: (?), ?): ?} */
 let genericCtorFnType;

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -14,5 +14,10 @@ exports = {};
  * @return {!Promise<void>}
  */
 function f(promiseCtor) {
-    return promiseCtor ? new promiseCtor((res, rej) => res()) : Promise.resolve();
+    return promiseCtor ? new promiseCtor((/**
+     * @param {function((undefined|void|!PromiseLike<void>)=): void} res
+     * @param {function(?=): void} rej
+     * @return {void}
+     */
+    (res, rej) => res())) : Promise.resolve();
 }

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -11,7 +11,12 @@ exports = {};
  * @return {!Promise<string>}
  */
 function toPromise(ctorLike) {
-    return (/** @type {!Promise<string>} */ (new ctorLike((resolve, reject) => {
+    return (/** @type {!Promise<string>} */ (new ctorLike((/**
+     * @param {function((undefined|string|!PromiseLike<string>)=): void} resolve
+     * @param {function(?=): void} reject
+     * @return {void}
+     */
+    (resolve, reject) => {
         reject('grumpycat');
-    })));
+    }))));
 }

--- a/test_files/return_this/return_this.js
+++ b/test_files/return_this/return_this.js
@@ -85,6 +85,23 @@ class MethodsReturnThis {
         }
         return (/** @type {!MethodsReturnThis} */ (this));
     }
+    // Ensures that arrow functions inherit the parent's `this` type.
+    /**
+     * @template THIS
+     * @this {THIS}
+     * @return {THIS}
+     */
+    nestedArrowThis() {
+        /** @type {function(): void} */
+        const sameThis = (/**
+         * @return {void}
+         */
+        () => {
+            (/** @type {!MethodsReturnThis} */ (this)).b = 1;
+        });
+        sameThis();
+        return (/** @type {!MethodsReturnThis} */ (this));
+    }
     /**
      * @template THIS,T
      * @this {THIS}

--- a/test_files/return_this/return_this.ts
+++ b/test_files/return_this/return_this.ts
@@ -38,6 +38,15 @@ class MethodsReturnThis {
     return this;
   }
 
+  // Ensures that arrow functions inherit the parent's `this` type.
+  nestedArrowThis(): this {
+    const sameThis = () => {
+      this.b = 1;
+    };
+    sameThis();
+    return this;
+  }
+
   overloadedThis(a: number): this;
   overloadedThis<U extends string>(u: U): this;
   overloadedThis<T extends string>(u: T): this;

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -25,4 +25,7 @@ if (false) {
  * @return {?}
  */
 function expectsAStructuralTest(st) { }
-expectsAStructuralTest({ field1: 'hi', method: () => 'hi' });
+expectsAStructuralTest({ field1: 'hi', method: (/**
+     * @return {?}
+     */
+    () => 'hi') });

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -16,7 +16,10 @@ if (false) {
     SomeClass.prototype.x;
 }
 /** @type {function(this: (!SomeClass), string): number} */
-const variableWithFunctionTypeUsingThis = () => 1;
+const variableWithFunctionTypeUsingThis = (/**
+ * @return {number}
+ */
+() => 1);
 // Has only a single this arg, no more parameters.
 /**
  * @return {(undefined|function(this: (string)): string)}

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,5 +1,7 @@
 // test_files/type/type.ts(3,1): warning TS0: type/symbol conflict for Array, using {?} for now
 // test_files/type/type.ts(15,5): warning TS0: unhandled anonymous type
+// test_files/type/type.ts(46,21): warning TS0: anonymous type has no symbol
+// test_files/type/type.ts(46,21): warning TS0: anonymous type has no symbol
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -53,11 +55,24 @@ let typeOptionalField = {};
 /** @type {{optional: (undefined|string|boolean)}} */
 let typeOptionalUnion = {};
 /** @type {function(): void} */
-let typeFunc = function () { };
+let typeFunc = (/**
+ * @return {void}
+ */
+function () { });
 /** @type {function(number, ?): string} */
-let typeFunc2 = function (a, b) { return ''; };
+let typeFunc2 = (/**
+ * @param {number} a
+ * @param {?} b
+ * @return {string}
+ */
+function (a, b) { return ''; });
 /** @type {function(number, function(number): string): string} */
-let typeFunc3 = function (x, cb) { return ''; };
+let typeFunc3 = (/**
+ * @param {number} x
+ * @param {function(number): string} cb
+ * @return {string}
+ */
+function (x, cb) { return ''; });
 /** @type {function(number, (undefined|*)=): string} */
 let typeFuncOptionalArg;
 /** @type {function(number, ...number): void} */
@@ -67,11 +82,19 @@ let typeFuncVarArgs;
  * @return {void}
  */
 function typeCallback(callback) { }
-typeCallback(val => val + 1);
+typeCallback((/**
+ * @param {number} val
+ * @return {number}
+ */
+val => val + 1));
 /**
  * @template T
  * @param {function(T): T} callback
  * @return {void}
  */
 function typeGenericCallback(callback) { }
-typeGenericCallback(val => val);
+typeGenericCallback((/**
+ * @param {?} val
+ * @return {?}
+ */
+val => val));

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,5 +1,5 @@
 // test_files/type/type.ts(3,1): warning TS0: type/symbol conflict for Array, using {?} for now
-// test_files/type/type.ts(14,5): warning TS0: unhandled anonymous type
+// test_files/type/type.ts(15,5): warning TS0: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -17,6 +17,8 @@ let typeArr;
 let typeArr2;
 /** @type {!Array<!Array<{a: ?}>>} */
 let typeNestedArr;
+/** @type {*} */
+let typeUnknown;
 /** @type {{a: number, b: string}} */
 let typeObject = { a: 3, b: 'b' };
 /** @type {!Object<string,number>} */

--- a/test_files/type/type.ts
+++ b/test_files/type/type.ts
@@ -8,6 +8,7 @@ let typeAny: any;
 let typeArr: Array<any>;
 let typeArr2: any[];
 let typeNestedArr: {a:any}[][];
+let typeUnknown: unknown;
 
 let typeObject: {a:number, b:string} = {a:3, b:'b'};
 let typeObjectIndexable: {[key:string]: number};


### PR DESCRIPTION
Previously, tsickle did not emit types for arrow functions and function
expressions, mostly because it was too hard to correctly pipe the
comments through the parse-emit-parse again pipeline, before tsickle was
a proper transformer.

This change adds appropriate comments, and makes sure to parenthesize
the function expressions, to avoid triggering automatic semicolon
insertion.