### PR TITLE
Use TypeScript's strict mode.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -138,10 +138,8 @@ export function emitWithTsickle(
   }
 
   const writeFileDelegate: ts.WriteFileCallback = writeFile || tsHost.writeFile.bind(tsHost);
-  const writeFileImpl =
-      (fileName: string, content: string, writeByteOrderMark: boolean,
-       onError: ((message: string) => void)|undefined,
-       sourceFiles: ReadonlyArray<ts.SourceFile>) => {
+  const writeFileImpl: ts.WriteFileCallback =
+      (fileName, content, writeByteOrderMark, onError, sourceFiles) => {
         assertAbsolute(fileName);
         if (host.addDtsClutzAliases && isDtsFileName(fileName) && sourceFiles) {
           // Only bundle emits pass more than one source file for .d.ts writes. Bundle emits however

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,11 +17,7 @@
     ],
     "downlevelIteration": true,
     "target": "es2015",
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true
+    "strict": true,
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This keeps us from forgetting to enable additional stritness flags, such
as strict function types.

Also fixes an instance of code that was incompatible with (surprise!)
strict function types. Instead of adjusting the parameter types over and
over again, this now specifies the required type (ts.WriteFileCallback)
and relies on TS' right hand side type inferral of function types.