### PR TITLE
Avoid crashing on conditional rest tuple types.

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -808,6 +808,16 @@ export class TypeTranslator {
       const varArgs = !!paramDecl.dotDotDotToken;
       let paramType = this.typeChecker.getTypeOfSymbolAtLocation(param, this.node);
       if (varArgs) {
+        if ((paramType.flags & ts.TypeFlags.Object) === 0) {
+          this.warn('var args type is not an object type');
+          paramTypes.push('!Array<?>');
+          continue;
+        }
+        if (((paramType as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference) === 0) {
+          this.warn('unsupported var args type (not an array reference)');
+          paramTypes.push('!Array<?>');
+          continue;
+        }
         const typeRef = paramType as ts.TypeReference;
         paramType = typeRef.typeArguments![0];
       }

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -1,0 +1,28 @@
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,3): warning TS0: emitting ? for conditional/substitution type
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(3,14): warning TS0: var args type is not an object type
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.conditional_rest_tuple_type.conditional_rest_tuple_type');
+var module = module || { id: 'test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts' };
+module = module;
+exports = {};
+/**
+ * @template T
+ * @param {...?} args
+ * @return {void}
+ */
+function conditionalRestTupleType(...args) { }
+/** @type {{conditionalRestTupleType: function(!Array<?>): void}} */
+exports.x = {
+    /**
+     * @template T
+     * @param {...?} args
+     * @return {void}
+     */
+    conditionalRestTupleType(...args) {
+        conditionalRestTupleType(...args);
+    }
+};

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts
@@ -1,0 +1,7 @@
+function conditionalRestTupleType<T>(...args: T extends string ? [] : ['a']) {}
+
+export const x = {
+  conditionalRestTupleType<T>(...args: T extends string ? [] : ['a']) {
+    conditionalRestTupleType(...args);
+  }
+};


### PR DESCRIPTION
These cannot be easily represented in Closure, but tsickle should at
least not crash on them.