### PR TITLE
add missingOverride to our global suppression list

### DIFF
--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -53,13 +53,11 @@ function augmentFileoverviewComments(tags: jsdoc.Tag[]) {
   // 3) Suppress uselessCode.  We emit an "if (false)" around type declarations,
   // which is flagged as unused code unless we suppress it.
   suppressions.add('uselessCode');
-  // 4) Suppress missingReturn.  If the TS compiler's exhaustiveness analysis
-  // concludes that all possible branches return a value, then we don't want
-  // Closure to second-guess this decision.
+  // 4) Suppress some checks for user errors that TS already checks.
   suppressions.add('missingReturn');
-  // 5) Suppress unusedPrivateMembers.  TS also captures this, so we don't
-  // want to check it a second time.
   suppressions.add('unusedPrivateMembers');
+  // 5) Suppress checking for @override, because TS doesn't model it.
+  suppressions.add('missingOverride');
   suppressTag.type = Array.from(suppressions.values()).sort().join(',');
 
   return tags;

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.abstract.abstract');
 var module = module || { id: 'test_files/abstract/abstract.ts' };

--- a/test_files/anon_class/anon_class.js
+++ b/test_files/anon_class/anon_class.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Verify we don't produce a type mentioning 'anonymous class'
 // for variables that involve anonymous classes.  Instead we just

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Reproduces an error that caused incorrect Automatic Semicolon Insertion.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');
 var module = module || { id: 'test_files/arrow_fn.es5/arrow_fn_es5.ts' };

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };

--- a/test_files/augment/user.js
+++ b/test_files/augment/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.augment.user');
 var module = module || { id: 'test_files/augment/user.ts' };

--- a/test_files/automatic_semicolon_insertion/asi.js
+++ b/test_files/automatic_semicolon_insertion/asi.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.automatic_semicolon_insertion.asi');
 var module = module || { id: 'test_files/automatic_semicolon_insertion/asi.ts' };

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.basic.untyped.basic.untyped');
 var module = module || { id: 'test_files/basic.untyped/basic.untyped.ts' };

--- a/test_files/blacklisted_ambient_external_module/user.js
+++ b/test_files/blacklisted_ambient_external_module/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Regression test for type-blacklisted ambient modules.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.blacklisted_ambient_external_module.user');
 var module = module || { id: 'test_files/blacklisted_ambient_external_module/user.ts' };

--- a/test_files/cast_extends/cast_extends.js
+++ b/test_files/cast_extends/cast_extends.js
@@ -5,7 +5,7 @@
  * @fileoverview Reproduces an issue where tsickle would emit a cast for the "extends" claus, and
  * Closure would report an error due to the extends expression not resolving to a plain identifier.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.cast_extends.cast_extends');
 var module = module || { id: 'test_files/cast_extends/cast_extends.ts' };

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,7 +1,7 @@
 // test_files/class.untyped/class.ts(41,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.class.untyped.class');
 var module = module || { id: 'test_files/class.untyped/class.ts' };

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -4,7 +4,7 @@
 // test_files/class/class.ts(130,1): warning TS0: omitting heritage reference to a type/value conflict: ZoneAlias
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This test exercises the various ways classes and interfaces can interact.
 // There are three types of classy things:

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.clutz.no_externs.strip_clutz_type');
 var module = module || { id: 'test_files/clutz.no_externs/strip_clutz_type.ts' };

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.coerce.coerce');
 var module = module || { id: 'test_files/coerce/coerce.ts' };

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.comments.comments');
 var module = module || { id: 'test_files/comments/comments.ts' };

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -3,7 +3,7 @@
 // test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(3,14): warning TS0: var args type is not an object type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.conditional_rest_tuple_type.conditional_rest_tuple_type');
 var module = module || { id: 'test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts' };

--- a/test_files/conditional_type/conditional_type.js
+++ b/test_files/conditional_type/conditional_type.js
@@ -1,7 +1,7 @@
 // test_files/conditional_type/conditional_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.conditional_type.conditional_type');
 var module = module || { id: 'test_files/conditional_type/conditional_type.ts' };

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };

--- a/test_files/declare/declare_nondts.js
+++ b/test_files/declare/declare_nondts.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare.declare_nondts');
 var module = module || { id: 'test_files/declare/declare_nondts.ts' };

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_ns.declare_class_ns');
 var module = module || { id: 'test_files/declare_class_ns/declare_class_ns.ts' };

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_overloads.declare_class_overloads');
 var module = module || { id: 'test_files/declare_class_overloads/declare_class_overloads.ts' };

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_export.untyped.declare_export');
 var module = module || { id: 'test_files/declare_export.untyped/declare_export.ts' };

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // All of the types/values declared in this file should
 // 1) generate externs

--- a/test_files/declare_export_dts/user.js
+++ b/test_files/declare_export_dts/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_export_dts.user');
 var module = module || { id: 'test_files/declare_export_dts/user.ts' };

--- a/test_files/declare_import/export_default.js
+++ b/test_files/declare_import/export_default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_import.export_default');
 var module = module || { id: 'test_files/declare_import/export_default.ts' };

--- a/test_files/declare_import/exporter.js
+++ b/test_files/declare_import/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_import.exporter');
 var module = module || { id: 'test_files/declare_import/exporter.ts' };

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,7 +1,7 @@
 // test_files/decorator/decorator.ts(13,66): warning TS0: should not emit a 'never' type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };

--- a/test_files/decorator/default_export.js
+++ b/test_files/decorator/default_export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Tests using a default imported class for in a decorated ctor.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.default_export');
 var module = module || { id: 'test_files/decorator/default_export.ts' };

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external');
 var module = module || { id: 'test_files/decorator/external.ts' };

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external2');
 var module = module || { id: 'test_files/decorator/external2.ts' };

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -3,7 +3,7 @@
  * @fileoverview only_types only exports types, so TypeScript will elide the
  * import entirely.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.only_types');
 var module = module || { id: 'test_files/decorator/only_types.ts' };

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');
 var module = module || { id: 'test_files/decorator_nested_scope/decorator_nested_scope.ts' };

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.default.default');
 var module = module || { id: 'test_files/default/default.ts' };

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.doc_params.doc_params');
 var module = module || { id: 'test_files/doc_params/doc_params.ts' };

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.untyped.enum.untyped');
 var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,7 +1,7 @@
 // test_files/enum/enum.ts(2,7): warning TS0: should not emit a 'never' type
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Line with a missing semicolon should not break the following enum.
 goog.module('test_files.enum.enum');

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.enum_user');
 var module = module || { id: 'test_files/enum/enum_user.ts' };

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Note: if you only have one value in the enum, then the type of "x" below
 // is just ExportedEnum, regardless of the annotation.  This might be a bug

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export');
 var module = module || { id: 'test_files/export/export.ts' };

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper');
 var module = module || { id: 'test_files/export/export_helper.ts' };

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper_3');
 var module = module || { id: 'test_files/export/export_helper_3.ts' };

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_star_imported');
 var module = module || { id: 'test_files/export/export_star_imported.ts' };

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.export_declare_namespace');
 var module = module || { id: 'test_files/export_declare_namespace/export_declare_namespace.ts' };

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };

--- a/test_files/export_equals.shim/export_equals.js
+++ b/test_files/export_equals.shim/export_equals.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.shim.export_equals');
 var module = module || { id: 'test_files/export_equals.shim/export_equals.ts' };

--- a/test_files/export_equals.shim/user.js
+++ b/test_files/export_equals.shim/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.shim.user');
 var module = module || { id: 'test_files/export_equals.shim/user.ts' };

--- a/test_files/export_local_type/export_local_type.js
+++ b/test_files/export_local_type/export_local_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Regression test to ensure local type symbols can be exported.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_local_type.export_local_type');
 var module = module || { id: 'test_files/export_local_type/export_local_type.ts' };

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.importer');
 var module = module || { id: 'test_files/export_types_values.untyped/importer.ts' };

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.value_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/value_exporter.ts' };

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -5,7 +5,7 @@
  * {ClassInImplements}", conflicting the ES6 extends syntax, leading to
  * incorrect optimization results.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.extend_and_implement.extend_and_implement');
 var module = module || { id: 'test_files/extend_and_implement/extend_and_implement.ts' };

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,7 +1,7 @@
 // test_files/fields/fields.ts(22,5): warning TS0: unhandled anonymous type with constructor signature but no declaration
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.fields.fields');
 var module = module || { id: 'test_files/fields/fields.ts' };

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');
 var module = module || { id: 'test_files/fields_no_ctor/fields_no_ctor.ts' };

--- a/test_files/file_comment/before_import.js
+++ b/test_files/file_comment/before_import.js
@@ -4,7 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the regular import case.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.before_import');
 var module = module || { id: 'test_files/file_comment/before_import.ts' };

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -4,7 +4,7 @@
  * it before its JSDoc block. This comment would not get emitted if detached
  * source file comments were not emitted separately.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_class');
 var module = module || { id: 'test_files/file_comment/comment_before_class.ts' };

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -3,7 +3,7 @@
  * @fileoverview This is a comment before an import, where the import will be elided but the comment
  * must be kept.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment/comment_before_elided_import.ts' };

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -4,7 +4,7 @@
  * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
  * @modName {foobar}
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_var');
 var module = module || { id: 'test_files/file_comment/comment_before_var.ts' };

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /** A comment without any tags. */
 // here comes code.

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview
- * @suppress {checkTypes,extraRequire,missingReturn,undefinedVars,unusedPrivateMembers,uselessCode}  because we don't like them errors
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,undefinedVars,unusedPrivateMembers,uselessCode}  because we don't like them errors
  *
  */
 goog.module('test_files.file_comment.comment_with_text');

--- a/test_files/file_comment/export_star.js
+++ b/test_files/file_comment/export_star.js
@@ -4,7 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the export * case.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.export_star');
 var module = module || { id: 'test_files/file_comment/export_star.ts' };

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.file_comment');
 var module = module || { id: 'test_files/file_comment/file_comment.ts' };

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview A file.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview a comment without a suppress tag.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // here comes code.
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -1,7 +1,7 @@
 /**
  *
  * @fileoverview Tests merging JSDoc tags in fileoverview comments.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode}
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode}
  *
  */
 /** second comment here */

--- a/test_files/file_comment/fileoverview_in_comment_text.js
+++ b/test_files/file_comment/fileoverview_in_comment_text.js
@@ -3,7 +3,7 @@
  * @fileoverview Tests that mere mentions of file overview tags in comment bodies don't get
  * reported as errors.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_in_comment_text');
 var module = module || { id: 'test_files/file_comment/fileoverview_in_comment_text.ts' };

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment/jsdoc_comment.ts' };

--- a/test_files/file_comment/latecomment.js
+++ b/test_files/file_comment/latecomment.js
@@ -1,7 +1,7 @@
 // test_files/file_comment/latecomment.ts(3,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.latecomment');
 var module = module || { id: 'test_files/file_comment/latecomment.ts' };

--- a/test_files/file_comment/latecomment_front.js
+++ b/test_files/file_comment/latecomment_front.js
@@ -1,7 +1,7 @@
 /** @license Here is a license comment. */
 /**
  * @fileoverview with a late fileoverview comment before the first statement.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.latecomment_front');
 var module = module || { id: 'test_files/file_comment/latecomment_front.ts' };

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -13,7 +13,7 @@
 /**
  *
  * @fileoverview The last fileoverview actually takes effect.
- * @suppress {checkTypes,extraRequire,globalThis,missingReturn,unusedPrivateMembers,uselessCode}
+ * @suppress {checkTypes,extraRequire,globalThis,missingOverride,missingReturn,unusedPrivateMembers,uselessCode}
  *
  */
 /** Here's another trailing comment */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview added by tsickle
  * @modName {some_mod}
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment/other_fileoverview_comments.ts' };

--- a/test_files/file_comment/run_in_comment.js
+++ b/test_files/file_comment/run_in_comment.js
@@ -1,7 +1,7 @@
 // test_files/file_comment/run_in_comment.ts(1,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.run_in_comment');
 var module = module || { id: 'test_files/file_comment/run_in_comment.ts' };

--- a/test_files/file_comment/side_effect_import.js
+++ b/test_files/file_comment/side_effect_import.js
@@ -4,7 +4,7 @@
  * transformer_util.ts has special logic to handle comments before
  * import/require() calls. This file tests the side-effect import case.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.side_effect_import');
 var module = module || { id: 'test_files/file_comment/side_effect_import.ts' };

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.untyped.functions');
 var module = module || { id: 'test_files/functions.untyped/functions.ts' };

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.functions');
 var module = module || { id: 'test_files/functions/functions.ts' };

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -2,7 +2,7 @@
  *
  * @fileoverview This text here matches the     text below in length.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.two_jsdoc_blocks');
 var module = module || { id: 'test_files/functions/two_jsdoc_blocks.ts' };

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_local_var.generic_local_var');
 var module = module || { id: 'test_files/generic_local_var/generic_local_var.ts' };

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_type_alias.generic_type_alias');
 var module = module || { id: 'test_files/generic_type_alias/generic_type_alias.ts' };

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.exporter');
 var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.interface');
 var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -5,7 +5,7 @@
  * would then crash Closure Compiler as it creates a union type, which is unexpected for super
  * interfaces.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.user');
 var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.importer');
 var module = module || { id: 'test_files/import_alias/importer.ts' };

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.exporter');
 var module = module || { id: 'test_files/import_default/exporter.ts' };

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.import_default');
 var module = module || { id: 'test_files/import_default/import_default.ts' };

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Make sure tsickle does not crash on empty imports.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.import_empty');
 var module = module || { id: 'test_files/import_empty/import_empty.ts' };

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.imported');
 var module = module || { id: 'test_files/import_empty/imported.ts' };

--- a/test_files/import_export_typedef_conflict/exporter.js
+++ b/test_files/import_export_typedef_conflict/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_export_typedef_conflict.exporter');
 var module = module || { id: 'test_files/import_export_typedef_conflict/exporter.ts' };

--- a/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
+++ b/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
@@ -4,7 +4,7 @@
  * scope would cause a duplicate exports assignment, once for the imported symbol and once for the
  * exported typedef.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_export_typedef_conflict.import_export_typedef_conflict');
 var module = module || { id: 'test_files/import_export_typedef_conflict/import_export_typedef_conflict.ts' };

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_from_goog.import_from_goog');
 var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' };

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_only_types.import_only_types');
 var module = module || { id: 'test_files/import_only_types/import_only_types.ts' };

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // const enum values are inlined, so even though const enums are values,
 // TypeScript might not generate any imports for them, which means modules

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Exports only types, but must still be goog.require'd for Closure Compiler.
 goog.module('test_files.import_only_types.types_only');

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.import_prefixed_mixed');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_mixed.ts' };

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.import_prefixed_types');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_types.ts' };

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.relative');
 var module = module || { id: 'test_files/index_import/has_index/relative.ts' };

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.user');
 var module = module || { id: 'test_files/index_import/user.ts' };

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.implement_import');
 var module = module || { id: 'test_files/interface/implement_import.ts' };

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface');
 var module = module || { id: 'test_files/interface/interface.ts' };

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_extends');
 var module = module || { id: 'test_files/interface/interface_extends.ts' };

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_type_params');
 var module = module || { id: 'test_files/interface/interface_type_params.ts' };

--- a/test_files/invalid_closure_properties/invalid_closure_properties.js
+++ b/test_files/invalid_closure_properties/invalid_closure_properties.js
@@ -5,7 +5,7 @@
  * @fileoverview Check the type generated when using a builtin symbol as
  * a computed property.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This test is verifying the type of this expression, which ultimately
 // refers to some TypeScript internal __@observeable thing.  Note that

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -19,7 +19,7 @@
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc.jsdoc');
 var module = module || { id: 'test_files/jsdoc/jsdoc.ts' };

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.default');
 var module = module || { id: 'test_files/jsdoc_types.untyped/default.ts' };

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /**
  * This test tests importing a type across module boundaries,

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -2,7 +2,7 @@
 // "quoted-bad-name": string;
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module1');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module1.ts' };

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module2');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module2.ts' };

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.default');
 var module = module || { id: 'test_files/jsdoc_types/default.ts' };

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -3,7 +3,7 @@
  * @fileoverview Tests that initialized variables that end up untyped (`?`) do not get an explicit
  * type annotation, so that Closure's type inference can kick in and possibly do a better job.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This should not have a type annotation.
 goog.module('test_files.jsdoc_types.initialized_unknown');

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types/jsdoc_types.ts' };

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -2,7 +2,7 @@
 // "quoted-bad-name": string;
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module1');
 var module = module || { id: 'test_files/jsdoc_types/module1.ts' };

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module2');
 var module = module || { id: 'test_files/jsdoc_types/module2.ts' };

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test
  * suite runner so that its types are always {?}.*/

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.methods.methods');
 var module = module || { id: 'test_files/methods/methods.ts' };

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -3,7 +3,7 @@
  * @fileoverview tsickle's Closure compatible exported enum emit does not work in namespaces. Bar
  * below must be exported onto foo, which tsickle does by disabling its emit for namespace'd enums.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_enum_in_namespace');

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // tslint:disable:no-namespace
 goog.module('test_files.namespaced.export_namespace');

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.local_namespace');
 var module = module || { id: 'test_files/namespaced/local_namespace.ts' };

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.nonnull_generics.nonnull_generics');
 var module = module || { id: 'test_files/nonnull_generics/nonnull_generics.ts' };

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.nullable.nullable');
 var module = module || { id: 'test_files/nullable/nullable.ts' };

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.optional.optional');
 var module = module || { id: 'test_files/optional/optional.ts' };

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.parameter_properties.parameter_properties');
 var module = module || { id: 'test_files/parameter_properties/parameter_properties.ts' };

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -1,7 +1,7 @@
 // test_files/partial/partial.ts(7,1): warning TS0: omitting heritage reference to a type literal: Partial<Base>
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.partial.partial');
 var module = module || { id: 'test_files/partial/partial.ts' };

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promiseconstructor.promiseconstructor');
 var module = module || { id: 'test_files/promiseconstructor/promiseconstructor.ts' };

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promisectorlike.promisectorlike');
 var module = module || { id: 'test_files/promisectorlike/promisectorlike.ts' };

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };

--- a/test_files/protected/protected.js
+++ b/test_files/protected/protected.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /** This test checks that we emit \@private/\@protected where necessary. */
 goog.module('test_files.protected.protected');

--- a/test_files/quote_props/quote.js
+++ b/test_files/quote_props/quote.js
@@ -6,7 +6,7 @@
 // test_files/quote_props/quote.ts(29,1): warning TS0: Declared property foo accessed with quotes. This can lead to renaming bugs. A better fix is to use 'declare interface' on the declaration.
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.quote_props.quote');
 var module = module || { id: 'test_files/quote_props/quote.ts' };

--- a/test_files/return_this/return_this.js
+++ b/test_files/return_this/return_this.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.return_this.return_this');
 var module = module || { id: 'test_files/return_this/return_this.ts' };

--- a/test_files/single_value_enum/single_value_enum.js
+++ b/test_files/single_value_enum/single_value_enum.js
@@ -5,7 +5,7 @@
  * Previously, tsickle would then emit the type as `SingleValuedEnum.C`, which is illegal in
  * Closure.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.single_value_enum.single_value_enum');
 var module = module || { id: 'test_files/single_value_enum/single_value_enum.ts' };

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.static.static');
 var module = module || { id: 'test_files/static/static.ts' };

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.structural.untyped.structural.untyped');
 var module = module || { id: 'test_files/structural.untyped/structural.untyped.ts' };

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.super.super');
 var module = module || { id: 'test_files/super/super.ts' };

--- a/test_files/symbol/symbol.js
+++ b/test_files/symbol/symbol.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.symbol.symbol');
 var module = module || { id: 'test_files/symbol/symbol.ts' };

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.this_type.this_type');
 var module = module || { id: 'test_files/this_type/this_type.ts' };

--- a/test_files/transitive_symbol_type_only/exporter.js
+++ b/test_files/transitive_symbol_type_only/exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.exporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/exporter.ts' };

--- a/test_files/transitive_symbol_type_only/reexporter.js
+++ b/test_files/transitive_symbol_type_only/reexporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.reexporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/reexporter.ts' };

--- a/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
+++ b/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
@@ -4,7 +4,7 @@
  * test makes sure there is no hard goog.require for the transitive file, as that breaks strict
  * dependency checking in some systems.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.transitive_symbol_type_only');
 var module = module || { id: 'test_files/transitive_symbol_type_only/transitive_symbol_type_only.ts' };

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -4,7 +4,7 @@
 // test_files/type/type.ts(46,21): warning TS0: anonymous type has no symbol
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // WARNING: interface has both a type and a value, skipping emit
 goog.module('test_files.type.type');

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.elided_comment');
 var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' };

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview See comments in type_alias_imported.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.export_constant');
 var module = module || { id: 'test_files/type_alias_imported/export_constant.ts' };

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -3,7 +3,7 @@
  * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
  * must ultimately be imported by type_alias_imported.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_declare');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_declare.ts' };

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -3,7 +3,7 @@
  * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
  * type reference is created (no .default property).
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_default_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_default_exporter.ts' };

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_exporter.ts' };

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Make sure imports are inserted *after* the fileoverview.
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_imported');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_imported.ts' };

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -2,7 +2,7 @@
 // test_files/type_and_value/module.ts(6,1): warning TS0: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // WARNING: interface has both a type and a value, skipping emit
 goog.module('test_files.type_and_value.module');

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -3,7 +3,7 @@
 // test_files/type_and_value/type_and_value.ts(19,5): warning TS0: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_guard_fn.type_guard_fn');
 var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.underscore.underscore');
 var module = module || { id: 'test_files/underscore/underscore.ts' };

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -3,7 +3,7 @@
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
  *
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.use_closure_externs.use_closure_externs');
 var module = module || { id: 'test_files/use_closure_externs/use_closure_externs.ts' };

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview added by tsickle
- * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };


### PR DESCRIPTION
This Closure check expects @override annotations on method overrides.
We don't want Closure to check this, because TypeScript doesn't model this.