### PR TITLE
Have `ReadonlyArray<T>` extend `Array<T>`.

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -47,7 +47,7 @@ var RegExpExecArray;
 /**
  * @record
  * @template T
- * @extends {IArrayLike<T>}
+ * @extends {Array<T>}
  */
 function ReadonlyArray() {}
 


### PR DESCRIPTION
`IArrayLike<T>` does not define several Array methods, such as `map`.
Extending `Array<T>` fixes this, and allows Closure Compiler to
understand calls such as `map` on it.