### PR TITLE
Fix a missing line break.

### DIFF
--- a/src/externs.ts
+++ b/src/externs.ts
@@ -455,7 +455,7 @@ export function generateExterns(
       exportDeclaration: ts.ExportDeclaration, namespace: ReadonlyArray<string>) {
     if (!exportDeclaration.exportClause) {
       emit(`\n// TODO(tsickle): export * declaration in ${
-          debugLocationStr(exportDeclaration, namespace)}`);
+          debugLocationStr(exportDeclaration, namespace)}\n`);
       return;
     }
     for (const exportSpecifier of exportDeclaration.exportClause.elements) {


### PR DESCRIPTION
The missing line break can cause parse errors if the next lines starts
with a block comment that is then ignored due to the line comment.

This is a follow up to #971.