### PR TITLE
carefully handle @template in jsdoc handling

### DIFF
--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -9,7 +9,6 @@
 // test_files/jsdoc/jsdoc.ts(43,3): warning TS0: @enum annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(46,3): warning TS0: the type annotation on @const is redundant with its TypeScript type, remove the {...} part
 // test_files/jsdoc/jsdoc.ts(49,3): warning TS0: @typedef annotations are redundant with TypeScript equivalents
-// test_files/jsdoc/jsdoc.ts(53,1): warning TS0: @template annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(56,1): warning TS0: use index signatures (`[k: string]: type`) instead of @dict
 // test_files/jsdoc/jsdoc.ts(59,1): warning TS0: @lends annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(65,1): warning TS0: @this annotations are redundant with TypeScript equivalents
@@ -156,3 +155,14 @@ const somePolymerBehavior = {};
  */
 let Polymer;
 Polymer({ behaviors: [(/** @type {?} */ ('test'))] });
+/**
+ * This class has a 'template' tag, which we want to allow (because this is
+ * how to doc this) but not let Closure interpret (because we emit our own).
+ * The desired behavior is that the user-written \@template comment (which
+ * talks about T) is dropped, but the tsickle-generated \@template comment
+ * (which talks about T2) is preserved.
+ *
+ * @template T1, T2
+ */
+class Foo {
+}

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -72,7 +72,7 @@ function BadInterface() {}
  * @madeUptag This tag will be escaped, because Closure disallows it.
  * @see This tag will be kept, because Closure allows it.
  */
-function x(){};
+function x() {};
 
 /**
  * This class has JSDoc, but some of it should be stripped.
@@ -115,4 +115,16 @@ const somePolymerBehavior = {};
  * if they are declared via the Polymer function.
  */
 let Polymer: any;
-Polymer({ behaviors: [ 'test' as any ] });
+Polymer({behaviors: ['test' as any]});
+
+/**
+ * This class has a 'template' tag, which we want to allow (because this is
+ * how to doc this) but not let Closure interpret (because we emit our own).
+ * The desired behavior is that the user-written @template comment (which
+ * talks about T) is dropped, but the tsickle-generated @template comment
+ * (which talks about T2) is preserved.
+ *
+ * @template T User-written comments on the template (typo of 'T1').
+ * @template T2 Another user comment.
+ */
+class Foo<T1, T2> {}


### PR DESCRIPTION
Some @tags are disallowed in the user's *input* jsdoc, like
@private, because we don't want users writing them.

Other @tags are escaped in the tsickle *output* jsdoc, because
we don't want Closure compiler interpreting them.

It turns out @template is special in that we want to allow it
in the input, and we want tsickle to be able to generate it
in the output, but we don't want the user's input to make it
to the output.

See the test case for some more rationale.