### PR TITLE
Handle renamed exports in Clutz declarations.

### DIFF
--- a/test_files/reexport.declaration/export.d.ts
+++ b/test_files/reexport.declaration/export.d.ts
@@ -1,9 +1,12 @@
 export declare const NUM_CONSTANT = 3;
+export declare const OTHER = 1;
 declare global {
 	namespace ಠ_ಠ.clutz {
 		export {NUM_CONSTANT as module$contents$test_files$reexport$declaration$export_NUM_CONSTANT}
+		export {OTHER as module$contents$test_files$reexport$declaration$export_OTHER}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$export {
 		export {module$contents$test_files$reexport$declaration$export_NUM_CONSTANT as NUM_CONSTANT}
+		export {module$contents$test_files$reexport$declaration$export_OTHER as OTHER}
 	}
 }

--- a/test_files/reexport.declaration/export.ts
+++ b/test_files/reexport.declaration/export.ts
@@ -1,1 +1,2 @@
 export const NUM_CONSTANT = 3;
+export const OTHER = 1;

--- a/test_files/reexport.declaration/renamed_export.d.ts
+++ b/test_files/reexport.declaration/renamed_export.d.ts
@@ -1,0 +1,10 @@
+import { OTHER } from './export';
+export { OTHER as MOTHER };
+declare global {
+	namespace ಠ_ಠ.clutz {
+		export {OTHER as module$contents$test_files$reexport$declaration$renamed_export_MOTHER}
+	}
+	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$renamed_export {
+		export {module$contents$test_files$reexport$declaration$renamed_export_MOTHER as MOTHER}
+	}
+}

--- a/test_files/reexport.declaration/renamed_export.ts
+++ b/test_files/reexport.declaration/renamed_export.ts
@@ -1,0 +1,2 @@
+import {OTHER} from './export';
+export {OTHER as MOTHER};


### PR DESCRIPTION
When a symbols is renamed in its export specifier, tsickle must use the
module local name to generate a Clutz declaration, not the exported
name. Paraphrasing:

    export {X as Y};
    // --> should generate -->
    declare global {
      namespace ಠ_ಠ.clutz {
        export {X as module$contents$file_Y}
      }
    }