### PR TITLE
 Handle bigint.

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -81,5 +81,8 @@ var PromiseConstructorLike;
 /** @typedef {?} */
 var SymbolConstructor;
 
-/** @constructor */
-function bigint() {}
+/**
+ * This is a placeholder for a Closure type to be determined.
+ * @constructor
+ */
+function bigintPlaceholder() {}

--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -80,3 +80,6 @@ var PromiseConstructorLike;
 
 /** @typedef {?} */
 var SymbolConstructor;
+
+/** @constructor */
+function bigint() {}

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -420,7 +420,7 @@ export class TypeTranslator {
       case ts.TypeFlags.Undefined:
         return 'undefined';
       case ts.TypeFlags.BigInt:
-        return 'bigint';
+        return 'bigintPlaceholder';
       case ts.TypeFlags.Null:
         return 'null';
       case ts.TypeFlags.Never:

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -419,6 +419,8 @@ export class TypeTranslator {
         return 'void';
       case ts.TypeFlags.Undefined:
         return 'undefined';
+      case ts.TypeFlags.BigInt:
+        return 'bigint';
       case ts.TypeFlags.Null:
         return 'null';
       case ts.TypeFlags.Never:

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,7 +1,7 @@
 // test_files/type/type.ts(3,1): warning TS0: type/symbol conflict for Array, using {?} for now
-// test_files/type/type.ts(15,5): warning TS0: unhandled anonymous type
-// test_files/type/type.ts(46,21): warning TS0: anonymous type has no symbol
-// test_files/type/type.ts(46,21): warning TS0: anonymous type has no symbol
+// test_files/type/type.ts(16,5): warning TS0: unhandled anonymous type
+// test_files/type/type.ts(47,21): warning TS0: anonymous type has no symbol
+// test_files/type/type.ts(47,21): warning TS0: anonymous type has no symbol
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -21,6 +21,8 @@ let typeArr2;
 let typeNestedArr;
 /** @type {*} */
 let typeUnknown;
+/** @type {bigint} */
+let typeBigInt;
 /** @type {{a: number, b: string}} */
 let typeObject = { a: 3, b: 'b' };
 /** @type {!Object<string,number>} */

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -21,7 +21,7 @@ let typeArr2;
 let typeNestedArr;
 /** @type {*} */
 let typeUnknown;
-/** @type {bigint} */
+/** @type {bigintPlaceholder} */
 let typeBigInt;
 /** @type {{a: number, b: string}} */
 let typeObject = { a: 3, b: 'b' };

--- a/test_files/type/type.ts
+++ b/test_files/type/type.ts
@@ -9,6 +9,7 @@ let typeArr: Array<any>;
 let typeArr2: any[];
 let typeNestedArr: {a:any}[][];
 let typeUnknown: unknown;
+let typeBigInt: bigint;
 
 let typeObject: {a:number, b:string} = {a:3, b:'b'};
 let typeObjectIndexable: {[key:string]: number};


### PR DESCRIPTION
Currently this refers to a type in closure_externs.js, to be replaced with a proper Closure externs definition.
