### PR TITLE
Update to latest Bazel rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,14 @@
 test --test_output=errors
 #TODO(alexeagle): enable worker mode
 
+# Opt-in to breaking change for runfiles layout, where Bazel will eventually stop providing
+# an external directory inside of our workspace like
+# `runfiles_root/my_proj/external/npm/node_modules`
+# This ensures we are forwards compatible.
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--legacy_external_runfiles
+test --nolegacy_external_runfiles
+run --nolegacy_external_runfiles
+
 # Enable debugging tests with --config=debug
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@
 # NPM dependencies changed.
 var_1: &cache_key angular-tsickle-{{ checksum "WORKSPACE" }}-{{ checksum "yarn.lock" }}
 # Default docker image for CircleCI jobs with Bazel installed. The version of Bazel is controlled
-# by the docker image version. e.g "google/bazel:0.18.0" installs Bazel v0.18.0. When updating this
+# by the docker image version. e.g "google/bazel:0.22.0" installs Bazel v0.22.0. When updating this
 # version, consider updating the minimum required Bazel version in the "WORKSPACE" file.
-var_2: &default_docker_image l.gcr.io/google/bazel:0.18.0
+var_2: &default_docker_image l.gcr.io/google/bazel:0.22.0
 
 # Settings common to each job
 var_3: &job_defaults

--- a/BUILD
+++ b/BUILD
@@ -13,12 +13,12 @@ filegroup(
     srcs = glob([
         "test_files/**/*",
         "third_party/**/*",
+    ]) + [
         # The test suites run version-specific TypeScript compilers,
-        # but they all need the 'tslib' package to be available in
-        # a node_modules directory *above* the test/ directory.  So
-        # we must provide this extra directory as data to those tests.
-        "node_modules/tslib/*",
-    ]),
+        # but they all need the 'tslib' package to be available. So
+        # we must provide this extra filegroup as data to those tests.
+        "@npm//tslib:tslib__files",
+    ],
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,36 +4,34 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "6139762b62b37c1fd171d7f22aa39566cb7dc2916f0f801d505a9aaf118c117f",
-    strip_prefix = "rules_nodejs-0.9.1",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.9.1.zip",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.5/rules_nodejs-0.18.5.tar.gz"],
+    sha256 = "c8cd6a77433f7d3bb1f4ac87f15822aa102989f8e9eb1907ca0cad718573985b",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
+load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
 # Force developers to use the same Bazel version as CircleCI, to prevent different
 # local behavior than CI.
-check_bazel_version("0.18.0")
+check_bazel_version("0.22.0")
 
-# NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
-# your npm dependencies. You must still run the package manager.
-node_repositories(package_json = [
-    "//:package.json",
-])
+# Just installs nodejs and yarn, provides a `@nodejs//` workspace
+node_repositories()
 
-http_archive(
-    name = "io_bazel_rules_webtesting",
-    sha256 = "cecc12f07e95740750a40d38e8b14b76fefa1551bef9332cb432d564d693723c",
-    strip_prefix = "rules_webtesting-0.2.0",
-    url = "https://github.com/bazelbuild/rules_webtesting/archive/v0.2.0.zip",
+# Run yarn install to create a node_modules tree for Bazel's use
+# In a future release, this will install into the dev's node_modules folder
+# but for now, you must also run yarn install locally for the editor to find
+# things like @types files
+yarn_install(
+  name = "npm",
+  package_json = "//:package.json",
+  yarn_lock = "//:yarn.lock",
 )
 
-http_archive(
-    name = "build_bazel_rules_typescript",
-    sha256 = "3792cc20ef13bb1d1d8b1760894c3320f02a87843e3a04fed7e8e454a75328b6",
-    strip_prefix = "rules_typescript-0.15.1",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.1.zip",
-)
+# Install all Bazel dependencies needed for npm packages that supply Bazel rules
+# In particular this installs the TypeScript rules
+load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+
+install_bazel_dependencies()
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typescript": "~3.3.1"
   },
   "devDependencies": {
+    "@bazel/typescript": "^0.24.1",
     "@types/diff-match-patch": "^1.0.32",
     "@types/glob": "5.0.35",
     "@types/jasmine": "2.8.8",

--- a/src/BUILD
+++ b/src/BUILD
@@ -25,5 +25,10 @@ ts_library(
     ],
     data = ["closure_externs.js"],
     tsconfig = "//:tsconfig.json",
-    deps = [],
+    deps = [
+        "@npm//@types/minimist",
+        "@npm//@types/mkdirp",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
 )

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -61,7 +61,9 @@ export function mergeEmitResults(emitResults: EmitResult[]): EmitResult {
   for (const er of emitResults) {
     diagnostics.push(...er.diagnostics);
     emitSkipped = emitSkipped || er.emitSkipped;
-    emittedFiles.push(...er.emittedFiles);
+    if (er.emittedFiles) {
+      emittedFiles.push(...er.emittedFiles);
+    }
     Object.assign(externs, er.externs);
     modulesManifest.addManifest(er.modulesManifest);
   }

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,8 +6,16 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 ts_library(
     name = "test_support",
     srcs = ["test_support.ts"],
+    testonly = True,
     tsconfig = "//:tsconfig.json",
-    deps = ["//src"],
+    deps = [
+        "//src",
+        "@npm//@types/diff-match-patch",
+        "@npm//@types/node",
+        "@npm//@types/jasmine",
+        "@npm//@types/glob",
+        "@npm//typescript",
+    ],
 )
 
 ts_library(
@@ -23,17 +31,26 @@ ts_library(
     # Unit tests run the TS compiler, which attempts to module-resolve 'tslib'
     # when configured with --importHelpers.  So the tests must have tslib.d.ts
     # available as a runtime data dep.
-    data = ["//:node_modules"],
+    data = ["@npm//tslib"],
+    testonly = True,
     tsconfig = "//:tsconfig.json",
     deps = [
         ":test_support",
         "//src",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 
 jasmine_node_test(
     name = "unit_test",
     srcs = [":unit_test_lib"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//diff-match-patch",
+        "@npm//source-map-support",
+    ],
 )
 
 ts_library(
@@ -42,10 +59,14 @@ ts_library(
         "e2e_clutz_dts_test.ts",
         "e2e_main_test.ts",
     ],
+    testonly = True,
     tsconfig = "//:tsconfig.json",
     deps = [
         ":test_support",
         "//src",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 
@@ -53,6 +74,13 @@ jasmine_node_test(
     name = "e2e_test",
     srcs = [":e2e_test_lib"],
     data = ["//:test_files"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//diff-match-patch",
+        "@npm//minimist",
+        "@npm//mkdirp",
+        "@npm//source-map-support",
+    ],
 )
 
 test_suite(
@@ -69,10 +97,13 @@ ts_library(
         "closure.ts",
         "e2e_closure_test.ts",
     ],
+    testonly = True,
     tsconfig = "//:tsconfig.json",
     deps = [
         ":test_support",
         "//src",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
     ],
 )
 
@@ -80,15 +111,25 @@ jasmine_node_test(
     name = "closure_e2e_test",
     srcs = [":closure_e2e_test_lib"],
     data = ["//:test_files"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//diff-match-patch",
+        "@npm//google-closure-compiler",
+        "@npm//source-map-support",
+    ],
 )
 
 ts_library(
     name = "golden_test_lib",
     srcs = ["golden_tsickle_test.ts"],
+    testonly = True,
     tsconfig = "//:tsconfig.json",
     deps = [
         ":test_support",
         "//src",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
+        "@npm//typescript"
     ],
 )
 
@@ -96,4 +137,9 @@ jasmine_node_test(
     name = "golden_test",
     srcs = [":golden_test_lib"],
     data = ["//:test_files"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//diff-match-patch",
+        "@npm//source-map-support",
+    ],
 )

--- a/test/decorator_downlevel_transformer_test.ts
+++ b/test/decorator_downlevel_transformer_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as fs from 'fs';
 
 import * as closure from './closure';

--- a/test/e2e_clutz_dts_test.ts
+++ b/test/e2e_clutz_dts_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/test/e2e_main_test.ts
+++ b/test/e2e_main_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as path from 'path';
 
 import {toClosureJS} from '../src/main';

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/test/googmodule_test.ts
+++ b/test/googmodule_test.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+///<reference types="jasmine"/>
 // Install source-map-support so that stack traces are mapped back to TS code.
 import 'source-map-support';
 
@@ -37,7 +38,7 @@ function rootDir(): string {
  * tslib if we let it do its normal module resolution.  So instead we fix
  * the path here to the known path to the desired file.
  */
-const tslibPath = path.join(rootDir(), 'node_modules/tslib/tslib.d.ts');
+const tslibPath = path.join(rootDir(), '../npm/node_modules/tslib/tslib.d.ts');
 
 /** Base compiler options to be customized and exposed. */
 export const baseCompilerOptions: ts.CompilerOptions = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,11 @@
     ],
     "jsx": "react",
     "types": [
+      // Note, we don't include `jasmine` here, as that's a test-only typing.
+      // To prevent accidental use of jasmine in production code, we instead
+      // bring the jasmine global typing with ///<reference/> pragmas in
+      // source files that use it.
       "node",
-      "jasmine"
     ],
     "downlevelIteration": true,
     "target": "es2015",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,21 @@
 # yarn lockfile v1
 
 
+"@bazel/typescript@^0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.24.1.tgz#3efdc085c122939b2dd161b7ff589454c50edffc"
+  integrity sha512-tvdgUlqA5EkSQmQ656G/Dc3LX4ZvqPucOGfQ/ls9fYnG4ZWIh1KgwZq99NbjMS5MAJ+47hQBH+gL6dcRfHOGUg==
+  dependencies:
+    jasmine-core "2.8.0"
+    protobufjs "5.0.3"
+    semver "5.6.0"
+    source-map-support "0.5.9"
+    tsutils "2.27.2"
+
 "@types/diff-match-patch@^1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.32.tgz#d9c3b8c914aa8229485351db4865328337a3d09f"
+  integrity sha512-bPYT5ECFiblzsVzyURaNhljBH2Gh1t9LowgUwciMrNAhFewLkHT2H0Mto07Y4/3KCOGZHRQll3CTtQZ0X11D/A==
 
 "@types/events@*":
   version "1.2.0"
@@ -13,6 +25,7 @@
 "@types/glob@5.0.35":
   version "5.0.35"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
+  integrity sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==
   dependencies:
     "@types/events" "*"
     "@types/minimatch" "*"
@@ -60,6 +73,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+ascli@~1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
+  integrity sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=
+  dependencies:
+    colour "~0.7.1"
+    optjs "~3.2.2"
+
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -91,6 +112,18 @@ builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bytebuffer@~5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
+  dependencies:
+    long "~3"
+
+camelcase@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -117,6 +150,15 @@ clang-format@^1.2.4:
     glob "^7.0.0"
     resolve "^1.1.6"
 
+cliui@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -137,6 +179,11 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
 color-convert@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
@@ -146,6 +193,11 @@ color-convert@^1.9.0:
 color-name@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+
+colour@~0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
+  integrity sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=
 
 commander@^2.12.1:
   version "2.17.0"
@@ -158,6 +210,11 @@ concat-map@0.0.1:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+decamelize@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 diff-match-patch@^1.0.1:
   version "1.0.1"
@@ -186,6 +243,18 @@ fs.realpath@^1.0.0:
 glob@7.1.2, glob@^7.0.0, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.5:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -245,9 +314,26 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+  dependencies:
+    number-is-nan "^1.0.0"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+jasmine-core@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
+  integrity sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=
 
 jasmine-core@~3.1.0:
   version "3.1.0"
@@ -271,6 +357,18 @@ js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
+  dependencies:
+    invert-kv "^1.0.0"
+
+long@~3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -291,11 +389,28 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+optjs@~3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
+  integrity sha1-aabOicRCpEQDFBrS+bNwvVu29O4=
+
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
+  dependencies:
+    lcid "^1.0.0"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -312,6 +427,16 @@ prettier@1.14.0:
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+protobufjs@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
+  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
+  dependencies:
+    ascli "~1"
+    bytebuffer "~5"
+    glob "^7.0.5"
+    yargs "^3.10.0"
 
 readable-stream@^2.3.5:
   version "2.3.6"
@@ -343,9 +468,22 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
+semver@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+source-map-support@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6:
   version "0.5.6"
@@ -370,13 +508,22 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^3.0.0:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
@@ -413,15 +560,23 @@ tslint@5.11.0:
     tslib "^1.8.0"
     tsutils "^2.27.2"
 
+tsutils@2.27.2:
+  version "2.27.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
+  integrity sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==
+  dependencies:
+    tslib "^1.8.1"
+
 tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.3.0:
+typescript@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
+  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -444,6 +599,37 @@ vinyl@^2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+window-size@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
+  integrity sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+y18n@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
+yargs@^3.10.0:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  integrity sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
+    decamelize "^1.1.1"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"


### PR DESCRIPTION
- Updates required version of Bazel to latest
- Now use Bazel-managed deps (Bazel runs yarn install, user does not have to)
- Use fine-grained deps, rather than every action depending on all node_modules
- Global (ambient) typings for jasmine are now declared per-file so this typing does not pollute non-test code
- rules_typescript now comes purely as an npm package