### PR TITLE
Handle rest arguments resolves to zero args.

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -823,7 +823,13 @@ export class TypeTranslator {
           continue;
         }
         const typeRef = paramType as ts.TypeReference;
-        paramType = typeRef.typeArguments![0];
+        if (!typeRef.typeArguments) {
+          // When a rest argument resolves empty, i.e. the concrete instantiation does not take any
+          // arguments, the type arguments are empty. Emit a function type that takes no arg in this
+          // position then.
+          continue;
+        }
+        paramType = typeRef.typeArguments[0];
       }
       let typeStr = this.translate(paramType);
       if (varArgs) typeStr = '...' + typeStr;

--- a/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
+++ b/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
@@ -1,0 +1,24 @@
+// test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts(3,1): warning TS0: var args type is not an object type
+// test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts(3,1): warning TS0: var args type is not an object type
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.rest_parameters_generic_empty.rest_parameters_generic_empty');
+var module = module || { id: 'test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts' };
+module = module;
+exports = {};
+/**
+ * @template A
+ * @param {function(!Array<?>): void} fn
+ * @return {function(!Array<?>): void}
+ */
+function returnsRestArgFn(fn) {
+    return fn;
+}
+/** @type {function(): void} */
+const zeroRestArguments = returnsRestArgFn((/**
+ * @return {void}
+ */
+() => { }));
+console.log(zeroRestArguments);

--- a/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts
+++ b/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts
@@ -1,0 +1,9 @@
+export {};
+
+function returnsRestArgFn<A extends unknown[]>(fn: (...args: A) => void):
+    (...args: A) => void {
+  return fn;
+}
+
+const zeroRestArguments = returnsRestArgFn(() => {});
+console.log(zeroRestArguments);


### PR DESCRIPTION
If a rest argument type is instantiated with no arguments, its type
paramters array is undefined (not empty). This change avoids a crash in
that situation, and emits a zero argument function.