### PR TITLE
Avoid emitting double `@this` types.

### DIFF
--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -27,3 +27,17 @@ const variableWithFunctionTypeUsingThis = (/**
 function foo() {
     return undefined;
 }
+class UnrelatedType {
+}
+class ThisThisReturnsThisAsThis {
+    // This (!) reproduces a situtation where tsickle would erroneously produce an @THIS tag for the
+    // explicitly passed this type, plus one for the template'd this type, which is an error in
+    // Closure.
+    /**
+     * @this {!UnrelatedType}
+     * @return {!ThisThisReturnsThisAsThis}
+     */
+    thisThisReturnsThisAsThis() {
+        return (/** @type {!ThisThisReturnsThisAsThis} */ (this));
+    }
+}

--- a/test_files/this_type/this_type.ts
+++ b/test_files/this_type/this_type.ts
@@ -10,3 +10,13 @@ const variableWithFunctionTypeUsingThis: (this: SomeClass, a: string) => number 
 function foo(): ((this: string) => string)|undefined {
   return undefined;
 }
+
+class UnrelatedType {}
+class ThisThisReturnsThisAsThis {
+  // This (!) reproduces a situtation where tsickle would erroneously produce an @THIS tag for the
+  // explicitly passed this type, plus one for the template'd this type, which is an error in
+  // Closure.
+  thisThisReturnsThisAsThis(this: UnrelatedType): this {
+    return this as this;
+  }
+}


### PR DESCRIPTION
TypeScript methods can specify a `this` parameter type together with a
`this` return type, e.g. `foo(this: Bar): this`, which caused tsickle to
emit double `@this` tags, which is an error in Closure.

This change fixes #997 by prefering the `this` parameter type over the
templatized return type.