### PR TITLE
Do not emit @type if @define is specified

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -153,6 +153,7 @@ const JSDOC_TAGS_INPUT_BLACKLIST = new Set([
 /** What to do with types found in JSDoc @tags. */
 enum TagWithTypePolicy {
   FORBIDDEN,
+  OPTIONAL,
   REQUIRED,
 }
 
@@ -162,7 +163,7 @@ enum TagWithTypePolicy {
  */
 const JSDOC_TAGS_WITH_TYPES = new Map([
   ['const', TagWithTypePolicy.FORBIDDEN],
-  ['define', TagWithTypePolicy.REQUIRED],
+  ['define', TagWithTypePolicy.OPTIONAL],  // NOTE: this could be made forbidden later.
   ['export', TagWithTypePolicy.FORBIDDEN],
   ['param', TagWithTypePolicy.FORBIDDEN],
   ['return', TagWithTypePolicy.FORBIDDEN],

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -158,12 +158,13 @@ enum TagWithTypePolicy {
 }
 
 /**
- * A list of JSDoc @tags that might include a {type} after them. Only banned when a type is passed.
- * Note that this does not include tags that carry a non-type system type, e.g. \@suppress.
+ * JSDoc \@tags that might include a {type} after them. Specifying a type is forbidden except in the
+ * case of \@suppress, whose argument is a suppression type, rather than a type system type.
  */
 const JSDOC_TAGS_WITH_TYPES = new Map([
   ['const', TagWithTypePolicy.FORBIDDEN],
-  ['define', TagWithTypePolicy.OPTIONAL],  // NOTE: this could be made forbidden later.
+  // NOTE: passing a type to @define will soon be forbidden as well, after usages are migrated.
+  ['define', TagWithTypePolicy.OPTIONAL],
   ['export', TagWithTypePolicy.FORBIDDEN],
   ['param', TagWithTypePolicy.FORBIDDEN],
   ['return', TagWithTypePolicy.FORBIDDEN],

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -153,7 +153,6 @@ const JSDOC_TAGS_INPUT_BLACKLIST = new Set([
 /** What to do with types found in JSDoc @tags. */
 enum TagWithTypePolicy {
   FORBIDDEN,
-  OPTIONAL,
   REQUIRED,
 }
 
@@ -164,7 +163,7 @@ enum TagWithTypePolicy {
 const JSDOC_TAGS_WITH_TYPES = new Map([
   ['const', TagWithTypePolicy.FORBIDDEN],
   // NOTE: passing a type to @define will soon be forbidden as well, after usages are migrated.
-  ['define', TagWithTypePolicy.OPTIONAL],
+  ['define', TagWithTypePolicy.FORBIDDEN],
   ['export', TagWithTypePolicy.FORBIDDEN],
   ['param', TagWithTypePolicy.FORBIDDEN],
   ['return', TagWithTypePolicy.FORBIDDEN],

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -624,6 +624,7 @@ export function jsdocTransformer(
                 moduleTypeTranslator.error(
                     varStmt,
                     `incorrect type in @define: found '${defineTag.type}' required '${typeStr}'`);
+                defineTag.type = typeStr;
               }
             }
           }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -616,14 +616,17 @@ export function jsdocTransformer(
               // getOriginalNode(decl) is required because the type checker cannot type check
               // synthesized nodes.
               const typeStr = moduleTypeTranslator.typeToClosure(ts.getOriginalNode(decl));
-              // If @define is present then do not add @type, but instead verify types are the same.
+              // If @define is present then do not add @type, but instead verify that any type is
+              // correct. Specifying any type at all here may become an error later.
               const defineTag = localTags.find(({tagName}) => tagName === 'define');
               if (!defineTag) {
                 localTags.push({tagName: 'type', type: typeStr});
               } else if (defineTag.type !== typeStr) {
-                moduleTypeTranslator.error(
-                    varStmt,
-                    `incorrect type in @define: found '${defineTag.type}' required '${typeStr}'`);
+                if (defineTag.type !== undefined) {
+                  moduleTypeTranslator.error(
+                      varStmt,
+                      `incorrect type in @define: found '${defineTag.type}' required '${typeStr}'`);
+                }
                 defineTag.type = typeStr;
               }
             }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -602,8 +602,9 @@ export function jsdocTransformer(
             tags = null;
           }
           // Add an @type for plain identifiers, but not for bindings patterns (i.e. object or array
-          // destructuring) - those do not have a syntax in Closure.
-          if (ts.isIdentifier(decl.name)) {
+          // destructuring - those do not have a syntax in Closure) or @defines, which already
+          // declare their type.
+          if (ts.isIdentifier(decl.name) && localTags.every(({tagName}) => tagName !== 'define')) {
             // For variables that are initialized and use a blacklisted type, do not emit a type at
             // all. Closure Compiler might be able to infer a better type from the initializer than
             // the `?` the code below would emit.

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -616,19 +616,12 @@ export function jsdocTransformer(
               // getOriginalNode(decl) is required because the type checker cannot type check
               // synthesized nodes.
               const typeStr = moduleTypeTranslator.typeToClosure(ts.getOriginalNode(decl));
-              // If @define is present then do not add @type, but instead verify that any type is
-              // correct. Specifying any type at all here may become an error later.
+              // If @define is present then add the type to it, rather than adding a normal @type.
               const defineTag = localTags.find(({tagName}) => tagName === 'define');
-              if (!defineTag) {
-                localTags.push({tagName: 'type', type: typeStr});
-              } else if (defineTag.type !== typeStr) {
-                if (defineTag.type !== undefined) {
-                  moduleTypeTranslator.error(
-                      varStmt,
-                      `incorrect type in @define: written Closure type was '${
-                          defineTag.type}' but TypeScript inferred '${typeStr}'`);
-                }
+              if (defineTag) {
                 defineTag.type = typeStr;
+              } else {
+                localTags.push({tagName: 'type', type: typeStr});
               }
             }
           }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -625,7 +625,8 @@ export function jsdocTransformer(
                 if (defineTag.type !== undefined) {
                   moduleTypeTranslator.error(
                       varStmt,
-                      `incorrect type in @define: found '${defineTag.type}' required '${typeStr}'`);
+                      `incorrect type in @define: written Closure type was '${
+                          defineTag.type}' but TypeScript inferred '${typeStr}'`);
                 }
                 defineTag.type = typeStr;
               }

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -16,7 +16,7 @@
 // test_files/jsdoc/jsdoc.ts(77,1): warning TS0: @extends annotations are redundant with TypeScript equivalents
 // @implements annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
-// test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: found 'boolean' required 'number'
+// test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: written Closure type was 'boolean' but TypeScript inferred 'number'
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -178,4 +178,8 @@ const BAD_DEFINE = 42;
 /**
  * @define {boolean}
  */
-const MISSING_DEFINE = false;
+const TS_INFERRED_DEFINE = false;
+/**
+ * @define {string}
+ */
+const TS_EXPLICIT_DEFINE = 'y';

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -16,6 +16,7 @@
 // test_files/jsdoc/jsdoc.ts(77,1): warning TS0: @extends annotations are redundant with TypeScript equivalents
 // @implements annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
+// test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: found 'boolean' required 'number'
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -169,4 +170,8 @@ class Foo {
 /**
  * @define {string}
  */
-const FOO = 'x';
+const GOOD_DEFINE = 'x';
+/**
+ * @define {boolean}
+ */
+const BAD_DEFINE = 42;

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -17,8 +17,6 @@
 // @implements annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: found 'boolean' required 'number'
-// test_files/jsdoc/jsdoc.ts(142,1): warning TS0: malformed @define tag: ""
-// test_files/jsdoc/jsdoc.ts(145,1): error TS0: incorrect type in @define: found 'undefined' required 'boolean'
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -17,6 +17,8 @@
 // @implements annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: found 'boolean' required 'number'
+// test_files/jsdoc/jsdoc.ts(142,1): warning TS0: malformed @define tag: ""
+// test_files/jsdoc/jsdoc.ts(145,1): error TS0: incorrect type in @define: found 'undefined' required 'boolean'
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -172,6 +174,10 @@ class Foo {
  */
 const GOOD_DEFINE = 'x';
 /**
- * @define {boolean}
+ * @define {number}
  */
 const BAD_DEFINE = 42;
+/**
+ * @define {boolean}
+ */
+const MISSING_DEFINE = false;

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -166,3 +166,7 @@ Polymer({ behaviors: [(/** @type {?} */ ('test'))] });
  */
 class Foo {
 }
+/**
+ * @define {string}
+ */
+const FOO = 'x';

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -16,7 +16,7 @@
 // test_files/jsdoc/jsdoc.ts(77,1): warning TS0: @extends annotations are redundant with TypeScript equivalents
 // @implements annotations are redundant with TypeScript equivalents
 // test_files/jsdoc/jsdoc.ts(84,3): warning TS0: @constructor annotations are redundant with TypeScript equivalents
-// test_files/jsdoc/jsdoc.ts(140,1): error TS0: incorrect type in @define: written Closure type was 'boolean' but TypeScript inferred 'number'
+// test_files/jsdoc/jsdoc.ts(132,1): warning TS0: the type annotation on @define is redundant with its TypeScript type, remove the {...} part
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -167,19 +167,13 @@ Polymer({ behaviors: [(/** @type {?} */ ('test'))] });
  */
 class Foo {
 }
-/**
- * @define {string}
- */
-const GOOD_DEFINE = 'x';
-/**
- * @define {number}
- */
-const BAD_DEFINE = 42;
+/** @type {number} */
+const DEFINE_WITH_JSDOC_TYPE = 42;
 /**
  * @define {boolean}
  */
-const TS_INFERRED_DEFINE = false;
+const DEFINE_WITH_INFERRED_TYPE = false;
 /**
  * @define {string}
  */
-const TS_EXPLICIT_DEFINE = 'y';
+const DEFINE_WITH_DECLARED_TYPE = 'y';

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -130,21 +130,16 @@ Polymer({behaviors: ['test' as any]});
 class Foo<T1, T2> {}
 
 /**
- * @define {string}
- */
-const GOOD_DEFINE = 'x';
-
-/**
  * @define {boolean}
  */
-const BAD_DEFINE = 42;
+const DEFINE_WITH_JSDOC_TYPE = 42;
 
 /**
  * @define
  */
-const TS_INFERRED_DEFINE = false;
+const DEFINE_WITH_INFERRED_TYPE = false;
 
 /**
  * @define
  */
-const TS_EXPLICIT_DEFINE: string = 'y';
+const DEFINE_WITH_DECLARED_TYPE: string = 'y';

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -128,3 +128,8 @@ Polymer({behaviors: ['test' as any]});
  * @template T2 Another user comment.
  */
 class Foo<T1, T2> {}
+
+/**
+ * @define {string}
+ */
+const FOO = 'x';

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -142,4 +142,9 @@ const BAD_DEFINE = 42;
 /**
  * @define
  */
-const MISSING_DEFINE = false;
+const TS_INFERRED_DEFINE = false;
+
+/**
+ * @define
+ */
+const TS_EXPLICIT_DEFINE: string = 'y';

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -138,3 +138,8 @@ const GOOD_DEFINE = 'x';
  * @define {boolean}
  */
 const BAD_DEFINE = 42;
+
+/**
+ * @define
+ */
+const MISSING_DEFINE = false;

--- a/test_files/jsdoc/jsdoc.ts
+++ b/test_files/jsdoc/jsdoc.ts
@@ -132,4 +132,9 @@ class Foo<T1, T2> {}
 /**
  * @define {string}
  */
-const FOO = 'x';
+const GOOD_DEFINE = 'x';
+
+/**
+ * @define {boolean}
+ */
+const BAD_DEFINE = 42;


### PR DESCRIPTION
Instead, just trust whatever type is specified in @define, which should be either string, number, or boolean.

This is a blocker for rolling out the new module-compatible style of `goog.define` to TypeScript code.