### PR TITLE
fix(externs): add GlobalFetch and WindowOrWorkerGlobalScope

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -86,3 +86,9 @@ var SymbolConstructor;
  * @constructor
  */
 function bigintPlaceholder() {}
+
+/** @typedef {!Object} */
+var GlobalFetch;
+
+/** @typedef {!Window|WorkerGlobalScope} */
+var WindowOrWorkerGlobalScope;


### PR DESCRIPTION
It isn't clear what the correct type for GlobalFetch should be so leaving it as a plain Object.