### PR TITLE
fix(externs): Ensure WindowOrWorkerGlobalScope is a type that can be extended

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -90,5 +90,9 @@ function bigintPlaceholder() {}
 /** @typedef {!Object} */
 var GlobalFetch;
 
-/** @typedef {!Window|WorkerGlobalScope} */
+/**
+ * @interface
+ * @extends{WorkerGlobalScope}
+ * @extends{Window}
+ */
 var WindowOrWorkerGlobalScope;


### PR DESCRIPTION
Some typings declare interfaces that extend WindowOrWorkerGlobalScope. Closure compiler does not support interfaces that extend type unions so instead declare WindowOrWorkerGlobalScope as an interface that extends Window and WorkerGlobalScope. This has the effect of creating a type with the union of all properties in these types. The correct type would instead be the intersection of these two types, but that doesn't appear to be possible while still supporting extending the type.