### PR TITLE
remove direct dependencies on node builtin modules

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -18,6 +18,7 @@ ts_library(
         "main.ts",
         "module_type_translator.ts",
         "modules_manifest.ts",
+        "path.ts",
         "transformer_util.ts",
         "tsickle.ts",
         "type_translator.ts",

--- a/src/cli_support.ts
+++ b/src/cli_support.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as assert from 'assert';
-import * as path from 'path';
+import * as path from './path';
 
 /**
  * asserts that the given fileName is an absolute path.
@@ -16,7 +15,9 @@ import * as path from 'path';
  * paths before handing them over to TypeScript.
  */
 export function assertAbsolute(fileName: string) {
-  assert(path.isAbsolute(fileName), `expected ${JSON.stringify(fileName)} to be absolute`);
+  if (!path.isAbsolute(fileName)) {
+    throw new Error(`expected ${JSON.stringify(fileName)} to be absolute`);
+  }
 }
 
 /**

--- a/src/googmodule.ts
+++ b/src/googmodule.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as path from 'path';
 import * as ts from 'typescript';
 
 import {ModulesManifest} from './modules_manifest';
+import * as path from './path';
 import {createNotEmittedStatementWithComments, createSingleQuoteStringLiteral,} from './transformer_util';
 
 export interface GoogModuleProcessorHost {

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview Path manipulation functions.
+ * These are the functions exposed by nodejs in the 'path' module.
+ *
+ * But we actually use the TypeScript path-manipulation logic because:
+ * 1) we want the exact same behaviors as TS;
+ * 2) we don't depend on node's 'path' module when running under a browser
+ * So we poke into their private API for these.
+ */
+
+import * as ts from 'typescript';
+
+declare module 'typescript' {
+  function isRootedDiskPath(path: string): boolean;
+  function combinePaths(...paths: string[]): string;
+  function getDirectoryPath(path: string): string;
+  function convertToRelativePath(
+      absoluteOrRelativePath: string, basePath: string,
+      getCanonicalFileName: (path: string) => string): string
+}
+
+export function isAbsolute(path: string): boolean {
+  return ts.isRootedDiskPath(path);
+}
+
+export function join(p1: string, p2: string): string {
+  return ts.combinePaths(p1, p2);
+}
+
+export function dirname(path: string): string {
+  return ts.getDirectoryPath(path);
+}
+
+export function relative(base: string, rel: string): string {
+  return ts.convertToRelativePath(rel, base, p => p);
+}
+
+export function normalize(path: string): string {
+  return ts.sys.resolvePath(path);
+}

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as path from 'path';
 import * as ts from 'typescript';
 
 import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
+import * as path from './path';
 import {getIdentifierText, hasModifierFlag, isAmbient} from './transformer_util';
 
 /**
@@ -672,8 +672,8 @@ export class TypeTranslator {
       const params = this.convertParams(ctors[0], decl.parameters);
       const paramsStr = params.length ? (', ' + params.join(', ')) : '';
       const constructedType = this.translate(ctors[0].getReturnType());
-      const constructedTypeStr = constructedType[0] == '!' ?
-        constructedType.substring(1) : constructedType;
+      const constructedTypeStr =
+          constructedType[0] == '!' ? constructedType.substring(1) : constructedType;
       // In the specific case of the "new" in a function, the correct Closure
       // type is:
       //


### PR DESCRIPTION
For 'assert', just replace it with a throw.

For 'path', use the TypeScript's path manipulation functions.  These
are likely better than using node's path functions anyway because we
interact heavily with TypeScript and using their functions ensures we
match.  On the downside, we must access internal functions to do this.

This is a step towards making it possible to run tsickle in a browser
playground.