### PR TITLE
always emit type aliases to closure

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -657,9 +657,6 @@ export function jsdocTransformer(
         // namespaces, the two emits would conflict if tsickle emitted both.
         const sym = moduleTypeTranslator.mustGetSymbolAtLocation(typeAlias.name);
         if (sym.flags & ts.SymbolFlags.Value) return [];
-        // Type aliases are always emitted as the resolved underlying type, so there is no need to
-        // emit anything, except for exported types.
-        if (!transformerUtil.hasModifierFlag(typeAlias, ts.ModifierFlags.Export)) return [];
         if (!shouldEmitExportsAssignments()) return [];
 
         const typeName = typeAlias.name.getText();
@@ -670,23 +667,36 @@ export function jsdocTransformer(
             moduleTypeTranslator.symbolsToAliasedNames, typeAlias.typeParameters);
         const typeStr =
             host.untyped ? '?' : moduleTypeTranslator.typeToClosure(typeAlias, undefined);
-        // In the case of an export, we cannot emit a `export var foo;` because TypeScript drops
-        // exports that are never assigned values, and Closure requires us to not assign values to
-        // typedef exports. Introducing a new local variable and exporting it can cause bugs due to
-        // name shadowing and confusing TypeScript's logic on what symbols and types vs values are
-        // exported. Mangling the name to avoid the conflicts would be reasonably clean, but would
-        // require a two pass emit to first find all type alias names, mangle them, and emit the use
-        // sites only later. With that, the fix here is to never emit type aliases, but always
-        // resolve the alias and emit the underlying type (fixing references in the local module,
-        // and also across modules). For downstream JavaScript code that imports the typedef, we
-        // emit an "export.Foo;" that declares and exports the type, and for TypeScript has no
-        // impact.
+
+        // We want to emit a @typedef.  They are a bit weird because they are 'var' statements
+        // that have no value.
         const tags = moduleTypeTranslator.getJSDoc(typeAlias, /* reportWarnings */ true);
         tags.push({tagName: 'typedef', type: typeStr});
-        const decl = ts.setSourceMapRange(
-            ts.createStatement(ts.createPropertyAccess(
-                ts.createIdentifier('exports'), ts.createIdentifier(typeName))),
-            typeAlias);
+        const isExported = transformerUtil.hasModifierFlag(typeAlias, ts.ModifierFlags.Export);
+        let decl: ts.Statement;
+        if (isExported) {
+          // Given: export type T = ...;
+          // We cannot emit `export var foo;` and let TS generate from there because TypeScript
+          // drops exports that are never assigned values, and Closure requires us to not assign
+          // values to typedef exports. Introducing a new local variable and exporting it can cause
+          // bugs due to name shadowing and confusing TypeScript's logic on what symbols and types
+          // vs values are exported. Mangling the name to avoid the conflicts would be reasonably
+          // clean, but would require a two pass emit to first find all type alias names, mangle
+          // them, and emit the use sites only later.
+          // So we produce: exports.T;
+          decl = ts.createStatement(ts.createPropertyAccess(
+              ts.createIdentifier('exports'), ts.createIdentifier(typeName)));
+        } else {
+          // Given: type T = ...;
+          // We produce: var T;
+          // Note: not const, because 'const Foo;' is illegal;
+          // not let, because we want hoisting behavior for types.
+          decl = ts.createVariableStatement(
+              /* modifiers */ undefined,
+              ts.createVariableDeclarationList(
+                  [ts.createVariableDeclaration(ts.createIdentifier(typeName))]));
+        }
+        decl = ts.setSourceMapRange(decl, typeAlias);
         addCommentOn(decl, tags, jsdoc.TAGS_CONFLICTING_WITH_TYPE);
         return [decl];
       }

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -39,6 +39,8 @@ class Extends extends Super {
      */
     interfaceFunc() { }
 }
+/** @typedef {?} */
+var TypeAlias;
 class ImplementsTypeAlias {
     /**
      * @return {?}
@@ -71,6 +73,8 @@ if (false) {
     /** @type {?} */
     ZoneImplementsInterface.prototype.zone;
 }
+/** @typedef {?} */
+var ZoneAlias;
 class ZoneImplementsAlias {
 }
 if (false) {

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,6 +1,7 @@
 // test_files/class/class.ts(44,1): warning TS0: omitting interface deriving from class: Class
 // test_files/class/class.ts(124,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 // test_files/class/class.ts(126,1): warning TS0: omitting heritage reference to a type/value conflict: Zone
+// test_files/class/class.ts(129,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 // test_files/class/class.ts(130,1): warning TS0: omitting heritage reference to a type/value conflict: ZoneAlias
 /**
  * @fileoverview added by tsickle
@@ -185,6 +186,8 @@ class AbstractClassExtendsClass extends Class {
  */
 class AbstractClassExtendsAbstractClass extends AbstractClass {
 }
+/** @typedef {!Interface} */
+var TypeAlias;
 /**
  * @implements {Interface}
  * @extends {Class}
@@ -227,6 +230,8 @@ if (false) {
     /** @type {string} */
     ZoneImplementsInterface.prototype.zone;
 }
+/** @typedef {?} */
+var ZoneAlias;
 class ZoneImplementsAlias {
 }
 if (false) {

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -50,6 +50,8 @@ function classDecorator(t) {
 function classAnnotation(t) {
     return t;
 }
+/** @typedef {!Map<string, number>} */
+var LocalTypeAlias;
 class DecoratorTest {
     /**
      * @param {!Array<?>} a

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -54,3 +54,7 @@ function createFoo() {
 exports.createFoo = createFoo;
 /** @typedef {!tsickle_export_helper_3_4.Foo} */
 exports.Foo; // re-export typedef
+/** @typedef {string} */
+var LocalType;
+/** @typedef {!LocalType} */
+exports.LocalType; // re-export typedef

--- a/test_files/export/export.ts
+++ b/test_files/export/export.ts
@@ -28,3 +28,8 @@ export function createFoo(): Foo {
 }
 
 export {Foo};
+
+// A type declaration that isn't immediately marked with 'export'
+// should still be possible to export.
+type LocalType = string;
+export {LocalType};

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -13,3 +13,5 @@ const tsickle_type_alias_declare_1 = goog.requireType("test_files.type_alias_imp
 class Z {
 }
 exports.Z = Z;
+/** @typedef {(!tsickle_type_alias_declare_1.X|!Z)} */
+var DefaultExport;

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -6,7 +6,11 @@ goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };
 module = module;
 exports = {};
+/** @typedef {?} */
+var MyType;
 /** @type {?} */
 var y = 3;
+/** @typedef {?} */
+var Recursive;
 /** @typedef {?} */
 exports.ExportedType;

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -6,6 +6,8 @@ goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };
 module = module;
 exports = {};
+/** @typedef {number} */
+var MyType;
 /** @type {number} */
 var y = 3;
 /** @typedef {{value: number, next: ?}} */


### PR DESCRIPTION
Before, we tried to be clever and for
  export type X = ...
we'd emit something, but then for just
  type X = ...
without an export, we'd skip emit for Closure.

But that trivially fails when code is like
  type X = ...
  export {X};
where the Closure emit for the export needs to refer to the "local-only" X.