### PR TITLE
pin to an old version of bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Example:
 
 ## Development
 
+### Bazel install
+
+We use [bazel](https://bazel.build/) to build, and are pinned to an old version
+of it in `package.json`. So unless you have that specific version of bazel installed,
+you should run run `yarn bazel` instead of `bazel` in any of the below commands.
+
 ### One-time setup
 
 Run `bazel run @nodejs//:yarn --script_path=yarn_install.sh && ./yarn_install.sh`

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typescript": "~3.4.1"
   },
   "devDependencies": {
+    "@bazel/bazel": "^0.24.0",
     "@bazel/typescript": "^0.24.1",
     "@types/diff-match-patch": "^1.0.32",
     "@types/glob": "5.0.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@bazel/bazel-darwin_x64@0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.24.1.tgz#11479d0548d83fea22e664452d3e70c5f2edf94e"
+  integrity sha512-EF2WlPIQeq4zhkwwSCDJncG/rA1C2xnjUynabzB04KOxEBj0lveqYLgoCvs6L3Y+1vp2TQJmKGVEG6GpYb4uUA==
+
+"@bazel/bazel-linux_x64@0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.24.1.tgz#59c61c4ed885fd7ceed1bc9d605db563a51b83bd"
+  integrity sha512-oFLpfUOzZK4VSOM49FMJjb5UOJ5HXpTZ+zBOVO0hfK+oAkRaRfZjQZoKm6wa67MxfvU4tP/LDWcw7uj6swaGLw==
+
+"@bazel/bazel-win32_x64@0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.24.1.tgz#ebc7b9958a5d0bb5ccca761852bcc750d07ec343"
+  integrity sha512-s+zFYNawvzDLnb0TBY4LmkT+8ZfjMJ6/dyVnH6w8Q24mevnJqTBflcPJUlXoLRCAtaK/S3+1KOfKPccIwDNDDg==
+
+"@bazel/bazel@^0.24.0":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel/-/bazel-0.24.1.tgz#15380c4d5945de47c7be1e3a83e9a8d1607aa33b"
+  integrity sha512-iTTUqdI2dX4S+fQOGbhr84jRRv9FbYr8GX3L69Z/HurgcDrgErOKo1LGtOuSYqZYaEvQ+ZpV0aP7OzaUsv59WA==
+  optionalDependencies:
+    "@bazel/bazel-darwin_x64" "0.24.1"
+    "@bazel/bazel-linux_x64" "0.24.1"
+    "@bazel/bazel-win32_x64" "0.24.1"
+
 "@bazel/typescript@^0.24.1":
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.24.1.tgz#3efdc085c122939b2dd161b7ff589454c50edffc"


### PR DESCRIPTION
Newer versions of bazel break the tsickle build.  To work around for
now, pin to a version that is known to work.