### PR TITLE
don't emit type aliases when they conflict with module imports

### DIFF
--- a/src/decorator_downlevel_transformer.ts
+++ b/src/decorator_downlevel_transformer.ts
@@ -30,7 +30,7 @@
 import * as ts from 'typescript';
 
 import {getDecoratorDeclarations} from './decorators';
-import {getAllLeadingComments, visitEachChild} from './transformer_util';
+import {getAllLeadingComments, symbolIsValue, visitEachChild} from './transformer_util';
 
 /**
  * Returns true if the given decorator should be downleveled.
@@ -368,11 +368,7 @@ export function decoratorDownlevelTransformer(
       if (!sym) return undefined;
       // Check if the entity name references a symbol that is an actual value. If it is not, it
       // cannot be referenced by an expression, so return undefined.
-      let symToCheck = sym;
-      if (symToCheck.flags & ts.SymbolFlags.Alias) {
-        symToCheck = typeChecker.getAliasedSymbol(symToCheck);
-      }
-      if (!(symToCheck.flags & ts.SymbolFlags.Value)) return undefined;
+      if (!symbolIsValue(typeChecker, sym)) return undefined;
 
       if (ts.isIdentifier(name)) {
         // If there's a known import name for this symbol, use it so that the import will be

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -37,6 +37,18 @@ export function getIdentifierText(identifier: ts.Identifier): string {
   return unescapeName(identifier.escapedText);
 }
 
+/**
+ * Returns true if the given symbol refers to a value (as distinct from a type).
+ *
+ * Expands aliases, which is important for the case where
+ *   import * as x from 'some-module';
+ * and x is now a value (the module object).
+ */
+export function symbolIsValue(tc: ts.TypeChecker, sym: ts.Symbol): boolean {
+  if (sym.flags & ts.SymbolFlags.Alias) sym = tc.getAliasedSymbol(sym);
+  return (sym.flags & ts.SymbolFlags.Value) !== 0;
+}
+
 /** Returns a dot-joined qualified name (foo.bar.Baz). */
 export function getEntityNameText(name: ts.EntityName): string {
   if (ts.isIdentifier(name)) {

--- a/test_files/type_and_value/type_and_value.ts
+++ b/test_files/type_and_value/type_and_value.ts
@@ -17,3 +17,7 @@ let useAsType: conflict.TypeAndValue;
 
 // Use a templatized user-defined interface/value pair as a type.
 let useAsTypeTemplatized: conflict.TemplatizedTypeAndValue<string>;
+
+// Construct a conflict between the module import and a type.
+// We should not emit the type in that case.
+type conflict = string;


### PR DESCRIPTION
In code like

```
import * as x from 'y';
type x = ...;
```

We don't want to emit a `@typedef` for `x`, because it conflicts with
the module import.  We already tried to avoid this problem by checking
whether `x` was both a type and a value, but in this case, `x` is
both a type and an *alias* to the module, and the value-ness of `x`
is on the other side of the alias.