### PR TITLE
make writeFile parameter non-optional

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,7 @@ function loadTscConfig(args: string[]):
  */
 export function toClosureJS(
     options: ts.CompilerOptions, fileNames: string[], settings: Settings,
-    writeFile?: ts.WriteFileCallback): tsickle.EmitResult {
+    writeFile: ts.WriteFileCallback): tsickle.EmitResult {
   // Use absolute paths to determine what files to process since files may be imported using
   // relative or absolute paths
   const absoluteFileNames = fileNames.map(i => path.resolve(i));
@@ -187,7 +187,7 @@ export function toClosureJS(
       emittedFiles: [],
     };
   }
-  return tsickle.emit(program, transformerHost, undefined, writeFile);
+  return tsickle.emit(program, transformerHost, writeFile);
 }
 
 function main(args: string[]): number {

--- a/test/decorator_downlevel_transformer_test.ts
+++ b/test/decorator_downlevel_transformer_test.ts
@@ -60,7 +60,7 @@ describe('decorator_downlevel_transformer', () => {
 
     const files = new Map<string, string>();
     const {diagnostics} = tsickle.emit(
-        program, transformerHost, undefined, (path, contents) => {}, undefined, undefined,
+        program, transformerHost, (path, contents) => {}, undefined, undefined, undefined,
         {beforeTs: [createAstPrintingTransform(files)]});
 
     if (!allowErrors) {

--- a/test/golden_tsickle_test.ts
+++ b/test/golden_tsickle_test.ts
@@ -187,7 +187,7 @@ testFn('golden tests with transformer', () => {
         }
       }
       const {diagnostics, externs} =
-          tsickle.emit(program, transformerHost, targetSource, (fileName: string, data: string) => {
+          tsickle.emit(program, transformerHost, (fileName: string, data: string) => {
             if (test.isDeclarationTest) {
               // Only compare .d.ts files for declaration tests.
               if (!fileName.endsWith('.d.ts')) return;
@@ -199,7 +199,7 @@ testFn('golden tests with transformer', () => {
             // we don't throw when we generate them, but if we're in a .declaration test,
             // we only care about the .d.ts files
             tscOutput.set(fileName, data);
-          });
+          }, targetSource);
       for (const d of diagnostics) allDiagnostics.add(d);
       const diagnosticsByFile = new Map<string, ts.Diagnostic[]>();
       for (const d of allDiagnostics) {

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -409,10 +409,9 @@ export function compileWithTransfromer(
   };
 
   const files = new Map<string, string>();
-  const {diagnostics, externs} =
-      tsickle.emit(program, transformerHost, undefined, (path, contents) => {
-        files.set(path, contents);
-      });
+  const {diagnostics, externs} = tsickle.emit(program, transformerHost, (path, contents) => {
+    files.set(path, contents);
+  });
 
   expectDiagnosticsEmpty(diagnostics);
   return {files, externs};

--- a/test/tsickle_test.ts
+++ b/test/tsickle_test.ts
@@ -53,10 +53,11 @@ describe('emitWithTsickle', () => {
     };
     const jsSources: {[fileName: string]: string} = {};
     tsickle.emit(
-        program, tsickleHost, /* sourceFile */ undefined,
+        program, tsickleHost,
         (fileName: string, data: string) => {
           jsSources[path.relative(tsCompilerOptions.rootDir!, fileName)] = data;
         },
+        /* sourceFile */ undefined,
         /* cancellationToken */ undefined, /* emitOnlyDtsFiles */ undefined, customTransformers);
     return jsSources;
   }


### PR DESCRIPTION
In my recent refactorings of the tsickle.emit function, I removed the
CompilerHost parameter.  The function used to accept an optional
writeFile callback, which would fallback to the CompilerHost.writeFile.
When I removed CompilerHost I made the writeFile usage optional.

However, it is important that we always intercept writeFile, because we
use it to add the clutz dts aliases; if a caller to tsickle.emit doesn't
provide writeFile we would silently drop that.  The fix is to make this
parameter non-optional, which also improves some of the call sites
(which mostly provided it anyway).