### PR TITLE
export pathToModuleName

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -19,6 +19,8 @@ import {jsdocTransformer, removeTypeAssertions} from './jsdoc_transformer';
 import {ModulesManifest} from './modules_manifest';
 import {isDtsFileName} from './transformer_util';
 
+// Exported for users as a default impl of pathToModuleName.
+export {pathToModuleName} from './cli_support';
 // Retained here for API compatibility.
 export {getGeneratedExterns} from './externs';
 export {FileMap, ModulesManifest} from './modules_manifest';


### PR DESCRIPTION
This default implementation of pathToModuleName is sufficient for
ordinary users of tsickle.  We let users provide their own for bazel,
which provides a more complicated implementation (handling
bazel-bin vs bazel-genfiles etc.).

This will be used by browser tsickle.