### PR TITLE
rewrite toplevel comma expressions as statements

### DIFF
--- a/test/googmodule_test.ts
+++ b/test/googmodule_test.ts
@@ -327,12 +327,14 @@ var foo = bar;
   it('deduplicates module imports', () => {
     expectCommonJs('a/b.ts', `import Foo from 'goog:foo';
 import Foo2 from 'goog:foo';
-Foo, Foo2;
+Foo;
+Foo2;
 `).toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
 var goog_foo_1 = goog.require('foo');
 var goog_foo_2 = goog_foo_1;
-goog_foo_1, goog_foo_2;
+goog_foo_1;
+goog_foo_2;
 `);
   });
 

--- a/test_files/export_multi/export_multi.js
+++ b/test_files/export_multi/export_multi.js
@@ -1,0 +1,27 @@
+goog.module('test_files.export_multi.export_multi');
+var module = module || { id: 'test_files/export_multi/export_multi.ts' };
+module = module;
+exports = {};
+var _a;
+/**
+ *
+ * @fileoverview Some export forms that create multi-expression 'export'
+ * statements, which are illegal under Closure and must be rewritten.
+ *
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+/** @enum {string} */
+const Fruit = {
+    APPLE: 'apple',
+    PEAR: 'pear',
+    ORANGE: 'orange',
+};
+exports.APPLE = Fruit.APPLE;
+exports.PEAR = Fruit.PEAR;
+exports.ORANGE = Fruit.ORANGE;
+_a = {
+    a: 1,
+    b: 2
+};
+exports.a = _a.a;
+exports.b = _a.b;

--- a/test_files/export_multi/export_multi.ts
+++ b/test_files/export_multi/export_multi.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Some export forms that create multi-expression 'export'
+ * statements, which are illegal under Closure and must be rewritten.
+ */
+
+enum Fruit {
+  APPLE = 'apple',
+  PEAR = 'pear',
+  ORANGE = 'orange'
+}
+
+export const {
+  APPLE,
+  PEAR,
+  ORANGE,
+} = Fruit;
+
+export const {a, b} = {
+  a: 1,
+  b: 2
+};


### PR DESCRIPTION
In various contexts TypeScript emits code like:
  exports.a = 1, exports.b = 2;
Closure wants all export statements to be separate toplevel statements:
  exports.a = 1; exports.b = 2;
(note the semi).

This new transformer pass rewrites all toplevel comma expressions as
statements.  See the test for the sorts of code we saw that is affected
by this.