### PR TITLE
skip emit for properties named 'prototype'

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -339,6 +339,14 @@ function createClosurePropertyDeclaration(
         prop, `Skipping unnamed member:\n${escapeForComment(prop.getText())}`);
   }
 
+  if (name === 'prototype') {
+    // Code that declares a property named 'prototype' typically is doing something
+    // funny with the TS type system, and isn't actually interested in naming a
+    // a field 'prototype', as prototype has special meaning in JS.
+    return transformerUtil.createMultiLineComment(
+        prop, `Skipping illegal member name:\n${escapeForComment(prop.getText())}`);
+  }
+
   let type = mtt.typeToClosure(prop);
   // When a property is optional, e.g.
   //   foo?: string;

--- a/test_files/cast_extends/cast_extends.js
+++ b/test_files/cast_extends/cast_extends.js
@@ -1,5 +1,5 @@
-// test_files/cast_extends/cast_extends.ts(17,1): warning TS0: unhandled type flags: IncludesNonWideningType
-// test_files/cast_extends/cast_extends.ts(23,10): warning TS0: unhandled type flags: IncludesNonWideningType
+// test_files/cast_extends/cast_extends.ts(16,1): warning TS0: unhandled type flags: IncludesNonWideningType
+// test_files/cast_extends/cast_extends.ts(22,10): warning TS0: unhandled type flags: IncludesNonWideningType
 /**
  *
  * @fileoverview Reproduces an issue where tsickle would emit a cast for the "extends" claus, and
@@ -27,11 +27,6 @@ if (false) {
  */
 function Ctor() { }
 exports.Ctor = Ctor;
-if (false) {
-    /** @type {T} */
-    Ctor.prototype.prototype;
-    /* Skipping unhandled member: new(...args: Array<{}>): T;*/
-}
 /**
  * @template T
  * @param {!Ctor<T>} baseclazz

--- a/test_files/cast_extends/cast_extends.ts
+++ b/test_files/cast_extends/cast_extends.ts
@@ -11,7 +11,6 @@ interface MixedIn {
 
 export interface Ctor<T = {}> {
   new(...args: Array<{}>): T;
-  readonly prototype: T;
 }
 
 export function mix<T extends Someclass>(baseclazz: Ctor<T>): Ctor<T&MixedIn> {

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -57,6 +57,8 @@ if (false) {
      * @type {function(string): number}
      */
     TrickyInterface.prototype.hasSomeParamJsDoc;
+    /* Skipping illegal member name:
+    prototype: string;*/
     /* Skipping unhandled member: [offset: number]: number;*/
     /* Skipping unhandled member: (x: number): __ yuck __
           number;*/

--- a/test_files/interface/interface.ts
+++ b/test_files/interface/interface.ts
@@ -39,4 +39,7 @@ interface TrickyInterface {
    * @override
    */
   hasSomeParamJsDoc: (a: string) => number;
+
+  // You can't define a field named 'prototype' in Closure.
+  prototype: string;
 }


### PR DESCRIPTION
This would end up emitting Closure code like
  /** @type {string} */
  Foo.prototype.prototype;
which ends up confusing the compiler.