### PR TITLE
Test for docstrings on parameter properties.

### DIFF
--- a/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
+++ b/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.docs_on_ctor_param_properties.docs_on_ctor_param_properties');
+var module = module || { id: 'test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.ts' };
+module = module;
+exports = {};
+class Clazz {
+    /**
+     * @param {!Array<string>} id
+     * @param {!Array<string>=} parameterProperty
+     */
+    constructor(id, parameterProperty = []) {
+        this.id = id;
+        this.parameterProperty = parameterProperty;
+    }
+}
+exports.Clazz = Clazz;
+if (false) {
+    /** @type {!Array<string>} */
+    Clazz.prototype.id;
+    /**
+     * Here is a docstring for the parameter property.
+     * @type {!Array<string>}
+     */
+    Clazz.prototype.parameterProperty;
+}

--- a/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.ts
+++ b/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.ts
@@ -1,0 +1,9 @@
+export class Clazz {
+  constructor(
+      readonly id: string[],
+      /**
+       * Here is a docstring for the parameter property.
+       */
+      readonly parameterProperty: string[] = [],
+  ) {}
+}


### PR DESCRIPTION
Confirms that #571 is fixed by other means (likely as part of either the
property extraction or the move to transformers).