### PR TITLE
always obey decorator downlevelling flag

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -129,8 +129,8 @@ export function emit(
     tsickleSourceTransformers.push(jsdocTransformer(
         host, tsOptions, typeChecker, tsickleDiagnostics, thisTypeByAsyncFunction));
     tsickleSourceTransformers.push(enumTransformer(typeChecker, tsickleDiagnostics));
-    tsickleSourceTransformers.push(decoratorDownlevelTransformer(typeChecker, tsickleDiagnostics));
-  } else if (host.transformDecorators) {
+  }
+  if (host.transformDecorators) {
     tsickleSourceTransformers.push(decoratorDownlevelTransformer(typeChecker, tsickleDiagnostics));
   }
   const modulesManifest = new ModulesManifest();


### PR DESCRIPTION
If the caller asked us to transform Closure types, we accidentally
would *always* add the decorator downleveller, regardless of the
setting of the decorator downleveller flag.

Once nvIvy is done, we will be in a config where we want Closure
types transformed and decorator downlevelling off, which was
inexpressible due to the above bug.  The fix here is trivial.