### PR TITLE
only gitignore root node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependency directory
-node_modules
+/node_modules
 
 # WebStorm/IntelliJ directory
 .idea


### PR DESCRIPTION
This was necessary for git to show me that the vestigal test_ts24
dirs were no longer needed.