### PR TITLE
improve user visibility of heritage backoffs

### DIFF
--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -1,8 +1,8 @@
-// test_files/class/class.ts(44,1): warning TS0: omitting interface deriving from class: Class
+// test_files/class/class.ts(44,1): warning TS0: dropped interface extends class: Class
 // test_files/class/class.ts(124,1): warning TS0: type/symbol conflict for Zone, using {?} for now
-// test_files/class/class.ts(128,1): warning TS0: omitting heritage reference to a type/value conflict: Zone
+// test_files/class/class.ts(128,1): warning TS0: dropped implements of a type/value conflict: Zone
 // test_files/class/class.ts(131,1): warning TS0: type/symbol conflict for Zone, using {?} for now
-// test_files/class/class.ts(132,1): warning TS0: omitting heritage reference to a type/value conflict: ZoneAlias
+// test_files/class/class.ts(132,1): warning TS0: dropped implements of a type/value conflict: ZoneAlias
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -72,6 +72,7 @@ let interfaceExtendsInterface = { /**
     interfaceFunc2() { } };
 /**
  * @record
+ * tsickle: dropped interface extends class: Class
  */
 function InterfaceExtendsClass() { }
 if (false) {
@@ -221,6 +222,9 @@ abstractClassVar = new ClassExtendsAbstractClass();
  * @return {void}
  */
 function Zone() { }
+/**
+ * tsickle: dropped implements of a type/value conflict: Zone
+ */
 class ZoneImplementsInterface {
 }
 if (false) {
@@ -229,6 +233,9 @@ if (false) {
 }
 /** @typedef {?} */
 var ZoneAlias;
+/**
+ * tsickle: dropped implements of a type/value conflict: ZoneAlias
+ */
 class ZoneImplementsAlias {
 }
 if (false) {

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -1,4 +1,4 @@
-// test_files/extend_and_implement/extend_and_implement.ts(15,1): warning TS0: omitting @implements of a class: ClassInImplements
+// test_files/extend_and_implement/extend_and_implement.ts(15,1): warning TS0: dropped implements of class: ClassInImplements
 /**
  *
  * @fileoverview Reproduces a problem where tsickle would emit "\\@extends
@@ -25,6 +25,9 @@ class ClassInExtends {
         return 'a';
     }
 }
+/**
+ * tsickle: dropped implements of class: ClassInImplements
+ */
 class ExtendsAndImplementsClass extends ClassInExtends {
 }
 if (false) {

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -1,3 +1,5 @@
+// test_files/jsdoc_types/jsdoc_types.ts(36,1): warning TS0: dropped implements of blacklisted type: NeverTyped
+// test_files/jsdoc_types/jsdoc_types.ts(39,1): warning TS0: dropped implements of blacklisted type: NeverTypedTemplated<T>
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -53,6 +55,7 @@ let useNeverTyped2;
 let useNeverTypedTemplated;
 /**
  * Note: JSDoc should not reference NeverTyped because the type is blacklisted.
+ * tsickle: dropped implements of blacklisted type: NeverTyped
  */
 class ImplementsNeverTyped {
 }
@@ -62,6 +65,7 @@ if (false) {
 }
 /**
  * @template T
+ * tsickle: dropped implements of blacklisted type: NeverTypedTemplated<T>
  */
 class ImplementsNeverTypedTemplated {
 }

--- a/test_files/mixin/dtsdiagnostics.txt
+++ b/test_files/mixin/dtsdiagnostics.txt
@@ -1,2 +1,2 @@
 test_files/mixin/mixin.d.ts(1,1): warning TS0: unhandled type flags: IncludesNonWideningType
-test_files/mixin/mixin.d.ts(12,1): warning TS0: could not resolve supertype: MyMixin(HTMLElement)
+test_files/mixin/mixin.d.ts(12,31): warning TS0: dropped extends of non-symbol supertype: MyMixin(HTMLElement)

--- a/test_files/mixin/externs.js
+++ b/test_files/mixin/externs.js
@@ -21,6 +21,7 @@ function MixinConstructor() {}
 /** @type {string} */
 MyMixin.prototype.mixinProp;
 /**
+ * tsickle: dropped extends of non-symbol supertype: MyMixin(HTMLElement)
  * @constructor
  * @struct
  */

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -1,4 +1,4 @@
-// test_files/partial/partial.ts(7,1): warning TS0: omitting heritage reference to a type literal: Partial<Base>
+// test_files/partial/partial.ts(7,1): warning TS0: dropped implements of a type literal: Partial<Base>
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
@@ -15,6 +15,9 @@ if (false) {
     /** @type {string} */
     Base.prototype.foo;
 }
+/**
+ * tsickle: dropped implements of a type literal: Partial<Base>
+ */
 class Derived {
     /**
      * @return {void}


### PR DESCRIPTION
When tsickle decides to omit a user-provided 'extends' or 'implements',
put a comment in the source saying that it did so and why it did.

Also improve the text of these messages to be more readable for users.