### PR TITLE
fix(perf): cache symbol strings within modules.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -661,8 +661,7 @@ export function jsdocTransformer(
           stmts.push(commentHolder);
         }
 
-        const declList = ts.visitNode(varStmt.declarationList, visitor);
-        for (const decl of declList.declarations) {
+        for (const decl of varStmt.declarationList.declarations) {
           const localTags: jsdoc.Tag[] = [];
           if (tags) {
             // Add any tags and docs preceding the entire statement to the first variable.
@@ -693,8 +692,9 @@ export function jsdocTransformer(
               }
             }
           }
+          const newDecl = ts.visitNode(decl, visitor);
           const newStmt = ts.createVariableStatement(
-              varStmt.modifiers, ts.createVariableDeclarationList([decl], flags));
+              varStmt.modifiers, ts.createVariableDeclarationList([newDecl], flags));
           if (localTags.length) addCommentOn(newStmt, localTags, jsdoc.TAGS_CONFLICTING_WITH_TYPE);
           stmts.push(newStmt);
         }

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -98,6 +98,12 @@ export class ModuleTypeTranslator {
   symbolsToAliasedNames = new Map<ts.Symbol, string>();
 
   /**
+   * A cache for expensive symbol lookups, see TypeTranslator.symbolToString. Maps symbols to their
+   * Closure name in the current file scope.
+   */
+  private symbolToNameCache = new Map<ts.Symbol, string>();
+
+  /**
    * The set of module symbols requireTyped in the local namespace.  This tracks which imported
    * modules we've already added to additionalImports below.
    */
@@ -151,8 +157,9 @@ export class ModuleTypeTranslator {
     const translationContext = this.isForExterns ? this.sourceFile : context;
 
     const translator = new typeTranslator.TypeTranslator(
-        this.host, this.typeChecker, translationContext, this.host.typeBlackListPaths,
-        this.symbolsToAliasedNames, (sym: ts.Symbol) => this.ensureSymbolDeclared(sym));
+        this.host, this.typeChecker, translationContext, this.host.typeBlackListPaths || new Set(),
+        this.symbolsToAliasedNames, this.symbolToNameCache,
+        (sym: ts.Symbol) => this.ensureSymbolDeclared(sym));
     translator.isForExterns = this.isForExterns;
     translator.warn = msg => this.debugWarn(context, msg);
     return translator;

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -99,7 +99,7 @@ export class ModuleTypeTranslator {
 
   /**
    * A cache for expensive symbol lookups, see TypeTranslator.symbolToString. Maps symbols to their
-   * Closure name in the current file scope.
+   * Closure name in this file scope.
    */
   private symbolToNameCache = new Map<ts.Symbol, string>();
 

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -1,6 +1,6 @@
 // test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
-// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,3): warning TS0: emitting ? for conditional/substitution type
 // test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(3,14): warning TS0: var args type is not an object type
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,3): warning TS0: emitting ? for conditional/substitution type
 /**
  * @fileoverview added by tsickle
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -12,8 +12,8 @@ exports = {};
  * @type {function(?): ?}
  */
 let genericFnType = (/**
- * @param {T} x
- * @return {T}
+ * @param {?} x
+ * @return {?}
  */
 (x) => x);
 /** @type {function(new:?, ?)} */


### PR DESCRIPTION
tsickle has bad performance for certain specific patterns, union types
with many members that are declared in namespaces with many members.

TypeScript compiler expands unions eagerly, including literal type
members. E.g. `undefined|SomeEnum` gets represented as
`undefined|SomeEnum.A|SomeEnum.B|...`. We then generate the type for
each member and deduplicate. For large enums (in the wild we see >2000
members), this means we generate many symbolToString calls.

That wouldn't be so bad, but it turns out `symbolToString`, or rather
the TS API `symbolToEntityName` that it calls, can be very slow.

Consider this example:

    namespace foo {
      enum OurEnum {A, B, C, ...}
    }
    namespace foo {
      // more declarations
    }
    namespace foo {
      // even more declarations
    }
    ...

`symbolToEntityName` is called for each enum member, then gets the
parent symbol chain for the enum member, i.e. `[foo, OurEnum]` here, and
then for each declaration of `foo` inspects whether that particular
declaration is better to name the symbol (e.g. would have a more
accessible file name/path for the user, be shorter in the current scope,
etc.).

This looks esoteric, but it turns out this is exactly the kind of code
that Clutz generates for top level namespaces with many declarations in
separate files contained in them. We counted >100'000 declarations for a
specific root namespace, with enums with many members, causing multi
minute tsickle runtimes on very small sources.

The cache is a quick fix to avoid the duplicated work. It might be
possible to (a) avoid generating these in Clutz and (b) improve
performance of `symbolToEntityName`.