### PR TITLE
Update tslib #1084

### DIFF
--- a/third_party/tslib/tslib.js
+++ b/third_party/tslib/tslib.js
@@ -58,7 +58,7 @@ exports.__rest = function (s, e) {
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
         t[p] = s[p];
     if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0 && (/** @type {function((string|symbol)):boolean} */ (Object.prototype.propertyIsEnumerable)).call(s, p[i]))
             t[p[i]] = s[p[i]];
     return t;
 };

--- a/third_party/tslib/tslib.js
+++ b/third_party/tslib/tslib.js
@@ -58,7 +58,7 @@ exports.__rest = function (s, e) {
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
         t[p] = s[p];
     if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
             t[p[i]] = s[p[i]];
     return t;
 };
@@ -260,6 +260,17 @@ exports.__spread = function() {
   for (var ar = [], i = 0; i < arguments.length; i++)
     ar = ar.concat(exports.__read(arguments[i]));
   return ar;
+};
+
+/**
+ * @return {!Array}
+ */
+exports.__spreadArrays = function() {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
 };
 
 /**

--- a/third_party/tslib/tslib.js
+++ b/third_party/tslib/tslib.js
@@ -254,7 +254,7 @@ exports.__read = function(o, n) {
 };
 
 /**
- * @return {!Array}
+ * @type {function(...?):!Array}
  */
 exports.__spread = function() {
   for (var ar = [], i = 0; i < arguments.length; i++)
@@ -263,7 +263,7 @@ exports.__spread = function() {
 };
 
 /**
- * @return {!Array}
+ * @type {function(...!Array):!Array}
  */
 exports.__spreadArrays = function() {
     for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;


### PR DESCRIPTION
I have updated `__rest` and `__spreadArrays`. 
I'm not sure whether it is done right or not, when I feed it to Closure Compiler, it prints some warnings:

```
WARNING - [JSC_TYPE_MISMATCH] actual parameter 2 of Object.prototype.propertyIsEnumerable.call does not match formal parameter
found   : symbol
required: string
        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
```

```
WARNING - [JSC_WRONG_ARGUMENT_COUNT] Function module$exports$tslib.__spreadArrays: called with 2 argument(s). Function requires at least 0 argument(s) and no more than 0 argument(s).
window['a'] = tslib.__spreadArrays(Array(5), Array(6));
```

Are those safe to be ignored, or does it need some more annotations?