### PR TITLE
add more async test cases, simplify code

### DIFF
--- a/test_files/async_functions/async_functions.js
+++ b/test_files/async_functions/async_functions.js
@@ -8,26 +8,23 @@ module = module;
 exports = {};
 const tslib_1 = goog.require('tslib');
 /**
+ * Exercises various forms of async functions.  When TypeScript downlevels these functions, it
+ * inserts a reference to 'this' which then tickles a Closure check around whether 'this' has a
+ * known type.
+ */
+/**
  * @param {string} param
  * @return {!Promise<string>}
  * @this {*}
  */
 function asyncTopLevelFunction(param) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
-        /** @type {!Promise<string>} */
-        const p = new Promise((/**
-         * @param {function((undefined|string|!PromiseLike<string>)=): void} res
-         * @param {function(?=): void} rej
-         * @return {void}
-         */
-        (res, rej) => {
-            res(param);
-        }));
         /** @type {string} */
-        const s = yield p;
+        const s = yield 'a';
         return s;
     });
 }
+exports.asyncTopLevelFunction = asyncTopLevelFunction;
 /**
  * @this {!Container}
  * @param {string} param
@@ -35,37 +32,20 @@ function asyncTopLevelFunction(param) {
  */
 function asyncTopLevelFunctionWithThisType(param) {
     return tslib_1.__awaiter(this, void 0, void 0, /** @this {!Container} */ function* () {
-        /** @type {!Promise<string>} */
-        const p = new Promise((/**
-         * @param {function((undefined|string|!PromiseLike<string>)=): void} res
-         * @param {function(?=): void} rej
-         * @return {void}
-         */
-        (res, rej) => {
-            res(param);
-        }));
-        /** @type {string} */
-        const s = yield p;
+        /** @type {number} */
+        const s = yield 3;
         return s + this.field;
     });
 }
+exports.asyncTopLevelFunctionWithThisType = asyncTopLevelFunctionWithThisType;
 /** @type {function(string): !Promise<string>} */
 const asyncTopLevelArrowFunction = (/**
  * @param {string} param
  * @return {!Promise<string>}
  */
 (param) => tslib_1.__awaiter(this, void 0, void 0, function* () {
-    /** @type {!Promise<string>} */
-    const p = new Promise((/**
-     * @param {function((undefined|string|!PromiseLike<string>)=): void} res
-     * @param {function(?=): void} rej
-     * @return {void}
-     */
-    (res, rej) => {
-        res(param);
-    }));
-    /** @type {string} */
-    const s = yield p;
+    /** @type {number} */
+    const s = yield 3;
     return s + this.field;
 }));
 class Container {
@@ -92,17 +72,8 @@ class Container {
          * @return {!Promise<string>}
          */
         (param) => tslib_1.__awaiter(this, void 0, void 0, function* () {
-            /** @type {!Promise<string>} */
-            const p = new Promise((/**
-             * @param {function((undefined|string|!PromiseLike<string>)=): void} res
-             * @param {function(?=): void} rej
-             * @return {void}
-             */
-            (res, rej) => {
-                res(param);
-            }));
-            /** @type {string} */
-            const s = yield p;
+            /** @type {number} */
+            const s = yield 3;
             return s + this.field;
         }));
         /**
@@ -112,23 +83,49 @@ class Container {
          */
         function asyncFunctionInMethod(param) {
             return tslib_1.__awaiter(this, void 0, void 0, /** @this {!Container} */ function* () {
-                /** @type {!Promise<string>} */
-                const p = new Promise((/**
-                 * @param {function((undefined|string|!PromiseLike<string>)=): void} res
-                 * @param {function(?=): void} rej
-                 * @return {void}
-                 */
-                (res, rej) => {
-                    res(param);
-                }));
-                /** @type {string} */
-                const s = yield p;
+                /** @type {number} */
+                const s = yield 3;
                 return s + this.field;
             });
         }
     }
+    /**
+     * @return {!Promise<string>}
+     */
+    static asyncStaticMethod() {
+        return tslib_1.__awaiter(this, void 0, void 0, /** @this {!Container} */ function* () {
+            /** @type {string} */
+            const s = yield asyncTopLevelFunction('x');
+            return s + this.staticField;
+        });
+    }
 }
+Container.staticField = 's';
 if (false) {
+    /** @type {string} */
+    Container.staticField;
     /** @type {string} */
     Container.prototype.field;
 }
+/** @type {function(): !Promise<void>} */
+const asyncFnExpression = (/**
+ * @return {!Promise<void>}
+ */
+function f() {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () { });
+});
+/** @type {function(): !Promise<void>} */
+const asyncArrowFn = (/**
+ * @return {!Promise<void>}
+ */
+() => tslib_1.__awaiter(this, void 0, void 0, function* () { }));
+/**
+ * @return {function(): !Promise<number>}
+ */
+function toplevelContainingAsync() {
+    return (/**
+     * @return {!Promise<number>}
+     */
+    () => tslib_1.__awaiter(this, void 0, void 0, function* () { return 3; }));
+}
+exports.toplevelContainingAsync = toplevelContainingAsync;

--- a/test_files/async_functions/async_functions.ts
+++ b/test_files/async_functions/async_functions.ts
@@ -1,26 +1,26 @@
+/**
+ * Exercises various forms of async functions.  When TypeScript downlevels these functions, it
+ * inserts a reference to 'this' which then tickles a Closure check around whether 'this' has a
+ * known type.
+ */
+
 export {};
 
 async function asyncTopLevelFunction(param: string): Promise<string> {
-  const p = new Promise<string>((res, rej) => {
-    res(param);
-  });
-  const s = await p;
+  const s = await 'a';
   return s;
 }
 
+// Note: some Closure checks are only triggered when functions are exported.
+export {asyncTopLevelFunction, asyncTopLevelFunctionWithThisType};
+
 async function asyncTopLevelFunctionWithThisType(this: Container, param: string): Promise<string> {
-  const p = new Promise<string>((res, rej) => {
-    res(param);
-  });
-  const s = await p;
+  const s = await 3;
   return s + this.field;
 }
 
 const asyncTopLevelArrowFunction = async(param: string): Promise<string> => {
-  const p = new Promise<string>((res, rej) => {
-    res(param);
-  });
-  const s = await p;
+  const s = await 3;
   return s + this.field;
 };
 
@@ -34,18 +34,26 @@ class Container {
 
   containerMethod() {
     const asyncArrowFunctionInMethod = async(param: string): Promise<string> => {
-      const p = new Promise<string>((res, rej) => {
-        res(param);
-      });
-      const s = await p;
+      const s = await 3;
       return s + this.field;
     };
     async function asyncFunctionInMethod(param: string): Promise<string> {
-      const p = new Promise<string>((res, rej) => {
-        res(param);
-      });
-      const s = await p;
+      const s = await 3;
       return s + this.field;
     }
   }
+
+  static staticField = 's';
+
+  static async asyncStaticMethod() {
+    const s = await asyncTopLevelFunction('x');
+    return s + this.staticField;
+  }
+}
+
+const asyncFnExpression = async function f() {};
+const asyncArrowFn = async () => {};
+
+export function toplevelContainingAsync() {
+  return async () => 3;
 }


### PR DESCRIPTION
These additional cases came from some problematic google3 code,
as well as from Rado's reverted patch.

Also, we don't need any Promises to exercise the this-checking logic,
so remove them to make the tests easier to read.