### PR TITLE
Fix enum emit for constant string values.

### DIFF
--- a/src/enum_transformer.ts
+++ b/src/enum_transformer.ts
@@ -119,6 +119,13 @@ export function enumTransformer(typeChecker: ts.TypeChecker, diagnostics: ts.Dia
           if (typeof enumConstValue === 'number') {
             enumIndex = enumConstValue + 1;
             enumValue = ts.createLiteral(enumConstValue);
+          } else if (typeof enumConstValue === 'string') {
+            // tsickle does not care about string enum values. However TypeScript expects compile
+            // time constant enum values to be replaced with their constant expression, and e.g.
+            // doesn't emit imports for modules referenced in them. Because tsickle replaces the
+            // enum with an object literal, i.e. handles the enum transform, it must thus also do
+            // the const value substitution for strings.
+            enumValue = ts.createLiteral(enumConstValue);
           } else {
             // Non-numeric enum value (string or an expression).
             // Emit this initializer expression as-is.

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -93,8 +93,8 @@ EnumWithNonConstValues[EnumWithNonConstValues.Scheme] = 'Scheme';
 EnumWithNonConstValues[EnumWithNonConstValues.UserInfoRenamed] = 'UserInfoRenamed';
 /** @enum {string} */
 const StringEnum = {
-    STR: 'abc',
-    OTHER_STR: 'xyz',
+    STR: "abc",
+    OTHER_STR: "xyz",
 };
 /** @enum {number} */
 const StringKeyEnum = {
@@ -105,7 +105,7 @@ StringKeyEnum[StringKeyEnum['string key']] = 'string key';
 StringKeyEnum[StringKeyEnum['string key 2']] = 'string key 2';
 /** @enum {?} */
 const MixedEnum = {
-    STR: 'abc',
+    STR: "abc",
     NUM: 3,
     'string key': 4,
 };

--- a/test_files/enum_ref_import/enum_ref_import.js
+++ b/test_files/enum_ref_import/enum_ref_import.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * @fileoverview TypeScript statically resolves enum member values to constants, if possible, and
+ * directly emits those constants. Because of this, it also elides any imports for modules
+ * referenced in the expressions of such constant initializers.
+ *
+ * The test below reproduces a problem where a compile-time constant value (such as another enum's
+ * value) is only referenced in enum member. Because tsickle rewrites the enum to an object literal
+ * initializer (`var ValuesInInitializer = {ENUM_MEMBER: Enum.X}`), TypeScript would no longer
+ * replace the initializer with the constant value, but would still elide the import (for `Enum`
+ * here). Thus we'd emit code that references an undeclared symbol.
+ *
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.enum_ref_import.enum_ref_import');
+var module = module || { id: 'test_files/enum_ref_import/enum_ref_import.ts' };
+module = module;
+exports = {};
+const tsickle_exporter_1 = goog.requireType("test_files.enum_ref_import.exporter");
+/** @enum {string} */
+const ValuesInInitializer = {
+    ENUM_MEMBER: "x",
+};
+exports.ValuesInInitializer = ValuesInInitializer;

--- a/test_files/enum_ref_import/enum_ref_import.ts
+++ b/test_files/enum_ref_import/enum_ref_import.ts
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview TypeScript statically resolves enum member values to constants, if possible, and
+ * directly emits those constants. Because of this, it also elides any imports for modules
+ * referenced in the expressions of such constant initializers.
+ *
+ * The test below reproduces a problem where a compile-time constant value (such as another enum's
+ * value) is only referenced in enum member. Because tsickle rewrites the enum to an object literal
+ * initializer (`var ValuesInInitializer = {ENUM_MEMBER: Enum.X}`), TypeScript would no longer
+ * replace the initializer with the constant value, but would still elide the import (for `Enum`
+ * here). Thus we'd emit code that references an undeclared symbol.
+ */
+
+import {Enum} from './exporter';
+
+export enum ValuesInInitializer {
+  ENUM_MEMBER = Enum.X,
+}

--- a/test_files/enum_ref_import/exporter.js
+++ b/test_files/enum_ref_import/exporter.js
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview See enum_ref_import.ts.
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.enum_ref_import.exporter');
+var module = module || { id: 'test_files/enum_ref_import/exporter.ts' };
+module = module;
+exports = {};
+/** @enum {string} */
+const Enum = {
+    X: "x",
+};
+exports.Enum = Enum;

--- a/test_files/enum_ref_import/exporter.ts
+++ b/test_files/enum_ref_import/exporter.ts
@@ -1,0 +1,5 @@
+/** @fileoverview See enum_ref_import.ts. */
+
+export enum Enum {
+  X = 'x',
+}

--- a/test_files/export_multi/export_multi.js
+++ b/test_files/export_multi/export_multi.js
@@ -12,9 +12,9 @@ var _a;
  */
 /** @enum {string} */
 const Fruit = {
-    APPLE: 'apple',
-    PEAR: 'pear',
-    ORANGE: 'orange',
+    APPLE: "apple",
+    PEAR: "pear",
+    ORANGE: "orange",
 };
 exports.APPLE = Fruit.APPLE;
 exports.PEAR = Fruit.PEAR;


### PR DESCRIPTION
**MULTIPLE COMMITS** please review independently :-)

TypeScript resolves and inlines compile time constant values for enums.
In doing so, it also elides any imports that are only used in
initializer expressions that resolve to compile time constants:

    import {Constant} from 'somewhere';
    enum MyEnum { Val: Constant }

Here, if `Constant` really is a compile time constant string or number,
the import for `'somewhere'` will not be emitted.

tsickle transforms enums into variable/object literal pairs. Because
TypeScript still elides the import, but no longer does the constant
substitution, tsickle would emit expressions that referenced module
imports that weren't actually imported, causing reference errors.

This change fixes the problem by unconditionally replacing compile time
constant enum members with their known value.

Another possible fix is enabling the `--isolatedModules` compiler flag
that prevents this sort of inlining. We should possibly advise that, but
it also has other consequences (e.g. disallowing const enums in `.d.ts`
files), so fixing this bug in isolation is still worthwhile.