### PR TITLE
TS3.7 clutz alias

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -335,10 +335,14 @@ function addClutzAliases(
       // Use the localName for the export then, but publish under the external name.
       localName = declaration.propertyName.text;
     }
-    globalSymbols +=
-        `\t\texport {${localName} as module$contents$${clutzModuleName}_${symbol.name}}\n`;
-    nestedSymbols +=
-        `\t\texport {module$contents$${clutzModuleName}_${symbol.name} as ${symbol.name}}\n`;
+    const mangledName = `module$contents$${clutzModuleName}_${symbol.name}`;
+    globalSymbols += `\t\texport {${localName} as ${mangledName}}\n`;
+    // TODO(mprobst): Once tsickle is on TS3.7, the two lines below can be replaced with
+    // "export {localName};". However in TS3.5, localName resolves within the module, so
+    // exporting {localName} causes a circular definition error. The workaround is to import the
+    // mangled name.
+    nestedSymbols += `\t\timport ${localName}$clutz = ಠ_ಠ.clutz.${mangledName};\n`;
+    nestedSymbols += `\t\texport {${localName}$clutz as ${symbol.name}};\n`;
   }
 
   dtsFileContent += 'declare global {\n';

--- a/test_files/basic.declaration/basic.d.ts
+++ b/test_files/basic.declaration/basic.d.ts
@@ -8,8 +8,11 @@ declare global {
 		export {y as module$contents$test_files$basic$declaration$basic_y}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$basic$declaration$basic {
-		export {module$contents$test_files$basic$declaration$basic_incr as incr}
-		export {module$contents$test_files$basic$declaration$basic_x as x}
-		export {module$contents$test_files$basic$declaration$basic_y as y}
+		import incr$clutz = ಠ_ಠ.clutz.module$contents$test_files$basic$declaration$basic_incr;
+		export {incr$clutz as incr};
+		import x$clutz = ಠ_ಠ.clutz.module$contents$test_files$basic$declaration$basic_x;
+		export {x$clutz as x};
+		import y$clutz = ಠ_ಠ.clutz.module$contents$test_files$basic$declaration$basic_y;
+		export {y$clutz as y};
 	}
 }

--- a/test_files/class.declaration/class.d.ts
+++ b/test_files/class.declaration/class.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {Foo as module$contents$test_files$class$declaration$class_Foo}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$class$declaration$class {
-		export {module$contents$test_files$class$declaration$class_Foo as Foo}
+		import Foo$clutz = ಠ_ಠ.clutz.module$contents$test_files$class$declaration$class_Foo;
+		export {Foo$clutz as Foo};
 	}
 }

--- a/test_files/generics.declaration/generics.d.ts
+++ b/test_files/generics.declaration/generics.d.ts
@@ -28,12 +28,19 @@ declare global {
 		export {loggingIdentity as module$contents$test_files$generics$declaration$generics_loggingIdentity}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$generics$declaration$generics {
-		export {module$contents$test_files$generics$declaration$generics_DefaultGeneric as DefaultGeneric}
-		export {module$contents$test_files$generics$declaration$generics_GenericNumber as GenericNumber}
-		export {module$contents$test_files$generics$declaration$generics_HasThing as HasThing}
-		export {module$contents$test_files$generics$declaration$generics_Lengthwise as Lengthwise}
-		export {module$contents$test_files$generics$declaration$generics_LengthwiseContainer as LengthwiseContainer}
-		export {module$contents$test_files$generics$declaration$generics_identity as identity}
-		export {module$contents$test_files$generics$declaration$generics_loggingIdentity as loggingIdentity}
+		import DefaultGeneric$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_DefaultGeneric;
+		export {DefaultGeneric$clutz as DefaultGeneric};
+		import GenericNumber$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_GenericNumber;
+		export {GenericNumber$clutz as GenericNumber};
+		import HasThing$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_HasThing;
+		export {HasThing$clutz as HasThing};
+		import Lengthwise$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_Lengthwise;
+		export {Lengthwise$clutz as Lengthwise};
+		import LengthwiseContainer$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_LengthwiseContainer;
+		export {LengthwiseContainer$clutz as LengthwiseContainer};
+		import identity$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_identity;
+		export {identity$clutz as identity};
+		import loggingIdentity$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_loggingIdentity;
+		export {loggingIdentity$clutz as loggingIdentity};
 	}
 }

--- a/test_files/interface_and_type.declaration/interface_and_type.d.ts
+++ b/test_files/interface_and_type.declaration/interface_and_type.d.ts
@@ -7,7 +7,9 @@ declare global {
 		export {Foo as module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$interface_and_type$declaration$interface_and_type {
-		export {module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar as Bar}
-		export {module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo as Foo}
+		import Bar$clutz = ಠ_ಠ.clutz.module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar;
+		export {Bar$clutz as Bar};
+		import Foo$clutz = ಠ_ಠ.clutz.module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo;
+		export {Foo$clutz as Foo};
 	}
 }

--- a/test_files/nested_folder.declaration/inner_folder/nested.d.ts
+++ b/test_files/nested_folder.declaration/inner_folder/nested.d.ts
@@ -4,6 +4,7 @@ declare global {
 		export {x as module$contents$test_files$nested_folder$declaration$inner_folder$nested_x}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$nested_folder$declaration$inner_folder$nested {
-		export {module$contents$test_files$nested_folder$declaration$inner_folder$nested_x as x}
+		import x$clutz = ಠ_ಠ.clutz.module$contents$test_files$nested_folder$declaration$inner_folder$nested_x;
+		export {x$clutz as x};
 	}
 }

--- a/test_files/reexport.declaration/clutz_user.d.ts
+++ b/test_files/reexport.declaration/clutz_user.d.ts
@@ -1,0 +1,9 @@
+/** @fileoverview Tests that renamed exports get emitted with the correct clutz alias names. */
+
+export {};
+
+declare const moduleInternalName:
+    typeof ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$renamed_export_MOTHER;
+
+declare const exportedName:
+    typeof ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$renamed_export.MOTHER;

--- a/test_files/reexport.declaration/export.d.ts
+++ b/test_files/reexport.declaration/export.d.ts
@@ -12,9 +12,13 @@ declare global {
 		export {OTHER as module$contents$test_files$reexport$declaration$export_OTHER}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$export {
-		export {module$contents$test_files$reexport$declaration$export_NEW_NAME as NEW_NAME}
-		export {module$contents$test_files$reexport$declaration$export_NON_DIRECT as NON_DIRECT}
-		export {module$contents$test_files$reexport$declaration$export_NUM_CONSTANT as NUM_CONSTANT}
-		export {module$contents$test_files$reexport$declaration$export_OTHER as OTHER}
+		import NON_DIRECT_TO_BE_RENAMED$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_NEW_NAME;
+		export {NON_DIRECT_TO_BE_RENAMED$clutz as NEW_NAME};
+		import NON_DIRECT$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_NON_DIRECT;
+		export {NON_DIRECT$clutz as NON_DIRECT};
+		import NUM_CONSTANT$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_NUM_CONSTANT;
+		export {NUM_CONSTANT$clutz as NUM_CONSTANT};
+		import OTHER$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_OTHER;
+		export {OTHER$clutz as OTHER};
 	}
 }

--- a/test_files/reexport.declaration/import_reexport.d.ts
+++ b/test_files/reexport.declaration/import_reexport.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {NUM_CONSTANT as module$contents$test_files$reexport$declaration$import_reexport_NUM_CONSTANT}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$import_reexport {
-		export {module$contents$test_files$reexport$declaration$import_reexport_NUM_CONSTANT as NUM_CONSTANT}
+		import NUM_CONSTANT$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$import_reexport_NUM_CONSTANT;
+		export {NUM_CONSTANT$clutz as NUM_CONSTANT};
 	}
 }

--- a/test_files/reexport.declaration/renamed_export.d.ts
+++ b/test_files/reexport.declaration/renamed_export.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {OTHER as module$contents$test_files$reexport$declaration$renamed_export_MOTHER}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$renamed_export {
-		export {module$contents$test_files$reexport$declaration$renamed_export_MOTHER as MOTHER}
+		import OTHER$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$renamed_export_MOTHER;
+		export {OTHER$clutz as MOTHER};
 	}
 }


### PR DESCRIPTION
*** REVIEW COMMITS SEPARATELY ***

* Adjust Clutz alias emit for TypeScript 3.7's change to module visibility. https://github.com/microsoft/TypeScript/issues/34612
* Fix a bug with renamed module exports.