### PR TITLE
Handle @internal APIs.

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -56,6 +56,7 @@ export const baseCompilerOptions: ts.CompilerOptions = {
   allowJs: false,
   importHelpers: true,
   noEmitHelpers: true,
+  stripInternal: true,
   baseUrl: '.',
   paths: {
     // The compiler builtin 'tslib' library is looked up by name,

--- a/test_files/internal.declaration/internal.d.ts
+++ b/test_files/internal.declaration/internal.d.ts
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Test to reproduce that \@internal functions are not re-exported for Clutz. There
+ * should not be any `.d.ts` aliases generated for the function below.
+ */
+export {};

--- a/test_files/internal.declaration/internal.ts
+++ b/test_files/internal.declaration/internal.ts
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview Test to reproduce that \@internal functions are not re-exported for Clutz. There
+ * should not be any `.d.ts` aliases generated for the function below.
+ */
+
+/** @internal */
+export function internalFunction() {
+  return 42;
+}


### PR DESCRIPTION
With stripInternal set, TypeScript does not generate exports for APIs
marked as @internal, which tsickle should respect when generating Clutz
aliases.