### PR TITLE
Add "Generated from" comment to @fileoverview of generated JS files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ any of the below commands to make sure you are using the right version.
 - `ibazel test test:unit_test` executes the unit tests in watch mode (use `bazel test test:unit_test` for a single run),
 - `bazel test test:e2e_test` executes the e2e tests,
 - `bazel test test:golden_test` executes the golden tests,
-- `node check-format.js` checks the source code formatting using
+- `node check_format.js` checks the source code formatting using
   `clang-format`,
 - `yarn test` runs unit tests, e2e tests and checks the source code formatting.
 

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -125,7 +125,8 @@ export function emit(
   const tsickleSourceTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
   if (host.transformTypesToClosure) {
     // Only add @suppress {checkTypes} comments when also adding type annotations.
-    tsickleSourceTransformers.push(transformFileoverviewCommentFactory(tsickleDiagnostics));
+    tsickleSourceTransformers.push(
+        transformFileoverviewCommentFactory(tsOptions, tsickleDiagnostics));
     tsickleSourceTransformers.push(jsdocTransformer(
         host, tsOptions, typeChecker, tsickleDiagnostics, thisTypeByAsyncFunction));
     tsickleSourceTransformers.push(enumTransformer(typeChecker, tsickleDiagnostics));

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/abstract/abstract.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.abstract.abstract');

--- a/test_files/anon_class/anon_class.js
+++ b/test_files/anon_class/anon_class.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/anon_class/anon_class.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Verify we don't produce a type mentioning 'anonymous class'

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Reproduces an error that caused incorrect Automatic Semicolon Insertion.
+ * Generated from: test_files/arrow_fn.es5/arrow_fn_es5.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/arrow_fn.untyped/arrow_fn.untyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/arrow_fn/arrow_fn.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.arrow_fn.arrow_fn');

--- a/test_files/async_functions/async_functions.js
+++ b/test_files/async_functions/async_functions.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/async_functions/async_functions.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.async_functions.async_functions');

--- a/test_files/augment/user.js
+++ b/test_files/augment/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/augment/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.augment.user');

--- a/test_files/automatic_semicolon_insertion/asi.js
+++ b/test_files/automatic_semicolon_insertion/asi.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/automatic_semicolon_insertion/asi.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.automatic_semicolon_insertion.asi');

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/basic.untyped/basic.untyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.basic.untyped.basic.untyped');

--- a/test_files/blacklisted_ambient_external_module/user.js
+++ b/test_files/blacklisted_ambient_external_module/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Regression test for type-blacklisted ambient modules.
+ * Generated from: test_files/blacklisted_ambient_external_module/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.blacklisted_ambient_external_module.user');

--- a/test_files/cast_extends/cast_extends.js
+++ b/test_files/cast_extends/cast_extends.js
@@ -5,6 +5,7 @@
  * @fileoverview Reproduces an issue where tsickle would emit a cast for the "extends" claus, and
  * Closure would report an error due to the extends expression not resolving to a plain identifier.
  *
+ * Generated from: test_files/cast_extends/cast_extends.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.cast_extends.cast_extends');

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -1,6 +1,7 @@
 // test_files/class.untyped/class.ts(43,1): warning TS0: type/symbol conflict for Zone, using {?} for now
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/class.untyped/class.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.class.untyped.class');

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -5,6 +5,7 @@
 // test_files/class/class.ts(132,1): warning TS0: dropped implements of a type/value conflict: ZoneAlias
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/class/class.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This test exercises the various ways classes and interfaces can interact.

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/clutz.no_externs/strip_clutz_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.clutz.no_externs.strip_clutz_type');

--- a/test_files/clutz_type_value.no_externs/user.js
+++ b/test_files/clutz_type_value.no_externs/user.js
@@ -3,6 +3,7 @@
  * @fileoverview This test verifies that a type/value-conflict symbol that
  * occurs in a clutz file still can be used in a heritage clause.
  *
+ * Generated from: test_files/clutz_type_value.no_externs/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.clutz_type_value.no_externs.user');

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/coerce/coerce.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.coerce.coerce');

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/comments/comments.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.comments.comments');

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -3,6 +3,7 @@
 // test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,3): warning TS0: emitting ? for conditional/substitution type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.conditional_rest_tuple_type.conditional_rest_tuple_type');

--- a/test_files/conditional_type/conditional_type.js
+++ b/test_files/conditional_type/conditional_type.js
@@ -1,6 +1,7 @@
 // test_files/conditional_type/conditional_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/conditional_type/conditional_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.conditional_type.conditional_type');

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/ctors/ctors.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.ctors.ctors');

--- a/test_files/debugger/user.js
+++ b/test_files/debugger/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/debugger/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // TODO: the type below should be emitted as `outer.debugger.Foo`. However

--- a/test_files/declare/declare_nondts.js
+++ b/test_files/declare/declare_nondts.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare/declare_nondts.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare.declare_nondts');

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare.user');

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_class_ns/declare_class_ns.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_ns.declare_class_ns');

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_class_overloads/declare_class_overloads.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_class_overloads.declare_class_overloads');

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_export.untyped/declare_export.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_export.untyped.declare_export');

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_export/declare_export.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // All of the types/values declared in this file should

--- a/test_files/declare_export_dts/user.js
+++ b/test_files/declare_export_dts/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_export_dts/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_export_dts.user');

--- a/test_files/declare_import/export_default.js
+++ b/test_files/declare_import/export_default.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_import/export_default.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_import.export_default');

--- a/test_files/declare_import/exporter.js
+++ b/test_files/declare_import/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/declare_import/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.declare_import.exporter');

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -1,6 +1,7 @@
 // test_files/decorator/decorator.ts(13,66): warning TS0: should not emit a 'never' type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/decorator/decorator.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.decorator');

--- a/test_files/decorator/default_export.js
+++ b/test_files/decorator/default_export.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Tests using a default imported class for in a decorated ctor.
+ * Generated from: test_files/decorator/default_export.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.default_export');

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/decorator/external.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external');

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/decorator/external2.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.external2');

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -3,6 +3,7 @@
  * @fileoverview only_types only exports types, so TypeScript will elide the
  * import entirely.
  *
+ * Generated from: test_files/decorator/only_types.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator.only_types');

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/decorator_nested_scope/decorator_nested_scope.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/default/default.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.default.default');

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/doc_params/doc_params.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.doc_params.doc_params');

--- a/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
+++ b/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.docs_on_ctor_param_properties.docs_on_ctor_param_properties');

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/enum.untyped/enum.untyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.untyped.enum.untyped');

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -1,6 +1,7 @@
 // test_files/enum/enum.ts(2,7): warning TS0: should not emit a 'never' type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/enum/enum.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Line with a missing semicolon should not break the following enum.

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/enum/enum_user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum.enum_user');

--- a/test_files/enum_ref_import/enum_ref_import.js
+++ b/test_files/enum_ref_import/enum_ref_import.js
@@ -10,6 +10,7 @@
  * replace the initializer with the constant value, but would still elide the import (for `Enum`
  * here). Thus we'd emit code that references an undeclared symbol.
  *
+ * Generated from: test_files/enum_ref_import/enum_ref_import.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum_ref_import.enum_ref_import');

--- a/test_files/enum_ref_import/exporter.js
+++ b/test_files/enum_ref_import/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview See enum_ref_import.ts.
+ * Generated from: test_files/enum_ref_import/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.enum_ref_import.exporter');

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/enum_value_literal_type/enum_value_literal_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Note: if you only have one value in the enum, then the type of "x" below

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/export.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export');

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/export_helper.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper');

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/export_helper_2.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This file isn't itself a test case, but it is imported by the

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/export_helper_3.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_helper_3');

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/export_star_imported.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.export_star_imported');

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export/type_and_value.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export.type_and_value');

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_declare_namespace/export_declare_namespace.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.export_declare_namespace');

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_declare_namespace/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_declare_namespace.user');

--- a/test_files/export_equals.shim/export_equals.js
+++ b/test_files/export_equals.shim/export_equals.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_equals.shim/export_equals.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.shim.export_equals');

--- a/test_files/export_equals.shim/user.js
+++ b/test_files/export_equals.shim/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_equals.shim/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_equals.shim.user');

--- a/test_files/export_local_type/export_local_type.js
+++ b/test_files/export_local_type/export_local_type.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Regression test to ensure local type symbols can be exported.
+ * Generated from: test_files/export_local_type/export_local_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_local_type.export_local_type');

--- a/test_files/export_multi/export_multi.js
+++ b/test_files/export_multi/export_multi.js
@@ -8,6 +8,7 @@ var _a, _b;
  * @fileoverview Some export forms that create multi-expression 'export'
  * statements, which are illegal under Closure and must be rewritten.
  *
+ * Generated from: test_files/export_multi/export_multi.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /** @enum {string} */

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_types_values.untyped/importer.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.importer');

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_types_values.untyped/type_exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.type_exporter');

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/export_types_values.untyped/value_exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.export_types_values.untyped.value_exporter');

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/exporting_decorator/exporting.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.exporting_decorator.exporting');

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -5,6 +5,7 @@
  * {ClassInImplements}", conflicting the ES6 extends syntax, leading to
  * incorrect optimization results.
  *
+ * Generated from: test_files/extend_and_implement/extend_and_implement.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.extend_and_implement.extend_and_implement');

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -1,6 +1,7 @@
 // test_files/fields/fields.ts(22,5): warning TS0: unhandled anonymous type with constructor signature but no declaration
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/fields/fields.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.fields.fields');

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/fields_no_ctor/fields_no_ctor.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.fields_no_ctor.fields_no_ctor');

--- a/test_files/file_comment/before_import.js
+++ b/test_files/file_comment/before_import.js
@@ -4,6 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the regular import case.
  *
+ * Generated from: test_files/file_comment/before_import.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.before_import');

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -4,6 +4,7 @@
  * it before its JSDoc block. This comment would not get emitted if detached
  * source file comments were not emitted separately.
  *
+ * Generated from: test_files/file_comment/comment_before_class.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_class');

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -3,6 +3,7 @@
  * @fileoverview This is a comment before an import, where the import will be elided but the comment
  * must be kept.
  *
+ * Generated from: test_files/file_comment/comment_before_elided_import.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.comment_before_elided_import');

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -1,6 +1,7 @@
 /**
  *
  * @fileoverview This comment must not be emitted twice.
+ * Generated from: test_files/file_comment/comment_before_var.ts
  * @mods {google3.java.com.google.javascript.typescript.examples.boqui.boqui}
  * @modName {foobar}
  *

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/comment_no_tag.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /** A comment without any tags. */

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -1,6 +1,7 @@
 /**
  *
- * @fileoverview
+ * @fileoverview undefined
+ * Generated from: test_files/file_comment/comment_with_text.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,undefinedVars,unusedPrivateMembers,uselessCode}  because we don't like them errors
  *
  */

--- a/test_files/file_comment/export_star.js
+++ b/test_files/file_comment/export_star.js
@@ -4,6 +4,7 @@
  * special logic to handle comments before import/require() calls. This file
  * tests the export * case.
  *
+ * Generated from: test_files/file_comment/export_star.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.export_star');

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/file_comment.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.file_comment');

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview A file.
+ * Generated from: test_files/file_comment/fileoverview_and_jsdoc.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview a comment without a suppress tag.
+ * Generated from: test_files/file_comment/fileoverview_comment_add_suppress.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // here comes code.

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -1,6 +1,7 @@
 /**
  *
  * @fileoverview Tests merging JSDoc tags in fileoverview comments.
+ * Generated from: test_files/file_comment/fileoverview_comment_merge_suppress.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode}
  *
  */

--- a/test_files/file_comment/fileoverview_in_comment_text.js
+++ b/test_files/file_comment/fileoverview_in_comment_text.js
@@ -3,6 +3,7 @@
  * @fileoverview Tests that mere mentions of file overview tags in comment bodies don't get
  * reported as errors.
  *
+ * Generated from: test_files/file_comment/fileoverview_in_comment_text.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.fileoverview_in_comment_text');

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/jsdoc_comment.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.jsdoc_comment');

--- a/test_files/file_comment/latecomment.js
+++ b/test_files/file_comment/latecomment.js
@@ -1,6 +1,7 @@
 // test_files/file_comment/latecomment.ts(3,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/latecomment.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.latecomment');

--- a/test_files/file_comment/latecomment_front.js
+++ b/test_files/file_comment/latecomment_front.js
@@ -1,6 +1,7 @@
 /** @license Here is a license comment. */
 /**
  * @fileoverview with a late fileoverview comment before the first statement.
+ * Generated from: test_files/file_comment/latecomment_front.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.latecomment_front');

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -13,6 +13,7 @@
 /**
  *
  * @fileoverview The last fileoverview actually takes effect.
+ * Generated from: test_files/file_comment/multiple_comments.ts
  * @suppress {checkTypes,const,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode}
  *
  */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/other_fileoverview_comments.ts
  * @modName {some_mod}
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */

--- a/test_files/file_comment/run_in_comment.js
+++ b/test_files/file_comment/run_in_comment.js
@@ -1,6 +1,7 @@
 // test_files/file_comment/run_in_comment.ts(1,1): warning TS0: file comments must be at the top of the file, separated from the file body by an empty line.
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/file_comment/run_in_comment.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.run_in_comment');

--- a/test_files/file_comment/side_effect_import.js
+++ b/test_files/file_comment/side_effect_import.js
@@ -4,6 +4,7 @@
  * transformer_util.ts has special logic to handle comments before
  * import/require() calls. This file tests the side-effect import case.
  *
+ * Generated from: test_files/file_comment/side_effect_import.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.file_comment.side_effect_import');

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/functions.untyped/functions.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.untyped.functions');

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/functions/functions.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.functions');

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -2,6 +2,7 @@
  *
  * @fileoverview This text here matches the     text below in length.
  *
+ * Generated from: test_files/functions/two_jsdoc_blocks.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.functions.two_jsdoc_blocks');

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/generic_fn_type/generic_fn_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_fn_type.generic_fn_type');

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/generic_local_var/generic_local_var.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_local_var.generic_local_var');

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/generic_type_alias/generic_type_alias.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.generic_type_alias.generic_type_alias');

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
+ * Generated from: test_files/implement_reexported_interface/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.exporter');

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview See user.ts for the actual test.
+ * Generated from: test_files/implement_reexported_interface/interface.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.interface');

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -5,6 +5,7 @@
  * would then crash Closure Compiler as it creates a union type, which is unexpected for super
  * interfaces.
  *
+ * Generated from: test_files/implement_reexported_interface/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.implement_reexported_interface.user');

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_alias/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.exporter');

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_alias/importer.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_alias.importer');

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_default/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.exporter');

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_default/import_default.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_default.import_default');

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Make sure tsickle does not crash on empty imports.
+ * Generated from: test_files/import_empty/import_empty.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.import_empty');

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_empty/imported.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_empty.imported');

--- a/test_files/import_export_typedef_conflict/exporter.js
+++ b/test_files/import_export_typedef_conflict/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_export_typedef_conflict/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_export_typedef_conflict.exporter');

--- a/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
+++ b/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
@@ -4,6 +4,7 @@
  * scope would cause a duplicate exports assignment, once for the imported symbol and once for the
  * exported typedef.
  *
+ * Generated from: test_files/import_export_typedef_conflict/import_export_typedef_conflict.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_export_typedef_conflict.import_export_typedef_conflict');

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_from_goog/import_from_goog.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_from_goog.import_from_goog');

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_only_types/import_only_types.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_only_types.import_only_types');

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_only_types/types_and_constenum.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // const enum values are inlined, so even though const enums are values,

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_only_types/types_only.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // Exports only types, but must still be goog.require'd for Closure Compiler.

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_prefixed/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.exporter');

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_prefixed/import_prefixed_mixed.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.import_prefixed_mixed');

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/import_prefixed/import_prefixed_types.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.import_prefixed.import_prefixed_types');

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/index_import/has_index/index.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.index');

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/index_import/has_index/relative.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.has_index.relative');

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/index_import/lib.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.lib');

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/index_import/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.index_import.user');

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/interface/implement_import.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.implement_import');

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/interface/interface.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface');

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/interface/interface_extends.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_extends');

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/interface/interface_type_params.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.interface.interface_type_params');

--- a/test_files/invalid_closure_properties/invalid_closure_properties.js
+++ b/test_files/invalid_closure_properties/invalid_closure_properties.js
@@ -5,6 +5,7 @@
  * @fileoverview Check the type generated when using a builtin symbol as
  * a computed property.
  *
+ * Generated from: test_files/invalid_closure_properties/invalid_closure_properties.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This test is verifying the type of this expression, which ultimately

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -19,6 +19,7 @@
 // test_files/jsdoc/jsdoc.ts(132,1): warning TS0: the type annotation on @define is redundant with its TypeScript type, remove the {...} part
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc/jsdoc.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc.jsdoc');

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types.untyped/default.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.default');

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types.untyped/jsdoc_types.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /**

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -2,6 +2,7 @@
 // "quoted-bad-name": string;
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types.untyped/module1.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module1');

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types.untyped/module2.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.untyped.module2');

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types.untyped/nevertyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types/default.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.default');

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -3,6 +3,7 @@
  * @fileoverview Tests that initialized variables that end up untyped (`?`) do not get an explicit
  * type annotation, so that Closure's type inference can kick in and possibly do a better job.
  *
+ * Generated from: test_files/jsdoc_types/initialized_unknown.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This should not have a type annotation.

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -2,6 +2,7 @@
 // test_files/jsdoc_types/jsdoc_types.ts(39,1): warning TS0: dropped implements of blacklisted type: NeverTypedTemplated<T>
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types/jsdoc_types.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.jsdoc_types');

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -2,6 +2,7 @@
 // "quoted-bad-name": string;
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types/module1.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module1');

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types/module2.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsdoc_types.module2');

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsdoc_types/nevertyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /* This filename is specially marked in the tsickle test

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/jsx/jsx.tsx
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.jsx.jsx.tsx');

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/methods/methods.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.methods.methods');

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/module/module.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.module.module');

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/namespaced/ambient_namespaced.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.ambient_namespaced');

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -3,6 +3,7 @@
  * @fileoverview tsickle's Closure compatible exported enum emit does not work in namespaces. Bar
  * below must be exported onto foo, which tsickle does by disabling its emit for namespace'd enums.
  *
+ * Generated from: test_files/namespaced/export_enum_in_namespace.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // tslint:disable:no-namespace

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/namespaced/export_namespace.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // tslint:disable:no-namespace

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/namespaced/local_namespace.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.local_namespace');

--- a/test_files/namespaced/reopen_ns.js
+++ b/test_files/namespaced/reopen_ns.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/namespaced/reopen_ns.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.reopen_ns');

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/namespaced/user.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.namespaced.user');

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/nonnull_generics/nonnull_generics.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.nonnull_generics.nonnull_generics');

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/nullable/nullable.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.nullable.nullable');

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/optional/optional.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.optional.optional');

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/parameter_properties/parameter_properties.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.parameter_properties.parameter_properties');

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -1,6 +1,7 @@
 // test_files/partial/partial.ts(7,1): warning TS0: dropped implements of a type literal: Partial<Base>
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/partial/partial.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.partial.partial');

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/promiseconstructor/promiseconstructor.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promiseconstructor.promiseconstructor');

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/promisectorlike/promisectorlike.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promisectorlike.promisectorlike');

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/promiselike/promiselike.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.promiselike.promiselike');

--- a/test_files/protected/protected.js
+++ b/test_files/protected/protected.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/protected/protected.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 /** This test checks that we emit \@private/\@protected where necessary. */

--- a/test_files/rest_parameters_any/rest_parameters_any.js
+++ b/test_files/rest_parameters_any/rest_parameters_any.js
@@ -1,6 +1,7 @@
 // test_files/rest_parameters_any/rest_parameters_any.ts(26,7): warning TS0: var args type is not an object type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/rest_parameters_any/rest_parameters_any.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // This test covers the rest parameter of function

--- a/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
+++ b/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
@@ -2,6 +2,7 @@
 // test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts(3,1): warning TS0: var args type is not an object type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.rest_parameters_generic_empty.rest_parameters_generic_empty');

--- a/test_files/return_this/return_this.js
+++ b/test_files/return_this/return_this.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/return_this/return_this.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.return_this.return_this');

--- a/test_files/single_value_enum/single_value_enum.js
+++ b/test_files/single_value_enum/single_value_enum.js
@@ -5,6 +5,7 @@
  * Previously, tsickle would then emit the type as `SingleValuedEnum.C`, which is illegal in
  * Closure.
  *
+ * Generated from: test_files/single_value_enum/single_value_enum.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.single_value_enum.single_value_enum');

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/static/static.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.static.static');

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/structural.untyped/structural.untyped.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.structural.untyped.structural.untyped');

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/super/super.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.super.super');

--- a/test_files/symbol/symbol.js
+++ b/test_files/symbol/symbol.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/symbol/symbol.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.symbol.symbol');

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/this_type/this_type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.this_type.this_type');

--- a/test_files/transitive_symbol_type_only/exporter.js
+++ b/test_files/transitive_symbol_type_only/exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/transitive_symbol_type_only/exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.exporter');

--- a/test_files/transitive_symbol_type_only/reexporter.js
+++ b/test_files/transitive_symbol_type_only/reexporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/transitive_symbol_type_only/reexporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.reexporter');

--- a/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
+++ b/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
@@ -4,6 +4,7 @@
  * test makes sure there is no hard goog.require for the transitive file, as that breaks strict
  * dependency checking in some systems.
  *
+ * Generated from: test_files/transitive_symbol_type_only/transitive_symbol_type_only.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.transitive_symbol_type_only.transitive_symbol_type_only');

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,6 +1,7 @@
 // test_files/type/type.ts(20,5): warning TS0: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type/type.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type.type');

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_alias_imported/elided_comment.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.elided_comment');

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview See comments in type_alias_imported.
+ * Generated from: test_files/type_alias_imported/export_constant.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.export_constant');

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -3,6 +3,7 @@
  * @fileoverview Declares the symbols used in union types in type_alias_exporter. These symbols
  * must ultimately be imported by type_alias_imported.
  *
+ * Generated from: test_files/type_alias_imported/type_alias_declare.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_declare');

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -3,6 +3,7 @@
  * @fileoverview Declares a type alias as default export. This allows testing that the appropriate
  * type reference is created (no .default property).
  *
+ * Generated from: test_files/type_alias_imported/type_alias_default_exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_default_exporter');

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_alias_imported/type_alias_exporter.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_exporter');

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Make sure imports are inserted *after* the fileoverview.
+ * Generated from: test_files/type_alias_imported/type_alias_imported.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_alias_imported.type_alias_imported');

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -2,6 +2,7 @@
 // test_files/type_and_value/module.ts(6,1): warning TS0: type/symbol conflict for TemplatizedTypeAndValue, using {?} for now
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_and_value/module.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 // WARNING: interface has both a type and a value, skipping emit

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -6,6 +6,7 @@
 // test_files/type_and_value/type_and_value.ts(39,5): warning TS0: anonymous type has no symbol
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_and_value/type_and_value.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_and_value.type_and_value');

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_guard_fn/type_guard_fn.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_guard_fn.type_guard_fn');

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/type_propaccess.no_externs/type_propaccess.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/typedef.untyped/typedef.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.untyped.typedef');

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/typedef/typedef.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.typedef.typedef');

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/underscore/export_underscore.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.underscore.export_underscore');

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/underscore/underscore.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.underscore.underscore');

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -3,6 +3,7 @@
  * @fileoverview A source file that uses types that are used in .d.ts files, but
  * that are not available or use different names in Closure's externs.
  *
+ * Generated from: test_files/use_closure_externs/use_closure_externs.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.use_closure_externs.use_closure_externs');

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview added by tsickle
+ * Generated from: test_files/variables/variables.ts
  * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
  */
 goog.module('test_files.variables.variables');


### PR DESCRIPTION
It will be used by other tooling (e.g. Kythe) that need to connect
JS file back to original TS file.

Tested:
  golden tests