### PR TITLE
handle one more async case

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -618,8 +618,13 @@ export function jsdocTransformer(
         const isDownlevellingAsync =
             tsOptions.target !== undefined && tsOptions.target <= ts.ScriptTarget.ES2015;
         const isFunction = fnDecl.kind === ts.SyntaxKind.FunctionDeclaration;
+        // Closure knows the type of class-level statics, but forbids using
+        // 'this' within them when language_out=ES2017.
+        const isClassStatic = ts.isMethodDeclaration(fnDecl) &&
+            ((ts.getCombinedModifierFlags(fnDecl) & ts.ModifierFlags.Static) !== 0);
         const hasExistingThisTag = tags.some(t => t.tagName === 'this');
-        if (isDownlevellingAsync && isFunction && !hasExistingThisTag && containsAsync(fnDecl)) {
+        if (isDownlevellingAsync && (isFunction || isClassStatic) && !hasExistingThisTag &&
+            containsAsync(fnDecl)) {
           tags.push({tagName: 'this', type: '*'});
         }
         const mjsdoc = moduleTypeTranslator.getMutableJSDoc(fnDecl);

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -52,7 +52,7 @@ describe('golden file tests', () => {
       'js': goldenJs,
       'externs': externs,
       'language_in': 'ECMASCRIPT6_STRICT',
-      'language_out': 'ECMASCRIPT5',
+      'language_out': 'ECMASCRIPT_2017',
       'jscomp_off': ['lintChecks'],
       'jscomp_error': [
         'accessControls',

--- a/test_files/async_functions/async_functions.js
+++ b/test_files/async_functions/async_functions.js
@@ -92,6 +92,7 @@ class Container {
     }
     /**
      * @return {!Promise<string>}
+     * @this {*}
      */
     static asyncStaticMethod() {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {


### PR DESCRIPTION
If you tell JSCompiler to emit ES2017, one of our async test cases
(a static async on a class) starts failing.  It appears that even in
ES5 this code patterns ends up with a this type of {?} but for some
reason the failure doesn't trigger, something about the JSCompiler
passes for ES5 emit.

This change fixes the test by handling static async, by busting the
type of 'this'.  This reads a bit wrong to me, but I am told that
  class C {
    static f() {}
    static g() { this.f(); }
  }
is illegal in JSCompiler anyway, so it's ok to break any code that
uses 'this' in a static.