### PR TITLE
Reduce dependencies of demo.ts

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -10,7 +10,6 @@
 
 import * as fs from 'fs';
 import * as minimist from 'minimist';
-import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as tsickle from 'tsickle';
@@ -207,7 +206,7 @@ function main(args: string[]): number {
   // Run tsickle+TSC to convert inputs to Closure JS files.
   const result = toClosureJS(
       config.options, config.fileNames, settings, (filePath: string, contents: string) => {
-        mkdirp.sync(path.dirname(filePath));
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
         fs.writeFileSync(filePath, contents, {encoding: 'utf-8'});
       });
   if (result.diagnostics.length) {
@@ -216,7 +215,7 @@ function main(args: string[]): number {
   }
 
   if (settings.externsPath) {
-    mkdirp.sync(path.dirname(settings.externsPath));
+    fs.mkdirSync(path.dirname(settings.externsPath), {recursive: true});
     fs.writeFileSync(
         settings.externsPath,
         tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,13 +11,11 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
-    "mkdirp": "^0.5.1",
     "tsickle": "^0.37.0",
     "typescript": "~3.5.3"
   },
   "devDependencies": {
     "@types/minimist": "1.2.0",
-    "@types/mkdirp": "0.5.2",
     "@types/node": "^10.5.6"
   }
 }

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -7,13 +7,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/mkdirp@0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
-  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "12.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"


### PR DESCRIPTION
The `mkdirp` dependency is not necessary. fs.mkdirSync has a recursive mode.