### PR TITLE
Visit enum nodes in jsdocTransformer to validate the enum's JSDoc

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -995,6 +995,16 @@ export function jsdocTransformer(
         return result;
       }
 
+      /**
+       * Visits enum declarations to check for validity of JSDoc comments without transforming the
+       * node at all.
+       */
+      function visitEnumDeclaration(node: ts.EnumDeclaration) {
+        // Calling `getJSDoc` will validate and report any errors, but this code
+        // doesn't really care about the return value.
+        moduleTypeTranslator.getJSDoc(node, /* reportWarnings */ true);
+      }
+
       function visitor(node: ts.Node): ts.Node|ts.Node[] {
         if (transformerUtil.isAmbient(node)) {
           if (!transformerUtil.hasModifierFlag(node as ts.Declaration, ts.ModifierFlags.Export)) {
@@ -1053,6 +1063,9 @@ export function jsdocTransformer(
             return visitAssertionExpression(node as ts.TypeAssertion);
           case ts.SyntaxKind.NonNullExpression:
             return visitNonNullExpression(node as ts.NonNullExpression);
+          case ts.SyntaxKind.EnumDeclaration:
+            visitEnumDeclaration(node as ts.EnumDeclaration);
+            break;
           default:
             break;
         }

--- a/test_files/jsdoc/enum_tag.js
+++ b/test_files/jsdoc/enum_tag.js
@@ -1,0 +1,49 @@
+// test_files/jsdoc/enum_tag.ts(6,1): warning TS0: @enum annotations are redundant with TypeScript equivalents
+// test_files/jsdoc/enum_tag.ts(14,1): warning TS0: @enum annotations are redundant with TypeScript equivalents
+// test_files/jsdoc/enum_tag.ts(20,1): warning TS0: @enum annotations are redundant with TypeScript equivalents
+// test_files/jsdoc/enum_tag.ts(29,3): warning TS0: @enum annotations are redundant with TypeScript equivalents
+// test_files/jsdoc/enum_tag.ts(29,3): warning TS0: @enum annotations are redundant with TypeScript equivalents
+/**
+ *
+ * @fileoverview Checks that JSDoc `\@enum` tags on an `enum` are flagged as
+ * warnings.
+ *
+ * Generated from: test_files/jsdoc/enum_tag.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.jsdoc.enum_tag');
+var module = module || { id: 'test_files/jsdoc/enum_tag.ts' };
+module = module;
+/** @enum {number} */
+const A = {
+    A: 0,
+    B: 1,
+};
+A[A.A] = 'A';
+A[A.B] = 'B';
+/** @enum {number} */
+const B = {
+    A: 0,
+    B: 1,
+};
+B[B.A] = 'A';
+B[B.B] = 'B';
+/** @enum {number} */
+const C = {
+    A: 10,
+    B: 20,
+};
+C[C.A] = 'A';
+C[C.B] = 'B';
+class SomeComponent {
+    constructor() {
+        this.MY_ENUM = {
+            A: 10,
+            B: 20,
+        };
+    }
+}
+if (false) {
+    /** @type {{A: number, B: number}} */
+    SomeComponent.prototype.MY_ENUM;
+}

--- a/test_files/jsdoc/enum_tag.ts
+++ b/test_files/jsdoc/enum_tag.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Checks that JSDoc `@enum` tags on an `enum` are flagged as
+ * warnings.
+ */
+
+/**
+ * @enum
+ */
+enum A {
+  A,
+  B
+}
+
+/** @enum */
+enum B {
+  A,
+  B
+}
+
+/**
+ * @enum {number}
+ */
+enum C {
+  A = 10,
+  B = 20
+}
+
+class SomeComponent {
+  /** @enum {number} */
+  readonly MY_ENUM = {
+    A: 10,
+    B: 20,
+  };
+}


### PR DESCRIPTION
Enum node types were not being validates along with other nodes in jsdocTransformer, and were only being seen after enumTransformer, which turned the enum into a valid closure enum, causing the original JSDoc to never be validated. This change makes jsdocTransformer visit (but not actually transform) the enum nodes and validates them by calling getJSDoc.

Fixes #998 