### PR TITLE
Handle `{default as Foo}` imports from Clutz.

### DIFF
--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -263,12 +263,17 @@ export class ModuleTypeTranslator {
             ts.NodeFlags.Const)));
     this.requireTypeModules.add(moduleSymbol);
     for (let sym of this.typeChecker.getExportsOfModule(moduleSymbol)) {
+      // Some users import {default as SomeAlias} from 'goog:...';
+      // The code below must recognize this as a default import to alias the symbol to just the
+      // blank module name.
+      const namedDefaultImport = sym.name === 'default';
       if (sym.flags & ts.SymbolFlags.Alias) {
         sym = this.typeChecker.getAliasedSymbol(sym);
       }
       // goog: imports don't actually use the .default property that TS thinks they have.
-      const qualifiedName =
-          nsImport && isDefaultImport ? requireTypePrefix : requireTypePrefix + '.' + sym.name;
+      const qualifiedName = nsImport && (isDefaultImport || namedDefaultImport) ?
+          requireTypePrefix :
+          requireTypePrefix + '.' + sym.name;
       this.symbolsToAliasedNames.set(sym, qualifiedName);
     }
   }

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -26,6 +26,7 @@ describe('golden file tests', () => {
     goldenJs.push('third_party/tslib/externs.js');
     goldenJs.push('third_party/tslib/tslib.js');
     goldenJs.push('test_files/augment/shim.js');
+    goldenJs.push('test_files/clutz.no_externs/default_export.js');
     goldenJs.push('test_files/clutz.no_externs/some_name_space.js');
     goldenJs.push('test_files/clutz.no_externs/some_other.js');
     goldenJs.push('test_files/clutz_type_value.no_externs/type_value.js');

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -21,21 +21,27 @@ describe('golden file tests', () => {
   it('compile with Closure', (done) => {
     // Declaration tests do not produce .js files.
     const tests = goldenTests().filter(t => !t.isDeclarationTest);
+    // Collect all JavaScript outputs generated from .ts files.
     const goldenJs = ([] as string[]).concat(...tests.map(t => t.jsPaths));
-    goldenJs.push('src/closure_externs.js');
-    goldenJs.push('third_party/tslib/externs.js');
-    goldenJs.push('third_party/tslib/tslib.js');
-    goldenJs.push('test_files/augment/shim.js');
-    goldenJs.push('test_files/clutz.no_externs/default_export.js');
-    goldenJs.push('test_files/clutz.no_externs/some_name_space.js');
-    goldenJs.push('test_files/clutz.no_externs/some_other.js');
-    goldenJs.push('test_files/clutz_type_value.no_externs/type_value.js');
-    goldenJs.push('test_files/declare/shim.js');
-    goldenJs.push('test_files/declare_export_dts/shim.js');
-    goldenJs.push('test_files/import_from_goog/closure_Module.js');
-    goldenJs.push('test_files/import_from_goog/closure_OtherModule.js');
-    goldenJs.push('test_files/export_equals.shim/shim.js');
-    goldenJs.push('test_files/type_propaccess.no_externs/nested_clazz.js');
+    // Manually add extra .js files that are not generated from .ts. Several tests include `.d.ts`
+    // files describing symbols defined in JavaScript, e.g. for `goog:...` style Clutz imports.
+    // These definitions must be included here so that Closure Compiler sees all definitions.
+    goldenJs.push(
+        'src/closure_externs.js',
+        'third_party/tslib/externs.js',
+        'third_party/tslib/tslib.js',
+        'test_files/augment/shim.js',
+        'test_files/clutz.no_externs/default_export.js',
+        'test_files/clutz.no_externs/some_name_space.js',
+        'test_files/clutz.no_externs/some_other.js',
+        'test_files/clutz_type_value.no_externs/type_value.js',
+        'test_files/declare/shim.js',
+        'test_files/declare_export_dts/shim.js',
+        'test_files/import_from_goog/closure_Module.js',
+        'test_files/import_from_goog/closure_OtherModule.js',
+        'test_files/export_equals.shim/shim.js',
+        'test_files/type_propaccess.no_externs/nested_clazz.js',
+    );
     const externs = tests.map(t => t.externsPath).filter(fs.existsSync);
     const startTime = Date.now();
     const total = goldenJs.length;

--- a/test_files/clutz.no_externs/clutz_typings.d.ts
+++ b/test_files/clutz.no_externs/clutz_typings.d.ts
@@ -18,3 +18,12 @@ declare module 'goog:some.other' {
   import alias = ಠ_ಠ.clutz.some.other;
   export = alias;
 }
+
+declare namespace ಠ_ಠ.clutz.default_export {
+  class AliasedDefaultExport {}
+}
+
+declare module 'goog:default_export' {
+  import AliasedDefaultExport = ಠ_ಠ.clutz.default_export.AliasedDefaultExport;
+  export default AliasedDefaultExport;
+}

--- a/test_files/clutz.no_externs/default_export.js
+++ b/test_files/clutz.no_externs/default_export.js
@@ -1,0 +1,3 @@
+goog.module('default_export');
+
+exports = class {};

--- a/test_files/clutz.no_externs/import_default.js
+++ b/test_files/clutz.no_externs/import_default.js
@@ -1,0 +1,18 @@
+/**
+ *
+ * @fileoverview Reproduces a problem where a renamed Clutz default export ({default as X}) would
+ * produce type annotations including an indirection to the aliased symbol.
+ *
+ * Generated from: test_files/clutz.no_externs/import_default.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.clutz.no_externs.import_default');
+var module = module || { id: 'test_files/clutz.no_externs/import_default.ts' };
+module = module;
+const tsickle_goog_default_export_1 = goog.requireType("default_export");
+/** @type {(null|!tsickle_goog_default_export_1)} */
+const usingType = null;
+// The symbol below was previously named as tsickle_default_export_1.AliasedDefaultExport. It must
+// be emitted as just tsickle_default_export_1.
+/** @type {(null|!tsickle_goog_default_export_1)} */
+const usingType2 = null;

--- a/test_files/clutz.no_externs/import_default.ts
+++ b/test_files/clutz.no_externs/import_default.ts
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview Reproduces a problem where a renamed Clutz default export ({default as X}) would
+ * produce type annotations including an indirection to the aliased symbol.
+ */
+
+import DefaultExportNamed from 'goog:default_export';
+// This import renaming style triggered the type naming issue, as Clutz did not recognize this as
+// a default import.
+import {default as RenamedDefaultExport} from 'goog:default_export';
+
+const usingType: DefaultExportNamed|null = null;
+// The symbol below was previously named as tsickle_default_export_1.AliasedDefaultExport. It must
+// be emitted as just tsickle_default_export_1.
+const usingType2: RenamedDefaultExport|null = null;


### PR DESCRIPTION
In ES modules (and thus TypeScript), the default export is simply a
property named `default` on the exports object. tsickle however maps
default imports from `goog:` modules directly to the exports object, to
better match common `goog.module` usage.

Previously, tsickle failed to recognize `{default as Foo}` style
renaming, causing it to alias an incorrect type symbol to the export, in
turn causing failed type resolution in Closure (see the test for an
example). This change recognizes the renaming style, fixing the problem.