### PR TITLE
Add BigIntLiteral to TypeTranslator#translate switch statement

### DIFF
--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -81,11 +81,11 @@ export function typeToDebugString(type: ts.Type): string {
     ts.TypeFlags.Any,           ts.TypeFlags.String,         ts.TypeFlags.Number,
     ts.TypeFlags.Boolean,       ts.TypeFlags.Enum,           ts.TypeFlags.StringLiteral,
     ts.TypeFlags.NumberLiteral, ts.TypeFlags.BooleanLiteral, ts.TypeFlags.EnumLiteral,
-    ts.TypeFlags.ESSymbol,      ts.TypeFlags.UniqueESSymbol, ts.TypeFlags.Void,
-    ts.TypeFlags.Undefined,     ts.TypeFlags.Null,           ts.TypeFlags.Never,
-    ts.TypeFlags.TypeParameter, ts.TypeFlags.Object,         ts.TypeFlags.Union,
-    ts.TypeFlags.Intersection,  ts.TypeFlags.Index,          ts.TypeFlags.IndexedAccess,
-    ts.TypeFlags.Conditional,   ts.TypeFlags.Substitution,
+    ts.TypeFlags.BigIntLiteral, ts.TypeFlags.ESSymbol,       ts.TypeFlags.UniqueESSymbol,
+    ts.TypeFlags.Void,          ts.TypeFlags.Undefined,      ts.TypeFlags.Null,
+    ts.TypeFlags.Never,         ts.TypeFlags.TypeParameter,  ts.TypeFlags.Object,
+    ts.TypeFlags.Union,         ts.TypeFlags.Intersection,   ts.TypeFlags.Index,
+    ts.TypeFlags.IndexedAccess, ts.TypeFlags.Conditional,    ts.TypeFlags.Substitution,
   ];
   for (const flag of basicTypes) {
     if ((type.flags & flag) !== 0) {
@@ -447,6 +447,7 @@ export class TypeTranslator {
       case ts.TypeFlags.Undefined:
         return 'undefined';
       case ts.TypeFlags.BigInt:
+      case ts.TypeFlags.BigIntLiteral:
         return 'bigintPlaceholder';
       case ts.TypeFlags.Null:
         return 'null';

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -48,6 +48,10 @@ export const baseCompilerOptions: ts.CompilerOptions = {
   // Disable searching for @types typings. This prevents TS from looking
   // around for a node_modules directory.
   types: [],
+  // Setting the target to ES2015 sets the lib field to ['lib.es6.d.ts'] by
+  // default. Override this value to also provide type declarations for BigInt
+  // literals.
+  lib: ['lib.es6.d.ts', 'lib.esnext.bigint.d.ts'],
   skipDefaultLibCheck: true,
   experimentalDecorators: true,
   module: ts.ModuleKind.CommonJS,

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -1,4 +1,4 @@
-// test_files/type/type.ts(20,5): warning TS0: unhandled anonymous type
+// test_files/type/type.ts(25,5): warning TS0: unhandled anonymous type
 /**
  * @fileoverview added by tsickle
  * Generated from: test_files/type/type.ts
@@ -19,6 +19,14 @@ let typeNestedArr;
 let typeUnknown;
 /** @type {bigintPlaceholder} */
 let typeBigInt;
+/** @type {boolean} */
+let typeBooleanLiteral;
+/** @type {number} */
+let typeNumberLiteral;
+/** @type {string} */
+let typeStringLiteral;
+/** @type {bigintPlaceholder} */
+let typeBigIntLiteral;
 /** @type {{a: number, b: string}} */
 let typeObject = { a: 3, b: 'b' };
 /** @type {!Object<string,number>} */

--- a/test_files/type/type.ts
+++ b/test_files/type/type.ts
@@ -15,6 +15,11 @@ let typeNestedArr: {a:any}[][];
 let typeUnknown: unknown;
 let typeBigInt: bigint;
 
+let typeBooleanLiteral: false;
+let typeNumberLiteral: 0;
+let typeStringLiteral: '';
+let typeBigIntLiteral: 0n;
+
 let typeObject: {a:number, b:string} = {a:3, b:'b'};
 let typeObjectIndexable: {[key:string]: number};
 let typeObjectMixedIndexProperty: {a:number, [key:string]: number};


### PR DESCRIPTION
Currently, using tsickle with code that features a BigInt literal causes the following error: `Error: unknown type flags 2048 on {type flags:0x800}` -- this should fix that.