### PR TITLE
Fixes running tsickle in browser

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -25,6 +25,7 @@ declare module 'typescript' {
   function convertToRelativePath(
       absoluteOrRelativePath: string, basePath: string,
       getCanonicalFileName: (path: string) => string): string;
+  function resolvePath(path: string, ...paths: Array<string|undefined>): string;
 }
 
 export function isAbsolute(path: string): boolean {
@@ -44,5 +45,5 @@ export function relative(base: string, rel: string): string {
 }
 
 export function normalize(path: string): string {
-  return ts.sys.resolvePath(path);
+  return ts.resolvePath(path);
 }


### PR DESCRIPTION
`path.normalize` relied on `ts.sys` being defined for access to the `resolvePath` function. `ts.sys` is [not defined when running in the browser](https://github.com/microsoft/TypeScript/blob/master/src/compiler/path.ts#L508-L520). However TypeScript exports another environment-independent [`resolveModule`](https://github.com/microsoft/TypeScript/blob/master/src/compiler/sys.ts#L1492-L1505) function along with the other utilities `path.ts` was using. Switching to this implementation should let tsickle work in the browser again, and all tests pass with this implementation so it seems mostly equivalent.