### PR TITLE
Refactor & fix rest parameter handling.

### DIFF
--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -1,6 +1,6 @@
-// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(1,1): warning TS0: emitting ? for conditional/substitution type
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(1,38): warning TS0: failed to resolve rest parameter type, emitting ?
 // test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(3,14): warning TS0: var args type is not an object type
-// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,3): warning TS0: emitting ? for conditional/substitution type
+// test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts(4,31): warning TS0: failed to resolve rest parameter type, emitting ?
 /**
  * @fileoverview added by tsickle
  * Generated from: test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts

--- a/test_files/rest_parameters_tuple/rest_parameters_tuple.js
+++ b/test_files/rest_parameters_tuple/rest_parameters_tuple.js
@@ -1,0 +1,18 @@
+// test_files/rest_parameters_tuple/rest_parameters_tuple.ts(6,20): warning TS0: failed to resolve rest parameter type, emitting ?
+/**
+ *
+ * @fileoverview Tests that complex union/tuple types for rest parameters get emitted as a fallback
+ * '?' unknown type.
+ *
+ * Generated from: test_files/rest_parameters_tuple/rest_parameters_tuple.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.rest_parameters_tuple.rest_parameters_tuple');
+var module = module || { id: 'test_files/rest_parameters_tuple/rest_parameters_tuple.ts' };
+module = module;
+/**
+ * @param {...?} args
+ * @return {void}
+ */
+function fn(...args) { }
+exports.fn = fn;

--- a/test_files/rest_parameters_tuple/rest_parameters_tuple.ts
+++ b/test_files/rest_parameters_tuple/rest_parameters_tuple.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Tests that complex union/tuple types for rest parameters get emitted as a fallback
+ * '?' unknown type.
+ */
+
+export function fn(...args: [number]|[string, number]) {}


### PR DESCRIPTION
This change mostly refactors rest parameter handling to extract some of
the complex logic from the main parameter handling loop.

In addition, it fixes a subtle bug where tsickle would, if it failed to
resolve the array member type of a rest parameter, just continue
emitting the type as is. This "fail open" behaviour can cause issues,
such as emitting `Array<Array<?>>` for a non-representable rest tuple
type, instead of `Array<?>`.

Not a huge improvement and clearly a corner case, but I believe this
overall improves correctness and legibility of the code.

Fixes #1120.