### PR TITLE
Allow @ExportsDecoratedItems to be applied to protected and private items.

### DIFF
--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -31,7 +31,7 @@ import * as ts from 'typescript';
 import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
-import {getVisibility, ModuleTypeTranslator} from './module_type_translator';
+import {getClosureVisibility, ModuleTypeTranslator} from './module_type_translator';
 import * as transformerUtil from './transformer_util';
 import {symbolIsValue} from './transformer_util';
 import {isClutzType, isValidClosurePropertyName} from './type_translator';
@@ -375,7 +375,7 @@ function createClosurePropertyDeclaration(
   const tags = mtt.getJSDoc(prop, /* reportWarnings */ true);
   tags.push({tagName: 'type', type});
   const flags = ts.getCombinedModifierFlags(prop);
-  const visibility = getVisibility(prop, mtt.typeChecker);
+  const visibility = getClosureVisibility(prop, mtt.typeChecker);
   if (visibility !== 'public') {
     // Public is the default, otherwise emit a jsdoc tag.
     tags.push({tagName: visibility});

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -437,7 +437,7 @@ export class ModuleTypeTranslator {
         addTag({tagName: 'abstract'});
       }
       // Add visibility.
-      const visibility = getVisibility(fnDecl, typeChecker);
+      const visibility = getClosureVisibility(fnDecl, typeChecker);
       if (visibility !== 'public') {
         addTag({tagName: visibility});
       }
@@ -580,11 +580,30 @@ export class ModuleTypeTranslator {
   }
 }
 
-/** Mutually exclusive visibility jsdoc tags. */
-export type Visibility = 'public'|'private'|'protected'|'export';
+/**
+ * Mutually exclusive closure compiler visibility jsdoc tags.
+ */
+export type ClosureVisibility =
+  /** Like TypeScript public. */
+  'public'|
+  /** Like TypeScript private. */
+  'private'|
+  /** Like TypeScript protected. */
+  'protected'|
+  /**
+   * The export jsdoc tag is an extension of the public visibility, with
+   * the additional semantics that Closure Compiler will not renamed
+   * the documented name.
+   *
+   * It is mutually exclusive with the other visibility tags.
+   */
+  'export';
 
-/** Returns the visibility jsdoc tag for the given declaration. */
-export function getVisibility(decl: ts.Declaration, typeChecker: ts.TypeChecker): Visibility {
+/**
+ * Returns the Closure visibility jsdoc tag that should apply to the given
+ * declaration.
+ */
+export function getClosureVisibility(decl: ts.Declaration, typeChecker: ts.TypeChecker): ClosureVisibility {
   if (hasExportingDecorator(decl, typeChecker)) {
     // Overrides any other visibility.
     return 'export';

--- a/test_files/exporting_decorator/visibility.js
+++ b/test_files/exporting_decorator/visibility.js
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview added by tsickle
+ * Generated from: test_files/exporting_decorator/visibility.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.exporting_decorator.visibility');
+var module = module || { id: 'test_files/exporting_decorator/visibility.ts' };
+module = module;
+const tslib_1 = goog.require('tslib');
+/**
+ * \@ExportDecoratedItems
+ * @return {function(*, (undefined|string|number|symbol)=): void}
+ */
+function exportDecorated() {
+    return (/**
+     * @param {*} protoOrDescriptor
+     * @param {(undefined|string|number|symbol)=} name
+     * @return {void}
+     */
+    (protoOrDescriptor, name) => { });
+}
+class ExportDecoratedClass {
+    constructor() {
+        this.implicitPublicProp = 0;
+        this.publicProp = 0;
+        this.protectedProp = 0;
+        this.privateProp = 0;
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    implicitPublicMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    publicMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    protectedMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    privateMethod() {
+    }
+}
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "implicitPublicProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "publicProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "protectedProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "privateProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "implicitPublicMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "publicMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "protectedMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "privateMethod", null);
+if (false) {
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.implicitPublicProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.publicProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.protectedProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.privateProp;
+}

--- a/test_files/exporting_decorator/visibility.ts
+++ b/test_files/exporting_decorator/visibility.ts
@@ -1,0 +1,28 @@
+/**
+ * @ExportDecoratedItems
+ */
+function exportDecorated() {
+  return (protoOrDescriptor: unknown, name?: PropertyKey): void => {};
+}
+
+class ExportDecoratedClass {
+  @exportDecorated() implicitPublicProp = 0;
+  @exportDecorated() publicProp = 0;
+  @exportDecorated() protected protectedProp = 0;
+  @exportDecorated() private privateProp = 0;
+
+  @exportDecorated()
+  implicitPublicMethod() {
+  }
+  @exportDecorated()
+  publicMethod() {
+  }
+  @exportDecorated()
+  protected protectedMethod() {
+  }
+  @exportDecorated()
+  private privateMethod() {
+  }
+}
+
+export {};


### PR DESCRIPTION
The items will be private and protected to other TypeScript code, but will still be emitted as @export in closure output.

This is a compromise, but an improvement over the current situation, where fields that are logically protected or private are public to both TypeScript and Closure Compiler. It does carry the downside that TS code authors may be overly confident in their privacy, but this seems a worthy trade. protected and private are just guidelines after all.

Internal global presubmit passed. Details at cl/282008467