### PR TITLE
Workaround Clutz namespace issue.

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -350,6 +350,8 @@ function addClutzAliases(
   dtsFileContent += globalSymbols;
   dtsFileContent += `\t}\n`;
   dtsFileContent += `\tnamespace ಠ_ಠ.clutz.module$exports$${clutzModuleName} {\n`;
+  // TODO(martinprobst): See https://github.com/Microsoft/TypeScript/issues/35385, remove once fixed
+  dtsFileContent += `\t\tconst clutz$workaround$tissue$35385: number;\n`;
   dtsFileContent += nestedSymbols;
   dtsFileContent += `\t}\n`;
   dtsFileContent += '}\n';

--- a/test_files/basic.declaration/basic.d.ts
+++ b/test_files/basic.declaration/basic.d.ts
@@ -8,6 +8,7 @@ declare global {
 		export {y as module$contents$test_files$basic$declaration$basic_y}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$basic$declaration$basic {
+		const clutz$workaround$tissue$35385: number;
 		import incr$clutz = ಠ_ಠ.clutz.module$contents$test_files$basic$declaration$basic_incr;
 		export {incr$clutz as incr};
 		import x$clutz = ಠ_ಠ.clutz.module$contents$test_files$basic$declaration$basic_x;

--- a/test_files/class.declaration/class.d.ts
+++ b/test_files/class.declaration/class.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {Foo as module$contents$test_files$class$declaration$class_Foo}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$class$declaration$class {
+		const clutz$workaround$tissue$35385: number;
 		import Foo$clutz = ಠ_ಠ.clutz.module$contents$test_files$class$declaration$class_Foo;
 		export {Foo$clutz as Foo};
 	}

--- a/test_files/generics.declaration/generics.d.ts
+++ b/test_files/generics.declaration/generics.d.ts
@@ -28,6 +28,7 @@ declare global {
 		export {loggingIdentity as module$contents$test_files$generics$declaration$generics_loggingIdentity}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$generics$declaration$generics {
+		const clutz$workaround$tissue$35385: number;
 		import DefaultGeneric$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_DefaultGeneric;
 		export {DefaultGeneric$clutz as DefaultGeneric};
 		import GenericNumber$clutz = ಠ_ಠ.clutz.module$contents$test_files$generics$declaration$generics_GenericNumber;

--- a/test_files/interface_and_type.declaration/interface_and_type.d.ts
+++ b/test_files/interface_and_type.declaration/interface_and_type.d.ts
@@ -7,6 +7,7 @@ declare global {
 		export {Foo as module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$interface_and_type$declaration$interface_and_type {
+		const clutz$workaround$tissue$35385: number;
 		import Bar$clutz = ಠ_ಠ.clutz.module$contents$test_files$interface_and_type$declaration$interface_and_type_Bar;
 		export {Bar$clutz as Bar};
 		import Foo$clutz = ಠ_ಠ.clutz.module$contents$test_files$interface_and_type$declaration$interface_and_type_Foo;

--- a/test_files/nested_folder.declaration/inner_folder/nested.d.ts
+++ b/test_files/nested_folder.declaration/inner_folder/nested.d.ts
@@ -4,6 +4,7 @@ declare global {
 		export {x as module$contents$test_files$nested_folder$declaration$inner_folder$nested_x}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$nested_folder$declaration$inner_folder$nested {
+		const clutz$workaround$tissue$35385: number;
 		import x$clutz = ಠ_ಠ.clutz.module$contents$test_files$nested_folder$declaration$inner_folder$nested_x;
 		export {x$clutz as x};
 	}

--- a/test_files/reexport.declaration/export.d.ts
+++ b/test_files/reexport.declaration/export.d.ts
@@ -12,6 +12,7 @@ declare global {
 		export {OTHER as module$contents$test_files$reexport$declaration$export_OTHER}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$export {
+		const clutz$workaround$tissue$35385: number;
 		import NON_DIRECT_TO_BE_RENAMED$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_NEW_NAME;
 		export {NON_DIRECT_TO_BE_RENAMED$clutz as NEW_NAME};
 		import NON_DIRECT$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$export_NON_DIRECT;

--- a/test_files/reexport.declaration/import_reexport.d.ts
+++ b/test_files/reexport.declaration/import_reexport.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {NUM_CONSTANT as module$contents$test_files$reexport$declaration$import_reexport_NUM_CONSTANT}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$import_reexport {
+		const clutz$workaround$tissue$35385: number;
 		import NUM_CONSTANT$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$import_reexport_NUM_CONSTANT;
 		export {NUM_CONSTANT$clutz as NUM_CONSTANT};
 	}

--- a/test_files/reexport.declaration/renamed_export.d.ts
+++ b/test_files/reexport.declaration/renamed_export.d.ts
@@ -5,6 +5,7 @@ declare global {
 		export {OTHER as module$contents$test_files$reexport$declaration$renamed_export_MOTHER}
 	}
 	namespace ಠ_ಠ.clutz.module$exports$test_files$reexport$declaration$renamed_export {
+		const clutz$workaround$tissue$35385: number;
 		import OTHER$clutz = ಠ_ಠ.clutz.module$contents$test_files$reexport$declaration$renamed_export_MOTHER;
 		export {OTHER$clutz as MOTHER};
 	}


### PR DESCRIPTION
TypeScript appears to ignore nested namespaces that only contain
re-exports, see https://github.com/Microsoft/TypeScript/issues/35385.

This change adds a fake value to the nested re-exporting namespace to
work around the problem.