### PR TITLE
Unify visibility emitting, prepare for erroring when @ExportDecoratoredItems is applied to a private field

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -40,20 +40,22 @@ export function getDecoratorDeclarations(
  */
 export function hasExportingDecorator(node: ts.Node, typeChecker: ts.TypeChecker) {
   return node.decorators &&
-      node.decorators.some(decorator => isExportingDecorator(decorator, typeChecker));
+      node.decorators.some(
+          decorator => hasDocsMatching(decorator, /@ExportDecoratedItems\b/, typeChecker));
 }
 
 /**
- * Returns true if the given decorator has an @ExportDecoratedItems directive in its JSDoc.
+ * Returns true if the given decorator has a comment whose text matches the
+ * given regex.
  */
-function isExportingDecorator(decorator: ts.Decorator, typeChecker: ts.TypeChecker) {
+function hasDocsMatching(decorator: ts.Decorator, regex: RegExp, typeChecker: ts.TypeChecker) {
   return getDecoratorDeclarations(decorator, typeChecker).some(declaration => {
     const range = getAllLeadingComments(declaration);
     if (!range) {
       return false;
     }
     for (const {text} of range) {
-      if (/@ExportDecoratedItems\b/.test(text)) {
+      if (regex.test(text)) {
         return true;
       }
     }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -29,10 +29,9 @@
 import * as ts from 'typescript';
 
 import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
-import {hasExportingDecorator} from './decorators';
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
-import {ModuleTypeTranslator} from './module_type_translator';
+import {getClosureVisibility, ModuleTypeTranslator} from './module_type_translator';
 import * as transformerUtil from './transformer_util';
 import {symbolIsValue} from './transformer_util';
 import {isClutzType, isValidClosurePropertyName} from './type_translator';
@@ -291,7 +290,6 @@ function createMemberTypeDeclaration(
       continue;
     }
     const {tags, parameterNames} = mtt.getFunctionTypeJSDoc([fnDecl], []);
-    if (hasExportingDecorator(fnDecl, mtt.typeChecker)) tags.push({tagName: 'export'});
     // Use element access instead of property access for compued names.
     const lhs = typeof name === 'string' ? ts.createPropertyAccess(instancePropAccess, name) :
                                            ts.createElementAccess(instancePropAccess, name);
@@ -377,13 +375,10 @@ function createClosurePropertyDeclaration(
   const tags = mtt.getJSDoc(prop, /* reportWarnings */ true);
   tags.push({tagName: 'type', type});
   const flags = ts.getCombinedModifierFlags(prop);
-  if (flags & ts.ModifierFlags.Protected) {
-    tags.push({tagName: 'protected'});
-  } else if (flags & ts.ModifierFlags.Private) {
-    tags.push({tagName: 'private'});
-  }
-  if (hasExportingDecorator(prop, mtt.typeChecker)) {
-    tags.push({tagName: 'export'});
+  const visibility = getClosureVisibility(prop, mtt.typeChecker, mtt.diagnostics);
+  if (visibility !== 'public') {
+    // Public is the default, otherwise emit a jsdoc tag.
+    tags.push({tagName: visibility});
   }
   const declStmt =
       ts.setSourceMapRange(ts.createStatement(ts.createPropertyAccess(expr, name)), prop);
@@ -600,11 +595,8 @@ export function jsdocTransformer(
           // Overloads are union-ized into the shared type in FunctionType.
           return ts.visitEachChild(fnDecl, visitor, context);
         }
-        const extraTags = [];
-        if (hasExportingDecorator(fnDecl, typeChecker)) extraTags.push({tagName: 'export'});
 
-        const {tags, thisReturnType} =
-            moduleTypeTranslator.getFunctionTypeJSDoc([fnDecl], extraTags);
+        const {tags, thisReturnType} = moduleTypeTranslator.getFunctionTypeJSDoc([fnDecl]);
 
         // async functions when down-leveled access `this` to pass it to
         // tslib.__awaiter.  Closure wants to know the type of 'this' for that.

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -617,10 +617,12 @@ export function getClosureVisibility(
   }
   if (exportedByDecorator) {
     if (visibility !== 'public') {
-      reportDiagnostic(
-          diagnostics, decl,
-          `A field may not be ${
-              visibility} and use a decorator annotated with @ExportsDecoratedItems.`);
+      // TODO(rictic): Make this fail, once decorator output is renaming safe.
+      // reportDiagnostic(
+      //     diagnostics, decl,
+      //     `A field may not be ${
+      //     visibility} and use a decorator annotated with ` +
+      //     `@ExportsDecoratedItems.`);
     }
     visibility = 'export';
   }

--- a/test_files/exporting_decorator/visibility_clashes.js
+++ b/test_files/exporting_decorator/visibility_clashes.js
@@ -1,0 +1,119 @@
+// test_files/exporting_decorator/visibility_clashes.ts(11,3): error TS0: A field may not be protected and use a decorator annotated with @ExportsDecoratedItems.
+// test_files/exporting_decorator/visibility_clashes.ts(12,3): error TS0: A field may not be private and use a decorator annotated with @ExportsDecoratedItems.
+// test_files/exporting_decorator/visibility_clashes.ts(20,3): error TS0: A field may not be protected and use a decorator annotated with @ExportsDecoratedItems.
+// test_files/exporting_decorator/visibility_clashes.ts(23,3): error TS0: A field may not be private and use a decorator annotated with @ExportsDecoratedItems.
+/**
+ * @fileoverview added by tsickle
+ * Generated from: test_files/exporting_decorator/visibility_clashes.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.exporting_decorator.visibility_clashes');
+var module = module || { id: 'test_files/exporting_decorator/visibility_clashes.ts' };
+module = module;
+const tslib_1 = goog.require('tslib');
+/**
+ * \@ExportDecoratedItems
+ * @return {function(*, (undefined|string|number|symbol)=): void}
+ */
+function exportDecorated() {
+    return (/**
+     * @param {*} protoOrDescriptor
+     * @param {(undefined|string|number|symbol)=} name
+     * @return {void}
+     */
+    (protoOrDescriptor, name) => { });
+}
+class ExportDecoratedClass {
+    constructor() {
+        this.implicitPublicProp = 0;
+        this.publicProp = 0;
+        this.protectedProp = 0;
+        this.privateProp = 0;
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    implicitPublicMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    publicMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    protectedMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    privateMethod() {
+    }
+}
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "implicitPublicProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "publicProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "protectedProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, "privateProp", void 0);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "implicitPublicMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "publicMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "protectedMethod", null);
+tslib_1.__decorate([
+    exportDecorated(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, "privateMethod", null);
+if (false) {
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.implicitPublicProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.publicProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.protectedProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.privateProp;
+}

--- a/test_files/exporting_decorator/visibility_clashes.js
+++ b/test_files/exporting_decorator/visibility_clashes.js
@@ -1,7 +1,3 @@
-// test_files/exporting_decorator/visibility_clashes.ts(11,3): error TS0: A field may not be protected and use a decorator annotated with @ExportsDecoratedItems.
-// test_files/exporting_decorator/visibility_clashes.ts(12,3): error TS0: A field may not be private and use a decorator annotated with @ExportsDecoratedItems.
-// test_files/exporting_decorator/visibility_clashes.ts(20,3): error TS0: A field may not be protected and use a decorator annotated with @ExportsDecoratedItems.
-// test_files/exporting_decorator/visibility_clashes.ts(23,3): error TS0: A field may not be private and use a decorator annotated with @ExportsDecoratedItems.
 /**
  * @fileoverview added by tsickle
  * Generated from: test_files/exporting_decorator/visibility_clashes.ts

--- a/test_files/exporting_decorator/visibility_clashes.ts
+++ b/test_files/exporting_decorator/visibility_clashes.ts
@@ -1,0 +1,28 @@
+/**
+ * @ExportDecoratedItems
+ */
+function exportDecorated() {
+  return (protoOrDescriptor: unknown, name?: PropertyKey): void => {};
+}
+
+class ExportDecoratedClass {
+  @exportDecorated() implicitPublicProp = 0;
+  @exportDecorated() publicProp = 0;
+  @exportDecorated() protected protectedProp = 0;
+  @exportDecorated() private privateProp = 0;
+
+  @exportDecorated()
+  implicitPublicMethod() {
+  }
+  @exportDecorated()
+  publicMethod() {
+  }
+  @exportDecorated()
+  protected protectedMethod() {
+  }
+  @exportDecorated()
+  private privateMethod() {
+  }
+}
+
+export {};


### PR DESCRIPTION
This is backwards compatible, because previously we'd have emitted both `@export` and either `@protected` or `@private`, which is an error in Closure Compiler.

This supercedes https://github.com/angular/tsickle/pull/1122 for now. I'm also working on a couple of follow up changes that make decorator output more rename safe (design at go/renaming-safe-decorators), and add a new annotation `@ExportDecoratedItemsIfPublic` which we could use in the LitElement decorators to allow protected and private fields. In my prototype this seems to work end to end, including renaming, and passes a global presubmit.