### PR TITLE
Support property renaming for decorators

### DIFF
--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -11,6 +11,7 @@ import * as ts from 'typescript';
 import {AnnotatorHost} from './annotator_host';
 import {assertAbsolute} from './cli_support';
 import {decoratorDownlevelTransformer} from './decorator_downlevel_transformer';
+import {transformDecoratorsOutputForClosurePropertyRenaming} from './decorators';
 import {enumTransformer} from './enum_transformer';
 import {generateExterns} from './externs';
 import {transformFileoverviewCommentFactory} from './fileoverview_comment_transformer';
@@ -151,6 +152,7 @@ export function emit(
   if (host.googmodule) {
     tsTransformers.after!.push(googmodule.commonJsToGoogmoduleTransformer(
         host, modulesManifest, typeChecker, tsickleDiagnostics));
+    tsTransformers.after!.push(transformDecoratorsOutputForClosurePropertyRenaming);
   }
 
   // Wrap the writeFile callback to hook writing of the dts file.

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -152,7 +152,8 @@ export function emit(
   if (host.googmodule) {
     tsTransformers.after!.push(googmodule.commonJsToGoogmoduleTransformer(
         host, modulesManifest, typeChecker, tsickleDiagnostics));
-    tsTransformers.after!.push(transformDecoratorsOutputForClosurePropertyRenaming);
+    tsTransformers.after!.push(
+        transformDecoratorsOutputForClosurePropertyRenaming(tsickleDiagnostics));
   }
 
   // Wrap the writeFile callback to hook writing of the dts file.

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -30,6 +30,7 @@ describe('golden file tests', () => {
         'src/closure_externs.js',
         'third_party/tslib/externs.js',
         'third_party/tslib/tslib.js',
+        'test_files/fake_goog_reflect.js',
         'test_files/augment/shim.js',
         'test_files/clutz.no_externs/default_export.js',
         'test_files/clutz.no_externs/some_name_space.js',
@@ -58,7 +59,7 @@ describe('golden file tests', () => {
       'warning_level': 'VERBOSE',
       'js': goldenJs,
       'externs': externs,
-      'language_in': 'ECMASCRIPT6_STRICT',
+      'language_in': 'STABLE',
       'language_out': 'ECMASCRIPT5',
       'jscomp_off': ['lintChecks'],
       'jscomp_error': [

--- a/test/e2e_closure_test.ts
+++ b/test/e2e_closure_test.ts
@@ -59,7 +59,7 @@ describe('golden file tests', () => {
       'warning_level': 'VERBOSE',
       'js': goldenJs,
       'externs': externs,
-      'language_in': 'STABLE',
+      'language_in': 'ECMASCRIPT6_STRICT',
       'language_out': 'ECMASCRIPT5',
       'jscomp_off': ['lintChecks'],
       'jscomp_error': [

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -7,6 +7,7 @@
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };
 module = module;
+const __googReflect = goog.require("goog.reflect");
 const tslib_1 = goog.require('tslib');
 const tsickle_default_export_1 = goog.requireType("test_files.decorator.default_export");
 const tsickle_external_2 = goog.requireType("test_files.decorator.external");
@@ -119,11 +120,11 @@ DecoratorTest.propDecorators = {
 tslib_1.__decorate([
     decorator,
     tslib_1.__metadata("design:type", Number)
-], DecoratorTest.prototype, "x", void 0);
+], DecoratorTest.prototype, __googReflect.objectProperty("x", DecoratorTest.prototype), void 0);
 tslib_1.__decorate([
     decorator,
     tslib_1.__metadata("design:type", external_1.AClass)
-], DecoratorTest.prototype, "z", void 0);
+], DecoratorTest.prototype, __googReflect.objectProperty("z", DecoratorTest.prototype), void 0);
 if (false) {
     /**
      * Some comment

--- a/test_files/decorator/decorator.js
+++ b/test_files/decorator/decorator.js
@@ -7,7 +7,7 @@
 goog.module('test_files.decorator.decorator');
 var module = module || { id: 'test_files/decorator/decorator.ts' };
 module = module;
-const __googReflect = goog.require("goog.reflect");
+const __tsickle_googReflect = goog.require("goog.reflect");
 const tslib_1 = goog.require('tslib');
 const tsickle_default_export_1 = goog.requireType("test_files.decorator.default_export");
 const tsickle_external_2 = goog.requireType("test_files.decorator.external");
@@ -120,11 +120,11 @@ DecoratorTest.propDecorators = {
 tslib_1.__decorate([
     decorator,
     tslib_1.__metadata("design:type", Number)
-], DecoratorTest.prototype, __googReflect.objectProperty("x", DecoratorTest.prototype), void 0);
+], DecoratorTest.prototype, __tsickle_googReflect.objectProperty("x", DecoratorTest.prototype), void 0);
 tslib_1.__decorate([
     decorator,
     tslib_1.__metadata("design:type", external_1.AClass)
-], DecoratorTest.prototype, __googReflect.objectProperty("z", DecoratorTest.prototype), void 0);
+], DecoratorTest.prototype, __tsickle_googReflect.objectProperty("z", DecoratorTest.prototype), void 0);
 if (false) {
     /**
      * Some comment

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -6,7 +6,7 @@
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };
 module = module;
-const __googReflect = goog.require("goog.reflect");
+const __tsickle_googReflect = goog.require("goog.reflect");
 const tslib_1 = goog.require('tslib');
 /**
  * \@ExportDecoratedItems
@@ -77,43 +77,43 @@ class MyClass {
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Boolean)
-], MyClass.prototype, __googReflect.objectProperty("exportMe", MyClass.prototype), void 0);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("exportMe", MyClass.prototype), void 0);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Number)
-], MyClass.prototype, __googReflect.objectProperty("doNotExportMe", MyClass.prototype), void 0);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("doNotExportMe", MyClass.prototype), void 0);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
-], MyClass.prototype, __googReflect.objectProperty("exportThisOneToo", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("exportThisOneToo", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
-], MyClass.prototype, __googReflect.objectProperty("doNotExportThisOneEither", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("doNotExportThisOneEither", MyClass.prototype), null);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Object),
     tslib_1.__metadata("design:paramtypes", [])
-], MyClass.prototype, __googReflect.objectProperty("exportThisGetter", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("exportThisGetter", MyClass.prototype), null);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Number),
     tslib_1.__metadata("design:paramtypes", [Number])
-], MyClass.prototype, __googReflect.objectProperty("exportThisSetter", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("exportThisSetter", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Object),
     tslib_1.__metadata("design:paramtypes", [])
-], MyClass.prototype, __googReflect.objectProperty("doNotExportThisGetter", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("doNotExportThisGetter", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Number),
     tslib_1.__metadata("design:paramtypes", [Number])
-], MyClass.prototype, __googReflect.objectProperty("doNotExportThisSetter", MyClass.prototype), null);
+], MyClass.prototype, __tsickle_googReflect.objectProperty("doNotExportThisSetter", MyClass.prototype), null);
 if (false) {
     /**
      * @type {boolean}

--- a/test_files/exporting_decorator/exporting.js
+++ b/test_files/exporting_decorator/exporting.js
@@ -6,6 +6,7 @@
 goog.module('test_files.exporting_decorator.exporting');
 var module = module || { id: 'test_files/exporting_decorator/exporting.ts' };
 module = module;
+const __googReflect = goog.require("goog.reflect");
 const tslib_1 = goog.require('tslib');
 /**
  * \@ExportDecoratedItems
@@ -76,43 +77,43 @@ class MyClass {
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Boolean)
-], MyClass.prototype, "exportMe", void 0);
+], MyClass.prototype, __googReflect.objectProperty("exportMe", MyClass.prototype), void 0);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Number)
-], MyClass.prototype, "doNotExportMe", void 0);
+], MyClass.prototype, __googReflect.objectProperty("doNotExportMe", MyClass.prototype), void 0);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
-], MyClass.prototype, "exportThisOneToo", null);
+], MyClass.prototype, __googReflect.objectProperty("exportThisOneToo", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Function),
     tslib_1.__metadata("design:paramtypes", []),
     tslib_1.__metadata("design:returntype", void 0)
-], MyClass.prototype, "doNotExportThisOneEither", null);
+], MyClass.prototype, __googReflect.objectProperty("doNotExportThisOneEither", MyClass.prototype), null);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Object),
     tslib_1.__metadata("design:paramtypes", [])
-], MyClass.prototype, "exportThisGetter", null);
+], MyClass.prototype, __googReflect.objectProperty("exportThisGetter", MyClass.prototype), null);
 tslib_1.__decorate([
     exportingDecorator(),
     tslib_1.__metadata("design:type", Number),
     tslib_1.__metadata("design:paramtypes", [Number])
-], MyClass.prototype, "exportThisSetter", null);
+], MyClass.prototype, __googReflect.objectProperty("exportThisSetter", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Object),
     tslib_1.__metadata("design:paramtypes", [])
-], MyClass.prototype, "doNotExportThisGetter", null);
+], MyClass.prototype, __googReflect.objectProperty("doNotExportThisGetter", MyClass.prototype), null);
 tslib_1.__decorate([
     nonExportingDecorator(),
     tslib_1.__metadata("design:type", Number),
     tslib_1.__metadata("design:paramtypes", [Number])
-], MyClass.prototype, "doNotExportThisSetter", null);
+], MyClass.prototype, __googReflect.objectProperty("doNotExportThisSetter", MyClass.prototype), null);
 if (false) {
     /**
      * @type {boolean}

--- a/test_files/fake_goog_reflect.js
+++ b/test_files/fake_goog_reflect.js
@@ -10,8 +10,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-var goog = goog || {};
-goog.provide('goog.reflect');
+goog.module('goog.reflect');
 
 /**
  * A fake goog.reflect.objectProperty
@@ -21,6 +20,6 @@ goog.provide('goog.reflect');
  *     for renaming
  * @return {string} The renamed property.
  */
-goog.reflect.objectProperty = function(prop, object) {
+exports.objectProperty = function(prop, object) {
   return prop;
 };

--- a/test_files/fake_goog_reflect.js
+++ b/test_files/fake_goog_reflect.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview A simple fake version of goog.reflect, for testing compilation.
+ */
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+var goog = goog || {};
+goog.provide('goog.reflect');
+
+/**
+ * A fake goog.reflect.objectProperty
+ *
+ * @param {string} prop Name of the property
+ * @param {!Object} object Instance of the object whose type will be used
+ *     for renaming
+ * @return {string} The renamed property.
+ */
+goog.reflect.objectProperty = function(prop, object) {
+  return prop;
+};


### PR DESCRIPTION
TypeScript converts code like this:

```typescript
class Foo {
  @decorator prop = 'hi';
}
```

into JS like this:

```javascript
tslib_1.__decorate([
    decorator,
    tslib_1.__metadata("design:type", Object)
], Foo.prototype, "prop", void 0);
```

This is a problem for Closure Compiler's property renaming, because the property `prop` may have been renamed, but `"prop"` is just a string literal, and so it won't be renamed. Fortunately there is an API that Closure Compiler knows to process at build time that will rename a string literal representing a field name on a type: https://google.github.io/closure-library/api/goog.reflect.html#objectProperty

With this change, when emitting goog.module output, tsickle will notice calls to `__decorate` and instead emit

```javascript
tslib_1.__decorate([
    decorator,
    tslib_1.__metadata("design:type", Object)
], Foo.prototype, __googReflect.objectProperty("prop", Foo.prototype), void 0);
```

where `__googReflect` is defined just after the `goog.module` section as

```javascript
const __googReflect = goog.require("goog.reflect");
```

In this way, the decorator may safely use the property name with the assurance that it will be renamed at runtime when compiled with Closure Compiler.

Doc (unfortunately internal to google) considering the various implementation options: https://goto.google.com/renaming-safe-decorators