### PR TITLE
Add a IterableIterator as an alias of IteratorIterable.

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -21,6 +21,11 @@ var ArrayLike;
 /** @typedef {!IteratorIterable} */
 var IterableIterator;
 
+/** @typedef {!IIterableResult} */
+var IteratorYieldResult;
+/** @typedef {!IIterableResult} */
+var IteratorReturnResult;
+
 /** @typedef {!HTMLCollection} */
 var HTMLCollectionOf;
 

--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -18,6 +18,9 @@
 /** @typedef {!IArrayLike} */
 var ArrayLike;
 
+/** @typedef {!IteratorIterable} */
+var IterableIterator;
+
 /** @typedef {!HTMLCollection} */
 var HTMLCollectionOf;
 

--- a/test_files/iterator/iterator.js
+++ b/test_files/iterator/iterator.js
@@ -1,0 +1,27 @@
+// test_files/iterator/iterator.ts(7,8): warning TS0: failed to resolve rest parameter type, emitting ?
+/**
+ * @fileoverview added by tsickle
+ * Generated from: test_files/iterator/iterator.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.iterator.iterator');
+var module = module || { id: 'test_files/iterator/iterator.ts' };
+module = module;
+/**
+ * @implements {IterableIterator}
+ */
+class MyIterable {
+    /**
+     * @return {!IterableIterator<string>}
+     */
+    [Symbol.iterator]() {
+        return this;
+    }
+    /**
+     * @param {...?} args
+     * @return {(!IteratorYieldResult<string>|!IteratorReturnResult<string>)}
+     */
+    next(...args) {
+        return { done: true, value: 'x' };
+    }
+}

--- a/test_files/iterator/iterator.ts
+++ b/test_files/iterator/iterator.ts
@@ -1,0 +1,10 @@
+export {};
+
+class MyIterable implements IterableIterator<string> {
+  [Symbol.iterator](): IterableIterator<string> {
+    return this;
+  }
+  next(...args: []|[string | undefined]): IteratorResult<string, string> {
+    return {done: true, value: 'x'};
+  }
+}


### PR DESCRIPTION
Including tests and types for IteratorReturnResult & IteratorYieldResult.

This supersedes #1102.