### PR TITLE
Add the @ExportDecoratedItemsIfPublic decorator modifier.

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -35,25 +35,37 @@ export function getDecoratorDeclarations(
 }
 
 /**
- * Returns true if node has an exporting decorator  (i.e., a decorator with @ExportDecoratedItems
- * in its JSDoc).
+ * Returns true if node has an exporting decorator  (i.e., a decorator
+ * with @ExportDecoratedItems in its JSDoc).
  */
 export function hasExportingDecorator(node: ts.Node, typeChecker: ts.TypeChecker) {
   return node.decorators &&
-      node.decorators.some(decorator => isExportingDecorator(decorator, typeChecker));
+      node.decorators.some(
+          decorator => hasDocsMatching(decorator, /@ExportDecoratedItems\b/, typeChecker));
 }
 
 /**
- * Returns true if the given decorator has an @ExportDecoratedItems directive in its JSDoc.
+ * Returns true if node has an exporting if public decorator (i.e., a decorator
+ * with @ExportDecoratedItemsIfPublic in its JSDoc).
  */
-function isExportingDecorator(decorator: ts.Decorator, typeChecker: ts.TypeChecker) {
+export function hasExportingIfPublicDecorator(node: ts.Node, typeChecker: ts.TypeChecker) {
+  return node.decorators &&
+      node.decorators.some(
+          decorator => hasDocsMatching(decorator, /@ExportDecoratedItemsIfPublic\b/, typeChecker));
+}
+
+/**
+ * Returns true if the given decorator has a comment whose text matches the
+ * given regex.
+ */
+function hasDocsMatching(decorator: ts.Decorator, regex: RegExp, typeChecker: ts.TypeChecker) {
   return getDecoratorDeclarations(decorator, typeChecker).some(declaration => {
     const range = getAllLeadingComments(declaration);
     if (!range) {
       return false;
     }
     for (const {text} of range) {
-      if (/@ExportDecoratedItems\b/.test(text)) {
+      if (regex.test(text)) {
         return true;
       }
     }

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -29,10 +29,10 @@
 import * as ts from 'typescript';
 
 import {AnnotatorHost, moduleNameAsIdentifier} from './annotator_host';
-import {hasExportingDecorator} from './decorators';
+import {hasExportingDecorator, hasExportingIfPublicDecorator} from './decorators';
 import * as googmodule from './googmodule';
 import * as jsdoc from './jsdoc';
-import {ModuleTypeTranslator} from './module_type_translator';
+import {getClosureVisibility, ModuleTypeTranslator} from './module_type_translator';
 import * as transformerUtil from './transformer_util';
 import {symbolIsValue} from './transformer_util';
 import {isValidClosurePropertyName, typeValueConflictHandled} from './type_translator';
@@ -372,10 +372,10 @@ function createClosurePropertyDeclaration(
   const tags = mtt.getJSDoc(prop, /* reportWarnings */ true);
   tags.push({tagName: 'type', type});
   const flags = ts.getCombinedModifierFlags(prop);
-  if (flags & ts.ModifierFlags.Protected) {
-    tags.push({tagName: 'protected'});
-  } else if (flags & ts.ModifierFlags.Private) {
-    tags.push({tagName: 'private'});
+  const visibility = getClosureVisibility(prop, mtt.typeChecker);
+  if (visibility !== 'public') {
+    // Public is the default, otherwise emit a jsdoc tag.
+    tags.push({tagName: visibility});
   }
   if (hasExportingDecorator(prop, mtt.typeChecker)) {
     tags.push({tagName: 'export'});

--- a/test_files/exporting_decorator/export_if_public.js
+++ b/test_files/exporting_decorator/export_if_public.js
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview added by tsickle
+ * Generated from: test_files/exporting_decorator/export_if_public.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+goog.module('test_files.exporting_decorator.export_if_public');
+var module = module || { id: 'test_files/exporting_decorator/export_if_public.ts' };
+module = module;
+const __tsickle_googReflect = goog.require("goog.reflect");
+const tslib_1 = goog.require('tslib');
+/**
+ * \@ExportDecoratedItemsIfPublic
+ * @return {function(*, (undefined|string|number|symbol)=): void}
+ */
+function exportDecoratedIfPublic() {
+    return (/**
+     * @param {*} protoOrDescriptor
+     * @param {(undefined|string|number|symbol)=} name
+     * @return {void}
+     */
+    (protoOrDescriptor, name) => { });
+}
+class ExportDecoratedClass {
+    constructor() {
+        this.implicitPublicProp = 0;
+        this.publicProp = 0;
+        this.protectedProp = 0;
+        this.privateProp = 0;
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    implicitPublicMethod() {
+    }
+    /**
+     * @export
+     * @return {void}
+     */
+    publicMethod() {
+    }
+    ;
+    /**
+     * @protected
+     * @return {void}
+     */
+    protectedMethod() {
+    }
+    ;
+    /**
+     * @private
+     * @return {void}
+     */
+    privateMethod() {
+    }
+    ;
+}
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("implicitPublicProp", ExportDecoratedClass.prototype), void 0);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("publicProp", ExportDecoratedClass.prototype), void 0);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("protectedProp", ExportDecoratedClass.prototype), void 0);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Object)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("privateProp", ExportDecoratedClass.prototype), void 0);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("implicitPublicMethod", ExportDecoratedClass.prototype), null);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("publicMethod", ExportDecoratedClass.prototype), null);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("protectedMethod", ExportDecoratedClass.prototype), null);
+tslib_1.__decorate([
+    exportDecoratedIfPublic(),
+    tslib_1.__metadata("design:type", Function),
+    tslib_1.__metadata("design:paramtypes", []),
+    tslib_1.__metadata("design:returntype", void 0)
+], ExportDecoratedClass.prototype, __tsickle_googReflect.objectProperty("privateMethod", ExportDecoratedClass.prototype), null);
+if (false) {
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.implicitPublicProp;
+    /**
+     * @type {number}
+     * @export
+     */
+    ExportDecoratedClass.prototype.publicProp;
+    /**
+     * @type {number}
+     * @protected
+     */
+    ExportDecoratedClass.prototype.protectedProp;
+    /**
+     * @type {number}
+     * @private
+     */
+    ExportDecoratedClass.prototype.privateProp;
+    /* Skipping unhandled member: ;*/
+    /* Skipping unhandled member: ;*/
+    /* Skipping unhandled member: ;*/
+}

--- a/test_files/exporting_decorator/export_if_public.ts
+++ b/test_files/exporting_decorator/export_if_public.ts
@@ -1,0 +1,28 @@
+/**
+ * @ExportDecoratedItemsIfPublic
+ */
+function exportDecoratedIfPublic() {
+  return (protoOrDescriptor: unknown, name?: PropertyKey): void => {};
+}
+
+class ExportDecoratedClass {
+  @exportDecoratedIfPublic() implicitPublicProp = 0;
+  @exportDecoratedIfPublic() public publicProp = 0;
+  @exportDecoratedIfPublic() protected protectedProp = 0;
+  @exportDecoratedIfPublic() private privateProp = 0;
+
+  @exportDecoratedIfPublic()
+  implicitPublicMethod() {
+  }
+  @exportDecoratedIfPublic()
+  public publicMethod() {
+  };
+  @exportDecoratedIfPublic()
+  protected protectedMethod() {
+  };
+  @exportDecoratedIfPublic()
+  private privateMethod() {
+  };
+}
+
+export {};


### PR DESCRIPTION
@ExportDecoratedItemsIfPublic is a new decorator modifier for fields which should only be exported if public. When private or protected they are renamable and may be eliminated as dead code. This is more optimal version of @ExportDecoratedItems for fields which can only be accessed by reflection if they're public.

Our use case ExportDecoratedItemsIfPublic is the LitElement @property decorator, where public properties are accessible as HTML attributes and may be written by raw HTML files or various template languages (lit-html, soy, angular templates, etc). This obviously is taking place outside of the class hierarchy of the element and so is only valid for public properties, but it is still useful for private properties to participate in the update lifecycle that comes along with @property.

This change, combined with the already-landed https://github.com/angular/tsickle/pull/1125 we'll be able to remove the final @ExportDecoratedItems annotation from the LitElement decorators.