### PR TITLE
Add @suppress before @license tags in file overview comments.

### DIFF
--- a/src/fileoverview_comment_transformer.ts
+++ b/src/fileoverview_comment_transformer.ts
@@ -49,7 +49,15 @@ function augmentFileoverviewComments(
     suppressions = new Set((suppressTag.type || '').split(',').map(s => s.trim()));
   } else {
     suppressTag = {tagName: 'suppress', text: 'checked by tsc'};
-    tags.push(suppressTag);
+    // Special case the @license tag because all text following this tag is
+    // treated by the compiler as part of the license, so we need to place the
+    // new @suppress tag before @license.
+    const licenseTagIndex = tags.findIndex(t => t.tagName === 'license');
+    if (licenseTagIndex !== -1) {
+      tags.splice(licenseTagIndex, 0, suppressTag);
+    } else {
+      tags.push(suppressTag);
+    }
     suppressions = new Set();
   }
 

--- a/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview a comment with a license tag.
+ *
+ * @license
+ * Some license
+ */
+goog.module('test_files.file_comment.puretransform.fileoverview_comment_add_suppress_before_license');
+var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.ts' };
+module = module;
+// here comes code.
+exports.x = 1;

--- a/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.ts
+++ b/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.ts
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview a comment with a license tag.
+ *
+ * @license
+ * Some license
+ */
+
+// here comes code.
+export let x = 1;

--- a/test_files/file_comment/fileoverview_comment_add_suppress_before_license.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress_before_license.js
@@ -1,0 +1,16 @@
+/**
+ *
+ * @fileoverview a comment with a license tag.
+ *
+ * Generated from: test_files/file_comment/fileoverview_comment_add_suppress_before_license.ts
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ * @license
+ * Some license
+ *
+ */
+// here comes code.
+goog.module('test_files.file_comment.fileoverview_comment_add_suppress_before_license');
+var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress_before_license.ts' };
+module = module;
+/** @type {number} */
+exports.x = 1;

--- a/test_files/file_comment/fileoverview_comment_add_suppress_before_license.ts
+++ b/test_files/file_comment/fileoverview_comment_add_suppress_before_license.ts
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview a comment with a license tag.
+ *
+ * @license
+ * Some license
+ */
+
+// here comes code.
+export let x = 1;


### PR DESCRIPTION
Special case the `@license` tag in the file overview comments so that newly added `@suppress` tags are placed above `@license` tags.

`@license` tag treats all text that comes after it as part of the license, so if `@suppress` is added after `@license` tags, it is essentially ignored by the Closure Compiler.