### PR TITLE
Updated Peer Dependencies since getTypeArguments is only available in…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "src/*"
   ],
   "peerDependencies": {
-    "typescript": "~3.6.4"
+    "typescript": "~3.7.3"
   },
   "devDependencies": {
     "@bazel/bazel": "^0.29.0",


### PR DESCRIPTION
… typescript >3.7.x