### PR TITLE
Fix Tsickle when compiled by Closure Compiler

### DIFF
--- a/src/googmodule.ts
+++ b/src/googmodule.ts
@@ -281,7 +281,7 @@ export function commonJsToGoogmoduleTransformer(
       // that a bundle by definition cannot be a goog.module()). The cast through any is necessary
       // to remain compatible with earlier TS versions.
       // tslint:disable-next-line:no-any
-      if ((sf as any).kind !== ts.SyntaxKind.SourceFile) return sf;
+      if ((sf as any)['kind'] !== ts.SyntaxKind.SourceFile) return sf;
 
       // JS scripts (as opposed to modules), must not be rewritten to
       // goog.modules.

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -508,7 +508,7 @@ export class ModuleTypeTranslator {
         // parameter. It's not clear how to resolve the two conflicting this types best, the current
         // solution prefers the explicitly given `this` parameter.
         // tslint:disable-next-line:no-any accessing TS internal field.
-        if ((retType as any).isThisType && !hasThisParam) {
+        if ((retType as any)['isThisType'] && !hasThisParam) {
           // foo(): this
           thisReturnType = retType;
           addTag({tagName: 'template', text: 'THIS'});

--- a/src/transformer_util.ts
+++ b/src/transformer_util.ts
@@ -178,7 +178,7 @@ export function isTypeNodeKind(kind: ts.SyntaxKind) {
 export function createSingleQuoteStringLiteral(text: string): ts.StringLiteral {
   const stringLiteral = ts.createLiteral(text);
   // tslint:disable-next-line:no-any accessing TS internal API.
-  (stringLiteral as any).singleQuote = true;
+  (stringLiteral as any)['singleQuote'] = true;
   return stringLiteral;
 }
 

--- a/src/tsickle.ts
+++ b/src/tsickle.ts
@@ -280,7 +280,7 @@ function addClutzAliases(
       // This uses an internal TS API, assuming that accessing this will be more stable compared to
       // implementing our own version.
       // tslint:disable-next-line: no-any
-      if (options.stripInternal && (ts as any).isInternalDeclaration(d, origSourceFile)) {
+      if (options.stripInternal && (ts as any)['isInternalDeclaration'](d, origSourceFile)) {
         return false;
       }
 

--- a/src/type_translator.ts
+++ b/src/type_translator.ts
@@ -540,7 +540,7 @@ export class TypeTranslator {
       // In that case, take the parent symbol of the enum member, which should be the enum
       // declaration.
       // tslint:disable-next-line:no-any working around a TS API deficiency.
-      const parent: ts.Symbol|undefined = (symbol as any).parent;
+      const parent: ts.Symbol|undefined = (symbol as any)['parent'];
       if (!parent) return '?';
       symbol = parent;
     }


### PR DESCRIPTION
When Tsickle is used to compile Tsickle with Closure Compiler it breaks when encountering an `export` statement like: `export const t = 10`. This is due to some property renaming by the compiler, where a dot-access is used to call an internal method after casting to any. This was fixed by changing the method access to use brackets + string, so Closure Compiler will leave it alone. 