### PR TITLE
Add a require to tslib for all generated JS files from tsickle.

### DIFF
--- a/test/googmodule_test.ts
+++ b/test/googmodule_test.ts
@@ -29,7 +29,7 @@ function processES5(fileName: string, content: string, {
   const host: googmodule.GoogModuleProcessorHost = {
     fileNameToModuleId: (fn: string) => path.relative(rootDir, fn),
     pathToModuleName: (context, fileName) =>
-        cliSupport.pathToModuleName(rootDir, context, fileName),
+        testSupport.pathToModuleName(rootDir, context, fileName),
     es5Mode: isES5,
     options: testSupport.compilerOptions,
     moduleResolutionHost: tsHost,
@@ -68,6 +68,7 @@ describe('convertCommonJsToGoogModule', () => {
     // NB: no line break added below.
     expectCommonJs('a.ts', `console.log('hello');`).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 console.log('hello');
 `);
   });
@@ -77,6 +78,7 @@ console.log('hello');
     expectCommonJs('a.ts', `console.log('hello');`, false).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
 module = module;
+goog.require('tslib');
 console.log('hello');
 `);
   });
@@ -84,12 +86,14 @@ console.log('hello');
   it('adds a goog.module call to empty files', () => {
     expectCommonJs('a.ts', ``).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 `);
   });
 
   it('adds a goog.module call to empty-looking files', () => {
     expectCommonJs('a.ts', `// empty`).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 // empty
 `);
   });
@@ -100,6 +104,7 @@ var module = module || { id: 'a.ts' };
 console.log('hello');`)
         .toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 console.log('hello');
 `);
   });
@@ -107,6 +112,7 @@ console.log('hello');
   it('converts imports to goog.require calls', () => {
     expectCommonJs('a.ts', `import {x} from 'req/mod'; console.log(x);`).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 var mod_1 = goog.require('req.mod');
 console.log(mod_1.x);
 `);
@@ -119,6 +125,7 @@ console.log(mod_1.x);
         .toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
 module = module;
+goog.require('tslib');
 const mod_1 = goog.require('req.mod');
 console.log(mod_1.x);
 `);
@@ -127,6 +134,7 @@ console.log(mod_1.x);
   it('converts side-effect import to goog.require calls', () => {
     expectCommonJs('a.ts', `import 'req/mod';`).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 var tsickle_module_1_ = goog.require('req.mod');
 `);
   });
@@ -137,6 +145,7 @@ var tsickle_module_1_ = goog.require('req.mod');
 import 'req/mod';`)
         .toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 // Comment
 var tsickle_module_1_ = goog.require('req.mod');
 `);
@@ -152,6 +161,7 @@ console.log('in mod_a', dep, sharedDep);
 `).toBe(`/** @modName {mod_a} */
 goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 var dep_1 = goog.require('dep');
 var shared_dep_1 = goog.require('shared_dep');
 console.log('in mod_a', dep_1.dep, shared_dep_1.sharedDep);
@@ -166,6 +176,7 @@ import {sharedDep} from './shared_dep';
 console.log('in mod_a', dep, sharedDep);
 `).toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 /** @modName {mod_a} */
 var dep_1 = goog.require('dep');
 var shared_dep_1 = goog.require('shared_dep');
@@ -185,6 +196,7 @@ console.log('in mod_a', x);
 `).toBe(`/** @fileoverview Hello Comment. */
 goog.module('a');
 var module = module || { id: 'a.ts' };
+goog.require('tslib');
 // Only uses the import as a type.
 const x = 1;
 console.log('in mod_a', x);
@@ -236,6 +248,7 @@ console.log(mod_1.x);
 console.log(x);`)
         .toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var mod_1 = goog.require('a.req.mod');
 console.log(mod_1.x);
 `);
@@ -247,6 +260,7 @@ import Foo from 'goog:foo_bar.baz';
 console.log(Foo);`)
         .toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var goog_foo_bar_baz_1 = goog.require('foo_bar.baz');
 console.log(goog_foo_bar_baz_1);
 `);
@@ -258,6 +272,7 @@ import Foo from 'goog:use.Foo';
 console.log(Foo);`)
         .toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var goog_use_Foo_1 = goog.require('use.Foo');
 console.log(goog_use_Foo_1);
 `);
@@ -269,6 +284,7 @@ import {default as Foo} from 'goog:use.Foo';
 console.log(Foo);`)
         .toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var goog_use_Foo_1 = goog.require('use.Foo');
 console.log(goog_use_Foo_1);
 `);
@@ -279,6 +295,7 @@ console.log(goog_use_Foo_1);
 export {default as Foo} from 'goog:use.Foo';
 `).toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var goog_use_Foo_1 = goog.require('use.Foo');
 exports.Foo = goog_use_Foo_1;
 `);
@@ -290,6 +307,7 @@ import * as Foo from 'goog:use.Foo';
 console.log(Foo.default);
 `).toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var Foo = goog.require('use.Foo');
 console.log(Foo);
 `);
@@ -302,6 +320,7 @@ console.log(this.default);
 console.log(foo.bar.default);`)
         .toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 console.log(this.default);
 console.log(foo.bar.default);
 `);
@@ -318,6 +337,7 @@ var foo = bar;
  */
 goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var foo = bar;
 `);
   });
@@ -329,6 +349,7 @@ Foo;
 Foo2;
 `).toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var goog_foo_1 = goog.require('foo');
 var goog_foo_2 = goog_foo_1;
 goog_foo_1;
@@ -348,6 +369,7 @@ console.log(sym, es6RelativeRequire, es6NonRelativeRequire);
     // Sanity check the output.
     expect(output).toBe(`goog.module('a.b');
 var module = module || { id: 'a/b.ts' };
+goog.require('tslib');
 var tsickle_module_1_ = goog.require('foo.bare_require');
 var goog_foo_bar_1 = goog.require('foo.bar');
 var relative_1 = goog.require('a.relative');
@@ -368,6 +390,7 @@ console.log(goog_foo_bar_1, relative_1.es6RelativeRequire, relative_2.es6NonRela
         .toBe(`goog.module('a');
 var module = module || { id: 'a.ts' };
 module = module;
+goog.require('tslib');
 console.log('hello');
 exports = 1;
 `);

--- a/test_files/abstract/abstract.js
+++ b/test_files/abstract/abstract.js
@@ -6,6 +6,7 @@
 goog.module('test_files.abstract.abstract');
 var module = module || { id: 'test_files/abstract/abstract.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @abstract
  */

--- a/test_files/anon_class/anon_class.js
+++ b/test_files/anon_class/anon_class.js
@@ -9,6 +9,7 @@
 goog.module('test_files.anon_class.anon_class');
 var module = module || { id: 'test_files/anon_class/anon_class.ts' };
 module = module;
+goog.require('tslib');
 /** @type {?} */
 const anonClassInstance = new class {
 };

--- a/test_files/arrow_fn.es5/arrow_fn_es5.js
+++ b/test_files/arrow_fn.es5/arrow_fn_es5.js
@@ -5,6 +5,7 @@
  */
 goog.module('test_files.arrow_fn.es5.arrow_fn_es5');
 var module = module || { id: 'test_files/arrow_fn.es5/arrow_fn_es5.ts' };
+goog.require('tslib');
 /** @type {function(): void} */
 var foo = (/**
  * @return {void}

--- a/test_files/arrow_fn.untyped/arrow_fn.untyped.js
+++ b/test_files/arrow_fn.untyped/arrow_fn.untyped.js
@@ -6,6 +6,7 @@
 goog.module('test_files.arrow_fn.untyped.arrow_fn.untyped');
 var module = module || { id: 'test_files/arrow_fn.untyped/arrow_fn.untyped.ts' };
 module = module;
+goog.require('tslib');
 /** @type {?} */
 var fn3 = (/**
  * @param {?} a

--- a/test_files/arrow_fn/arrow_fn.js
+++ b/test_files/arrow_fn/arrow_fn.js
@@ -6,6 +6,7 @@
 goog.module('test_files.arrow_fn.arrow_fn');
 var module = module || { id: 'test_files/arrow_fn/arrow_fn.ts' };
 module = module;
+goog.require('tslib');
 /** @type {function(number): number} */
 var fn3 = (/**
  * @param {number} a

--- a/test_files/augment/user.js
+++ b/test_files/augment/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.augment.user');
 var module = module || { id: 'test_files/augment/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_angular_1 = goog.requireType("test_files.augment.angular.index");
 const ng = goog.require('test_files.augment.angular.index');
 /** @type {!tsickle_angular_1.Scope} */

--- a/test_files/automatic_semicolon_insertion/asi.js
+++ b/test_files/automatic_semicolon_insertion/asi.js
@@ -6,6 +6,7 @@
 goog.module('test_files.automatic_semicolon_insertion.asi');
 var module = module || { id: 'test_files/automatic_semicolon_insertion/asi.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @return {function(number): number}
  */

--- a/test_files/basic.untyped/basic.untyped.js
+++ b/test_files/basic.untyped/basic.untyped.js
@@ -6,6 +6,7 @@
 goog.module('test_files.basic.untyped.basic.untyped');
 var module = module || { id: 'test_files/basic.untyped/basic.untyped.ts' };
 module = module;
+goog.require('tslib');
 // This test is just a random collection of typed code, to
 // ensure the output is all with {?} annotations.
 /**

--- a/test_files/blacklisted_ambient_external_module/user.js
+++ b/test_files/blacklisted_ambient_external_module/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.blacklisted_ambient_external_module.user');
 var module = module || { id: 'test_files/blacklisted_ambient_external_module/user.ts' };
 module = module;
+goog.require('tslib');
 class User {
     constructor() { this.field = null; }
 }

--- a/test_files/cast_extends/cast_extends.js
+++ b/test_files/cast_extends/cast_extends.js
@@ -11,6 +11,7 @@
 goog.module('test_files.cast_extends.cast_extends');
 var module = module || { id: 'test_files/cast_extends/cast_extends.ts' };
 module = module;
+goog.require('tslib');
 class Someclass {
 }
 /**

--- a/test_files/class.untyped/class.js
+++ b/test_files/class.untyped/class.js
@@ -7,6 +7,7 @@
 goog.module('test_files.class.untyped.class');
 var module = module || { id: 'test_files/class.untyped/class.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/class/class.js
+++ b/test_files/class/class.js
@@ -19,6 +19,7 @@
 goog.module('test_files.class.class');
 var module = module || { id: 'test_files/class/class.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/clutz.no_externs/import_default.js
+++ b/test_files/clutz.no_externs/import_default.js
@@ -9,6 +9,7 @@
 goog.module('test_files.clutz.no_externs.import_default');
 var module = module || { id: 'test_files/clutz.no_externs/import_default.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_goog_default_export_1 = goog.requireType("default_export");
 /** @type {(null|!tsickle_goog_default_export_1)} */
 const usingType = null;

--- a/test_files/clutz.no_externs/strip_clutz_type.js
+++ b/test_files/clutz.no_externs/strip_clutz_type.js
@@ -6,6 +6,7 @@
 goog.module('test_files.clutz.no_externs.strip_clutz_type');
 var module = module || { id: 'test_files/clutz.no_externs/strip_clutz_type.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_space_1 = goog.requireType("some.name.space");
 const tsickle_other_2 = goog.requireType("some.other");
 const goog_some_name_space_1 = goog.require('some.name.space');

--- a/test_files/clutz_type_value.no_externs/user.js
+++ b/test_files/clutz_type_value.no_externs/user.js
@@ -9,6 +9,7 @@
 goog.module('test_files.clutz_type_value.no_externs.user');
 var module = module || { id: 'test_files/clutz_type_value.no_externs/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_goog_type_value_1 = goog.requireType("type_value");
 // We expect IFace to show up in the @implements tag.
 /**

--- a/test_files/coerce/coerce.js
+++ b/test_files/coerce/coerce.js
@@ -6,6 +6,7 @@
 goog.module('test_files.coerce.coerce');
 var module = module || { id: 'test_files/coerce/coerce.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {string} arg
  * @return {string}

--- a/test_files/comments/comments.js
+++ b/test_files/comments/comments.js
@@ -6,6 +6,7 @@
 goog.module('test_files.comments.comments');
 var module = module || { id: 'test_files/comments/comments.ts' };
 module = module;
+goog.require('tslib');
 class Comments {
 }
 if (false) {

--- a/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
+++ b/test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.js
@@ -9,6 +9,7 @@
 goog.module('test_files.conditional_rest_tuple_type.conditional_rest_tuple_type');
 var module = module || { id: 'test_files/conditional_rest_tuple_type/conditional_rest_tuple_type.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @template T
  * @param {...?} args

--- a/test_files/conditional_type/conditional_type.js
+++ b/test_files/conditional_type/conditional_type.js
@@ -7,5 +7,6 @@
 goog.module('test_files.conditional_type.conditional_type');
 var module = module || { id: 'test_files/conditional_type/conditional_type.ts' };
 module = module;
+goog.require('tslib');
 /** @typedef {?} */
 exports.Filter;

--- a/test_files/ctors/ctors.js
+++ b/test_files/ctors/ctors.js
@@ -6,6 +6,7 @@
 goog.module('test_files.ctors.ctors');
 var module = module || { id: 'test_files/ctors/ctors.ts' };
 module = module;
+goog.require('tslib');
 /** @type {function(new:Document)} */
 let x = Document;
 class X {

--- a/test_files/debugger/user.js
+++ b/test_files/debugger/user.js
@@ -10,5 +10,6 @@
 goog.module('test_files.debugger.user');
 var module = module || { id: 'test_files/debugger/user.ts' };
 module = module;
+goog.require('tslib');
 /** @type {(null|!_debugger.Foo)} */
 const x = null;

--- a/test_files/declare/declare_nondts.js
+++ b/test_files/declare/declare_nondts.js
@@ -6,3 +6,4 @@
 goog.module('test_files.declare.declare_nondts');
 var module = module || { id: 'test_files/declare/declare_nondts.ts' };
 module = module;
+goog.require('tslib');

--- a/test_files/declare/user.js
+++ b/test_files/declare/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.declare.user');
 var module = module || { id: 'test_files/declare/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_declare_module_1 = goog.requireType("test_files.declare.declare_module");
 const declare_module_1 = goog.require('test_files.declare.declare_module');
 /** @type {!ModuleGlobalClass} */

--- a/test_files/declare_class_ns/declare_class_ns.js
+++ b/test_files/declare_class_ns/declare_class_ns.js
@@ -6,3 +6,4 @@
 goog.module('test_files.declare_class_ns.declare_class_ns');
 var module = module || { id: 'test_files/declare_class_ns/declare_class_ns.ts' };
 module = module;
+goog.require('tslib');

--- a/test_files/declare_class_overloads/declare_class_overloads.js
+++ b/test_files/declare_class_overloads/declare_class_overloads.js
@@ -6,3 +6,4 @@
 goog.module('test_files.declare_class_overloads.declare_class_overloads');
 var module = module || { id: 'test_files/declare_class_overloads/declare_class_overloads.ts' };
 module = module;
+goog.require('tslib');

--- a/test_files/declare_export.untyped/declare_export.js
+++ b/test_files/declare_export.untyped/declare_export.js
@@ -6,5 +6,6 @@
 goog.module('test_files.declare_export.untyped.declare_export');
 var module = module || { id: 'test_files/declare_export.untyped/declare_export.ts' };
 module = module;
+goog.require('tslib');
 ;
 ;

--- a/test_files/declare_export/declare_export.js
+++ b/test_files/declare_export/declare_export.js
@@ -16,6 +16,7 @@
 goog.module('test_files.declare_export.declare_export');
 var module = module || { id: 'test_files/declare_export/declare_export.ts' };
 module = module;
+goog.require('tslib');
 /** @type {!test_files$declare_export$declare_export.ExportDeclaredIf} */
 let user1;
 /** @typedef {!test_files$declare_export$declare_export.ExportDeclaredIf} */

--- a/test_files/declare_export_dts/user.js
+++ b/test_files/declare_export_dts/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.declare_export_dts.user');
 var module = module || { id: 'test_files/declare_export_dts/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_declare_export_dts_1 = goog.requireType("test_files.declare_export_dts.declare_export_dts");
 /** @type {!tsickle_declare_export_dts_1.InterfaceExportedInDts} */
 const useExportDeclaredInterface = {

--- a/test_files/declare_import/export_default.js
+++ b/test_files/declare_import/export_default.js
@@ -6,6 +6,7 @@
 goog.module('test_files.declare_import.export_default');
 var module = module || { id: 'test_files/declare_import/export_default.ts' };
 module = module;
+goog.require('tslib');
 // tslint:disable-next-line:no-default-export
 class ExportDefaultClass {
 }

--- a/test_files/declare_import/exporter.js
+++ b/test_files/declare_import/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.declare_import.exporter');
 var module = module || { id: 'test_files/declare_import/exporter.ts' };
 module = module;
+goog.require('tslib');
 class ExportedClass {
 }
 exports.ExportedClass = ExportedClass;

--- a/test_files/decorator/default_export.js
+++ b/test_files/decorator/default_export.js
@@ -6,6 +6,7 @@
 goog.module('test_files.decorator.default_export');
 var module = module || { id: 'test_files/decorator/default_export.ts' };
 module = module;
+goog.require('tslib');
 // tslint:disable-next-line:no-default-export
 class DefaultExport {
 }

--- a/test_files/decorator/external.js
+++ b/test_files/decorator/external.js
@@ -6,6 +6,7 @@
 goog.module('test_files.decorator.external');
 var module = module || { id: 'test_files/decorator/external.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_external2_1 = goog.requireType("test_files.decorator.external2");
 const external2_1 = goog.require('test_files.decorator.external2');
 exports.ReexportedOtherClass = external2_1.OtherClass;

--- a/test_files/decorator/external2.js
+++ b/test_files/decorator/external2.js
@@ -6,6 +6,7 @@
 goog.module('test_files.decorator.external2');
 var module = module || { id: 'test_files/decorator/external2.ts' };
 module = module;
+goog.require('tslib');
 class OtherClass {
 }
 exports.OtherClass = OtherClass;

--- a/test_files/decorator/only_types.js
+++ b/test_files/decorator/only_types.js
@@ -9,6 +9,7 @@
 goog.module('test_files.decorator.only_types');
 var module = module || { id: 'test_files/decorator/only_types.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/decorator_nested_scope/decorator_nested_scope.js
+++ b/test_files/decorator_nested_scope/decorator_nested_scope.js
@@ -6,6 +6,7 @@
 goog.module('test_files.decorator_nested_scope.decorator_nested_scope');
 var module = module || { id: 'test_files/decorator_nested_scope/decorator_nested_scope.ts' };
 module = module;
+goog.require('tslib');
 class SomeService {
 }
 /**

--- a/test_files/default/default.js
+++ b/test_files/default/default.js
@@ -6,6 +6,7 @@
 goog.module('test_files.default.default');
 var module = module || { id: 'test_files/default/default.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {number} x
  * @param {string=} y

--- a/test_files/doc_params/doc_params.js
+++ b/test_files/doc_params/doc_params.js
@@ -6,6 +6,7 @@
 goog.module('test_files.doc_params.doc_params');
 var module = module || { id: 'test_files/doc_params/doc_params.ts' };
 module = module;
+goog.require('tslib');
 class Foo {
     /**
      * @ngInject

--- a/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
+++ b/test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.js
@@ -6,6 +6,7 @@
 goog.module('test_files.docs_on_ctor_param_properties.docs_on_ctor_param_properties');
 var module = module || { id: 'test_files/docs_on_ctor_param_properties/docs_on_ctor_param_properties.ts' };
 module = module;
+goog.require('tslib');
 class Clazz {
     /**
      * @param {!Array<string>} id

--- a/test_files/enum.untyped/enum.untyped.js
+++ b/test_files/enum.untyped/enum.untyped.js
@@ -6,6 +6,7 @@
 goog.module('test_files.enum.untyped.enum.untyped');
 var module = module || { id: 'test_files/enum.untyped/enum.untyped.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {number} */
 const EnumUntypedTest1 = {
     XYZ: 0, PI: 3.14159,

--- a/test_files/enum/enum.js
+++ b/test_files/enum/enum.js
@@ -8,6 +8,7 @@
 goog.module('test_files.enum.enum');
 var module = module || { id: 'test_files/enum/enum.ts' };
 module = module;
+goog.require('tslib');
 /** @type {!Array<?>} */
 const EnumTestMissingSemi = [];
 /** @enum {number} */

--- a/test_files/enum/enum_user.js
+++ b/test_files/enum/enum_user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.enum.enum_user');
 var module = module || { id: 'test_files/enum/enum_user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_enum_1 = goog.requireType("test_files.enum.enum");
 /**
  * @record

--- a/test_files/enum_ref_import/enum_ref_import.js
+++ b/test_files/enum_ref_import/enum_ref_import.js
@@ -16,6 +16,7 @@
 goog.module('test_files.enum_ref_import.enum_ref_import');
 var module = module || { id: 'test_files/enum_ref_import/enum_ref_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.enum_ref_import.exporter");
 /** @enum {string} */
 const ValuesInInitializer = {

--- a/test_files/enum_ref_import/exporter.js
+++ b/test_files/enum_ref_import/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.enum_ref_import.exporter');
 var module = module || { id: 'test_files/enum_ref_import/exporter.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {string} */
 const Enum = {
     X: "x",

--- a/test_files/enum_value_literal_type/enum_value_literal_type.js
+++ b/test_files/enum_value_literal_type/enum_value_literal_type.js
@@ -10,6 +10,7 @@
 goog.module('test_files.enum_value_literal_type.enum_value_literal_type');
 var module = module || { id: 'test_files/enum_value_literal_type/enum_value_literal_type.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {number} */
 const ExportedEnum = {
     VALUE: 0,

--- a/test_files/export/export.js
+++ b/test_files/export/export.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export.export');
 var module = module || { id: 'test_files/export/export.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_helper_1 = goog.requireType("test_files.export.export_helper");
 const tsickle_export_helper_2_2 = goog.requireType("test_files.export.export_helper_2");
 const tsickle_type_and_value_3 = goog.requireType("test_files.export.type_and_value");

--- a/test_files/export/export_helper.js
+++ b/test_files/export/export_helper.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export.export_helper');
 var module = module || { id: 'test_files/export/export_helper.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_helper_2_1 = goog.requireType("test_files.export.export_helper_2");
 // This file isn't itself a test case, but it is imported by the
 // export.in.ts test case.

--- a/test_files/export/export_helper_2.js
+++ b/test_files/export/export_helper_2.js
@@ -8,6 +8,7 @@
 goog.module('test_files.export.export_helper_2');
 var module = module || { id: 'test_files/export/export_helper_2.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.export2 = 3;
 /** @type {number} */

--- a/test_files/export/export_helper_3.js
+++ b/test_files/export/export_helper_3.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export.export_helper_3');
 var module = module || { id: 'test_files/export/export_helper_3.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/export/export_star_imported.js
+++ b/test_files/export/export_star_imported.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export.export_star_imported');
 var module = module || { id: 'test_files/export/export_star_imported.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_helper_1 = goog.requireType("test_files.export.export_helper");
 const export_helper_1 = goog.require('test_files.export.export_helper');
 exports.export1 = export_helper_1.export1;

--- a/test_files/export/type_and_value.js
+++ b/test_files/export/type_and_value.js
@@ -6,5 +6,6 @@
 goog.module('test_files.export.type_and_value');
 var module = module || { id: 'test_files/export/type_and_value.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.TypeAndValue = 1;

--- a/test_files/export_declare_namespace/export_declare_namespace.js
+++ b/test_files/export_declare_namespace/export_declare_namespace.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_declare_namespace.export_declare_namespace');
 var module = module || { id: 'test_files/export_declare_namespace/export_declare_namespace.ts' };
 module = module;
+goog.require('tslib');
 class ModuleType {
 }
 exports.ModuleType = ModuleType;

--- a/test_files/export_declare_namespace/user.js
+++ b/test_files/export_declare_namespace/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_declare_namespace.user');
 var module = module || { id: 'test_files/export_declare_namespace/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_declare_namespace_1 = goog.requireType("test_files.export_declare_namespace.export_declare_namespace");
 /** @type {!tsickle_export_declare_namespace_1.exportedDeclaredNamespace.Used} */
 let x;

--- a/test_files/export_equals.shim/export_equals.js
+++ b/test_files/export_equals.shim/export_equals.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_equals.shim.export_equals');
 var module = module || { id: 'test_files/export_equals.shim/export_equals.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_namespace_1 = goog.requireType("test_files.export_equals.shim.namespace");
 const someNamespace = goog.require('test_files.export_equals.shim.namespace');
 exports = someNamespace;

--- a/test_files/export_equals.shim/user.js
+++ b/test_files/export_equals.shim/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_equals.shim.user');
 var module = module || { id: 'test_files/export_equals.shim/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_equals_1 = goog.requireType("test_files.export_equals.shim.export_equals");
 const modPrefix = goog.require('test_files.export_equals.shim.export_equals');
 console.log(new modPrefix.Clazz());

--- a/test_files/export_local_type/export_local_type.js
+++ b/test_files/export_local_type/export_local_type.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_local_type.export_local_type');
 var module = module || { id: 'test_files/export_local_type/export_local_type.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/export_multi/export_multi.js
+++ b/test_files/export_multi/export_multi.js
@@ -1,6 +1,7 @@
 goog.module('test_files.export_multi.export_multi');
 var module = module || { id: 'test_files/export_multi/export_multi.ts' };
 module = module;
+goog.require('tslib');
 var _a, _b;
 /**
  *

--- a/test_files/export_types_values.untyped/importer.js
+++ b/test_files/export_types_values.untyped/importer.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_types_values.untyped.importer');
 var module = module || { id: 'test_files/export_types_values.untyped/importer.ts' };
 module = module;
+goog.require('tslib');
 const type_exporter_1 = goog.require('test_files.export_types_values.untyped.type_exporter');
 const value_exporter_1 = goog.require('test_files.export_types_values.untyped.value_exporter');
 exports.Clazz = value_exporter_1.Clazz;

--- a/test_files/export_types_values.untyped/type_exporter.js
+++ b/test_files/export_types_values.untyped/type_exporter.js
@@ -6,5 +6,6 @@
 goog.module('test_files.export_types_values.untyped.type_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/type_exporter.ts' };
 module = module;
+goog.require('tslib');
 /** @typedef {?} */
 exports.TypeDef;

--- a/test_files/export_types_values.untyped/value_exporter.js
+++ b/test_files/export_types_values.untyped/value_exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.export_types_values.untyped.value_exporter');
 var module = module || { id: 'test_files/export_types_values.untyped/value_exporter.ts' };
 module = module;
+goog.require('tslib');
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/extend_and_implement/extend_and_implement.js
+++ b/test_files/extend_and_implement/extend_and_implement.js
@@ -11,6 +11,7 @@
 goog.module('test_files.extend_and_implement.extend_and_implement');
 var module = module || { id: 'test_files/extend_and_implement/extend_and_implement.ts' };
 module = module;
+goog.require('tslib');
 class ClassInImplements {
 }
 if (false) {

--- a/test_files/fields/fields.js
+++ b/test_files/fields/fields.js
@@ -7,6 +7,7 @@
 goog.module('test_files.fields.fields');
 var module = module || { id: 'test_files/fields/fields.ts' };
 module = module;
+goog.require('tslib');
 class FieldsTest {
     /**
      * @param {number} field3

--- a/test_files/fields_no_ctor/fields_no_ctor.js
+++ b/test_files/fields_no_ctor/fields_no_ctor.js
@@ -6,6 +6,7 @@
 goog.module('test_files.fields_no_ctor.fields_no_ctor');
 var module = module || { id: 'test_files/fields_no_ctor/fields_no_ctor.ts' };
 module = module;
+goog.require('tslib');
 class NoCtor {
 }
 if (false) {

--- a/test_files/file_comment.puretransform/before_import.js
+++ b/test_files/file_comment.puretransform/before_import.js
@@ -6,5 +6,6 @@
 goog.module('test_files.file_comment.puretransform.before_import');
 var module = module || { id: 'test_files/file_comment.puretransform/before_import.ts' };
 module = module;
+goog.require('tslib');
 const comment_before_var_1 = goog.require('test_files.file_comment.puretransform.comment_before_var');
 console.log(comment_before_var_1.y);

--- a/test_files/file_comment.puretransform/comment_before_class.js
+++ b/test_files/file_comment.puretransform/comment_before_class.js
@@ -6,6 +6,7 @@
 goog.module('test_files.file_comment.puretransform.comment_before_class');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_class.ts' };
 module = module;
+goog.require('tslib');
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/file_comment.puretransform/comment_before_elided_import.js
+++ b/test_files/file_comment.puretransform/comment_before_elided_import.js
@@ -5,5 +5,6 @@
 goog.module('test_files.file_comment.puretransform.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_elided_import.ts' };
 module = module;
+goog.require('tslib');
 const x = null;
 console.log(x);

--- a/test_files/file_comment.puretransform/comment_before_var.js
+++ b/test_files/file_comment.puretransform/comment_before_var.js
@@ -6,4 +6,5 @@
 goog.module('test_files.file_comment.puretransform.comment_before_var');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_before_var.ts' };
 module = module;
+goog.require('tslib');
 exports.y = 3;

--- a/test_files/file_comment.puretransform/comment_no_tag.js
+++ b/test_files/file_comment.puretransform/comment_no_tag.js
@@ -2,5 +2,6 @@
 goog.module('test_files.file_comment.puretransform.comment_no_tag');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_no_tag.ts' };
 module = module;
+goog.require('tslib');
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment.puretransform/comment_with_text.js
+++ b/test_files/file_comment.puretransform/comment_with_text.js
@@ -5,4 +5,5 @@
 goog.module('test_files.file_comment.puretransform.comment_with_text');
 var module = module || { id: 'test_files/file_comment.puretransform/comment_with_text.ts' };
 module = module;
+goog.require('tslib');
 console.log('hello');

--- a/test_files/file_comment.puretransform/file_comment.js
+++ b/test_files/file_comment.puretransform/file_comment.js
@@ -1,6 +1,7 @@
 goog.module('test_files.file_comment.puretransform.file_comment');
 var module = module || { id: 'test_files/file_comment.puretransform/file_comment.ts' };
 module = module;
+goog.require('tslib');
 // This test verifies that initial comments don't confuse offsets.
 function foo() {
     return 'foo';

--- a/test_files/file_comment.puretransform/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment.puretransform/fileoverview_and_jsdoc.js
@@ -1,6 +1,7 @@
 goog.module('test_files.file_comment.puretransform.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_and_jsdoc.ts' };
 module = module;
+goog.require('tslib');
 /** @fileoverview A file. */
 /**
  * @deprecated Some Text

--- a/test_files/file_comment.puretransform/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_add_suppress.js
@@ -2,5 +2,6 @@
 goog.module('test_files.file_comment.puretransform.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_add_suppress.ts' };
 module = module;
+goog.require('tslib');
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.js
@@ -7,5 +7,6 @@
 goog.module('test_files.file_comment.puretransform.fileoverview_comment_add_suppress_before_license');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_add_suppress_before_license.ts' };
 module = module;
+goog.require('tslib');
 // here comes code.
 exports.x = 1;

--- a/test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.js
@@ -5,5 +5,6 @@
 goog.module('test_files.file_comment.puretransform.fileoverview_comment_merge_suppress');
 var module = module || { id: 'test_files/file_comment.puretransform/fileoverview_comment_merge_suppress.ts' };
 module = module;
+goog.require('tslib');
 /** second comment here */
 console.log('code');

--- a/test_files/file_comment.puretransform/jsdoc_comment.js
+++ b/test_files/file_comment.puretransform/jsdoc_comment.js
@@ -1,6 +1,7 @@
 goog.module('test_files.file_comment.puretransform.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment.puretransform/jsdoc_comment.ts' };
 module = module;
+goog.require('tslib');
 /**
  * This comment belongs to the class below.
  */

--- a/test_files/file_comment.puretransform/multiple_comments.js
+++ b/test_files/file_comment.puretransform/multiple_comments.js
@@ -17,6 +17,7 @@
 goog.module('test_files.file_comment.puretransform.multiple_comments');
 var module = module || { id: 'test_files/file_comment.puretransform/multiple_comments.ts' };
 module = module;
+goog.require('tslib');
 function f() {
     // Make sure the {const} suppression above is maintained.
     /** @const */

--- a/test_files/file_comment.puretransform/other_fileoverview_comments.js
+++ b/test_files/file_comment.puretransform/other_fileoverview_comments.js
@@ -2,5 +2,6 @@
 goog.module('test_files.file_comment.puretransform.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment.puretransform/other_fileoverview_comments.ts' };
 module = module;
+goog.require('tslib');
 // @modName also belongs in a fileoverview comment, so must be merged.
 console.log('hello');

--- a/test_files/file_comment.puretransform/side_effect_import.js
+++ b/test_files/file_comment.puretransform/side_effect_import.js
@@ -6,4 +6,5 @@
 goog.module('test_files.file_comment.puretransform.side_effect_import');
 var module = module || { id: 'test_files/file_comment.puretransform/side_effect_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_module_1_ = goog.require('test_files.file_comment.puretransform.file_comment');

--- a/test_files/file_comment/before_import.js
+++ b/test_files/file_comment/before_import.js
@@ -10,6 +10,7 @@
 goog.module('test_files.file_comment.before_import');
 var module = module || { id: 'test_files/file_comment/before_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_comment_before_var_1 = goog.requireType("test_files.file_comment.comment_before_var");
 const comment_before_var_1 = goog.require('test_files.file_comment.comment_before_var');
 console.log(comment_before_var_1.y);

--- a/test_files/file_comment/comment_before_class.js
+++ b/test_files/file_comment/comment_before_class.js
@@ -10,6 +10,7 @@
 goog.module('test_files.file_comment.comment_before_class');
 var module = module || { id: 'test_files/file_comment/comment_before_class.ts' };
 module = module;
+goog.require('tslib');
 class Clazz {
 }
 exports.Clazz = Clazz;

--- a/test_files/file_comment/comment_before_elided_import.js
+++ b/test_files/file_comment/comment_before_elided_import.js
@@ -9,6 +9,7 @@
 goog.module('test_files.file_comment.comment_before_elided_import');
 var module = module || { id: 'test_files/file_comment/comment_before_elided_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_comment_before_class_1 = goog.requireType("test_files.file_comment.comment_before_class");
 /** @type {(null|!tsickle_comment_before_class_1.Clazz)} */
 const x = null;

--- a/test_files/file_comment/comment_before_var.js
+++ b/test_files/file_comment/comment_before_var.js
@@ -10,5 +10,6 @@
 goog.module('test_files.file_comment.comment_before_var');
 var module = module || { id: 'test_files/file_comment/comment_before_var.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.y = 3;

--- a/test_files/file_comment/comment_no_tag.js
+++ b/test_files/file_comment/comment_no_tag.js
@@ -8,5 +8,6 @@
 goog.module('test_files.file_comment.comment_no_tag');
 var module = module || { id: 'test_files/file_comment/comment_no_tag.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/comment_with_text.js
+++ b/test_files/file_comment/comment_with_text.js
@@ -8,4 +8,5 @@
 goog.module('test_files.file_comment.comment_with_text');
 var module = module || { id: 'test_files/file_comment/comment_with_text.ts' };
 module = module;
+goog.require('tslib');
 console.log('hello');

--- a/test_files/file_comment/export_star.js
+++ b/test_files/file_comment/export_star.js
@@ -10,6 +10,7 @@
 goog.module('test_files.file_comment.export_star');
 var module = module || { id: 'test_files/file_comment/export_star.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_comment_before_var_1 = goog.requireType("test_files.file_comment.comment_before_var");
 const comment_before_var_1 = goog.require('test_files.file_comment.comment_before_var');
 exports.y = comment_before_var_1.y;

--- a/test_files/file_comment/file_comment.js
+++ b/test_files/file_comment/file_comment.js
@@ -6,6 +6,7 @@
 goog.module('test_files.file_comment.file_comment');
 var module = module || { id: 'test_files/file_comment/file_comment.ts' };
 module = module;
+goog.require('tslib');
 // This test verifies that initial comments don't confuse offsets.
 /**
  * @return {string}

--- a/test_files/file_comment/fileoverview_and_jsdoc.js
+++ b/test_files/file_comment/fileoverview_and_jsdoc.js
@@ -6,6 +6,7 @@
 goog.module('test_files.file_comment.fileoverview_and_jsdoc');
 var module = module || { id: 'test_files/file_comment/fileoverview_and_jsdoc.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @deprecated Some Text
  * @type {number}

--- a/test_files/file_comment/fileoverview_comment_add_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress.js
@@ -7,5 +7,6 @@
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/fileoverview_comment_add_suppress_before_license.js
+++ b/test_files/file_comment/fileoverview_comment_add_suppress_before_license.js
@@ -12,5 +12,6 @@
 goog.module('test_files.file_comment.fileoverview_comment_add_suppress_before_license');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_add_suppress_before_license.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.x = 1;

--- a/test_files/file_comment/fileoverview_comment_merge_suppress.js
+++ b/test_files/file_comment/fileoverview_comment_merge_suppress.js
@@ -9,4 +9,5 @@
 goog.module('test_files.file_comment.fileoverview_comment_merge_suppress');
 var module = module || { id: 'test_files/file_comment/fileoverview_comment_merge_suppress.ts' };
 module = module;
+goog.require('tslib');
 console.log('code');

--- a/test_files/file_comment/fileoverview_in_comment_text.js
+++ b/test_files/file_comment/fileoverview_in_comment_text.js
@@ -9,6 +9,7 @@
 goog.module('test_files.file_comment.fileoverview_in_comment_text');
 var module = module || { id: 'test_files/file_comment/fileoverview_in_comment_text.ts' };
 module = module;
+goog.require('tslib');
 /**
  * This is a function comment that talks about \@fileoverview, but isn't such a comment.
  * @return {void}

--- a/test_files/file_comment/jsdoc_comment.js
+++ b/test_files/file_comment/jsdoc_comment.js
@@ -6,6 +6,7 @@
 goog.module('test_files.file_comment.jsdoc_comment');
 var module = module || { id: 'test_files/file_comment/jsdoc_comment.ts' };
 module = module;
+goog.require('tslib');
 /**
  * This comment belongs to the class below.
  */

--- a/test_files/file_comment/latecomment.js
+++ b/test_files/file_comment/latecomment.js
@@ -7,6 +7,7 @@
 goog.module('test_files.file_comment.latecomment');
 var module = module || { id: 'test_files/file_comment/latecomment.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 const someVariable = 1;
 /** @fileoverview This file overview comment appears after the first statement in the file. */

--- a/test_files/file_comment/latecomment_front.js
+++ b/test_files/file_comment/latecomment_front.js
@@ -7,5 +7,6 @@
 goog.module('test_files.file_comment.latecomment_front');
 var module = module || { id: 'test_files/file_comment/latecomment_front.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 const followedByCode = 1;

--- a/test_files/file_comment/multiple_comments.js
+++ b/test_files/file_comment/multiple_comments.js
@@ -21,6 +21,7 @@
 goog.module('test_files.file_comment.multiple_comments');
 var module = module || { id: 'test_files/file_comment/multiple_comments.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @return {void}
  */

--- a/test_files/file_comment/other_fileoverview_comments.js
+++ b/test_files/file_comment/other_fileoverview_comments.js
@@ -7,5 +7,6 @@
 goog.module('test_files.file_comment.other_fileoverview_comments');
 var module = module || { id: 'test_files/file_comment/other_fileoverview_comments.ts' };
 module = module;
+goog.require('tslib');
 // @modName also belongs in a fileoverview comment, so must be merged.
 console.log('hello');

--- a/test_files/file_comment/run_in_comment.js
+++ b/test_files/file_comment/run_in_comment.js
@@ -7,6 +7,7 @@
 goog.module('test_files.file_comment.run_in_comment');
 var module = module || { id: 'test_files/file_comment/run_in_comment.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @pintomodule Comment is not separated from file body as it should be.
  * @type {number}

--- a/test_files/file_comment/side_effect_import.js
+++ b/test_files/file_comment/side_effect_import.js
@@ -10,4 +10,5 @@
 goog.module('test_files.file_comment.side_effect_import');
 var module = module || { id: 'test_files/file_comment/side_effect_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_module_1_ = goog.require('test_files.file_comment.file_comment');

--- a/test_files/functions.untyped/functions.js
+++ b/test_files/functions.untyped/functions.js
@@ -6,6 +6,7 @@
 goog.module('test_files.functions.untyped.functions');
 var module = module || { id: 'test_files/functions.untyped/functions.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {?} a
  * @return {?}

--- a/test_files/functions/functions.js
+++ b/test_files/functions/functions.js
@@ -6,6 +6,7 @@
 goog.module('test_files.functions.functions');
 var module = module || { id: 'test_files/functions/functions.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {number} a
  * @return {number}

--- a/test_files/functions/two_jsdoc_blocks.js
+++ b/test_files/functions/two_jsdoc_blocks.js
@@ -8,6 +8,7 @@
 goog.module('test_files.functions.two_jsdoc_blocks');
 var module = module || { id: 'test_files/functions/two_jsdoc_blocks.ts' };
 module = module;
+goog.require('tslib');
 /**
  * A comment.
  * @return {boolean}

--- a/test_files/generic_fn_type/generic_fn_type.js
+++ b/test_files/generic_fn_type/generic_fn_type.js
@@ -6,6 +6,7 @@
 goog.module('test_files.generic_fn_type.generic_fn_type');
 var module = module || { id: 'test_files/generic_fn_type/generic_fn_type.ts' };
 module = module;
+goog.require('tslib');
 /**
  * A function type that includes a generic type argument. Unsupported by
  * Closure, so tsickle should emit ?.

--- a/test_files/generic_local_var/generic_local_var.js
+++ b/test_files/generic_local_var/generic_local_var.js
@@ -6,6 +6,7 @@
 goog.module('test_files.generic_local_var.generic_local_var');
 var module = module || { id: 'test_files/generic_local_var/generic_local_var.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @template T
  */

--- a/test_files/generic_type_alias/generic_type_alias.js
+++ b/test_files/generic_type_alias/generic_type_alias.js
@@ -6,6 +6,7 @@
 goog.module('test_files.generic_type_alias.generic_type_alias');
 var module = module || { id: 'test_files/generic_type_alias/generic_type_alias.ts' };
 module = module;
+goog.require('tslib');
 /**
  * A type alias including a generic type parameter. Unsupported by Closure, so
  * tsickle emits <?>.

--- a/test_files/implement_reexported_interface/exporter.js
+++ b/test_files/implement_reexported_interface/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.implement_reexported_interface.exporter');
 var module = module || { id: 'test_files/implement_reexported_interface/exporter.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_interface_1 = goog.requireType("test_files.implement_reexported_interface.interface");
 /** @typedef {!tsickle_interface_1.ExportedInterface} */
 exports.ExportedInterface; // re-export typedef

--- a/test_files/implement_reexported_interface/interface.js
+++ b/test_files/implement_reexported_interface/interface.js
@@ -6,6 +6,7 @@
 goog.module('test_files.implement_reexported_interface.interface');
 var module = module || { id: 'test_files/implement_reexported_interface/interface.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/implement_reexported_interface/user.js
+++ b/test_files/implement_reexported_interface/user.js
@@ -11,6 +11,7 @@
 goog.module('test_files.implement_reexported_interface.user');
 var module = module || { id: 'test_files/implement_reexported_interface/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.implement_reexported_interface.exporter");
 const tsickle_interface_2 = goog.requireType("test_files.implement_reexported_interface.interface");
 /**

--- a/test_files/import_alias/exporter.js
+++ b/test_files/import_alias/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_alias.exporter');
 var module = module || { id: 'test_files/import_alias/exporter.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 const FOO = 1;
 exports.FOO = FOO;

--- a/test_files/import_alias/importer.js
+++ b/test_files/import_alias/importer.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_alias.importer');
 var module = module || { id: 'test_files/import_alias/importer.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.import_alias.exporter");
 const exporter_1 = goog.require('test_files.import_alias.exporter');
 console.log(exporter_1.FOO);

--- a/test_files/import_default/exporter.js
+++ b/test_files/import_default/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_default.exporter');
 var module = module || { id: 'test_files/import_default/exporter.ts' };
 module = module;
+goog.require('tslib');
 // tslint:disable-next-line:no-default-export
 class default_1 {
 }

--- a/test_files/import_default/import_default.js
+++ b/test_files/import_default/import_default.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_default.import_default');
 var module = module || { id: 'test_files/import_default/import_default.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.import_default.exporter");
 const exporter_1 = goog.require('test_files.import_default.exporter');
 // Make sure that regular TypeScript default imports are emitted as a .default

--- a/test_files/import_empty/import_empty.js
+++ b/test_files/import_empty/import_empty.js
@@ -6,5 +6,6 @@
 goog.module('test_files.import_empty.import_empty');
 var module = module || { id: 'test_files/import_empty/import_empty.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_imported_1 = goog.requireType("test_files.import_empty.imported");
 console.log('hello');

--- a/test_files/import_empty/imported.js
+++ b/test_files/import_empty/imported.js
@@ -6,3 +6,4 @@
 goog.module('test_files.import_empty.imported');
 var module = module || { id: 'test_files/import_empty/imported.ts' };
 module = module;
+goog.require('tslib');

--- a/test_files/import_export_typedef_conflict/exporter.js
+++ b/test_files/import_export_typedef_conflict/exporter.js
@@ -6,5 +6,6 @@
 goog.module('test_files.import_export_typedef_conflict.exporter');
 var module = module || { id: 'test_files/import_export_typedef_conflict/exporter.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.x = 1;

--- a/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
+++ b/test_files/import_export_typedef_conflict/import_export_typedef_conflict.js
@@ -10,6 +10,7 @@
 goog.module('test_files.import_export_typedef_conflict.import_export_typedef_conflict');
 var module = module || { id: 'test_files/import_export_typedef_conflict/import_export_typedef_conflict.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.import_export_typedef_conflict.exporter");
 const ConflictingName = goog.require('test_files.import_export_typedef_conflict.exporter');
 /** @typedef {number} */

--- a/test_files/import_from_goog/import_from_goog.js
+++ b/test_files/import_from_goog/import_from_goog.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_from_goog.import_from_goog');
 var module = module || { id: 'test_files/import_from_goog/import_from_goog.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_Module_1 = goog.requireType("closure.Module");
 const tsickle_OtherModule_2 = goog.requireType("closure.OtherModule");
 const goog_closure_Module_1 = goog.require('closure.Module');

--- a/test_files/import_only_types/import_only_types.js
+++ b/test_files/import_only_types/import_only_types.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_only_types.import_only_types');
 var module = module || { id: 'test_files/import_only_types/import_only_types.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_types_only_1 = goog.requireType("test_files.import_only_types.types_only");
 const tsickle_types_and_constenum_2 = goog.requireType("test_files.import_only_types.types_and_constenum");
 /** @type {!tsickle_types_only_1.Foo} */

--- a/test_files/import_only_types/types_and_constenum.js
+++ b/test_files/import_only_types/types_and_constenum.js
@@ -9,6 +9,7 @@
 goog.module('test_files.import_only_types.types_and_constenum');
 var module = module || { id: 'test_files/import_only_types/types_and_constenum.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {number} */
 const ConstEnum = {
     BAR: 0,

--- a/test_files/import_only_types/types_only.js
+++ b/test_files/import_only_types/types_only.js
@@ -7,6 +7,7 @@
 goog.module('test_files.import_only_types.types_only');
 var module = module || { id: 'test_files/import_only_types/types_only.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/import_prefixed/exporter.js
+++ b/test_files/import_prefixed/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_prefixed.exporter');
 var module = module || { id: 'test_files/import_prefixed/exporter.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.valueExport = 1;
 /** @typedef {(string|number)} */

--- a/test_files/import_prefixed/import_prefixed_mixed.js
+++ b/test_files/import_prefixed/import_prefixed_mixed.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_prefixed.import_prefixed_mixed');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_mixed.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.import_prefixed.exporter");
 // This file imports exporter with a prefix import (* as ...), and then uses the
 // import in a type and in a value position.

--- a/test_files/import_prefixed/import_prefixed_types.js
+++ b/test_files/import_prefixed/import_prefixed_types.js
@@ -6,6 +6,7 @@
 goog.module('test_files.import_prefixed.import_prefixed_types');
 var module = module || { id: 'test_files/import_prefixed/import_prefixed_types.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.import_prefixed.exporter");
 // This file imports exporter with a prefix import (* as ...), and then only
 // uses the import in a type position.

--- a/test_files/index_import/has_index/index.js
+++ b/test_files/index_import/has_index/index.js
@@ -6,5 +6,6 @@
 goog.module('test_files.index_import.has_index.index');
 var module = module || { id: 'test_files/index_import/has_index/index.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.a = 1;

--- a/test_files/index_import/has_index/relative.js
+++ b/test_files/index_import/has_index/relative.js
@@ -6,4 +6,5 @@
 goog.module('test_files.index_import.has_index.relative');
 var module = module || { id: 'test_files/index_import/has_index/relative.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_has_index_1 = goog.requireType("test_files.index_import.has_index.index");

--- a/test_files/index_import/lib.js
+++ b/test_files/index_import/lib.js
@@ -6,5 +6,6 @@
 goog.module('test_files.index_import.lib');
 var module = module || { id: 'test_files/index_import/lib.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.b = 2;

--- a/test_files/index_import/user.js
+++ b/test_files/index_import/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.index_import.user');
 var module = module || { id: 'test_files/index_import/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_has_index_1 = goog.requireType("test_files.index_import.has_index.index");
 const tsickle_lib_2 = goog.requireType("test_files.index_import.lib");
 const has_index_1 = goog.require('test_files.index_import.has_index.index');

--- a/test_files/interface/implement_import.js
+++ b/test_files/interface/implement_import.js
@@ -6,6 +6,7 @@
 goog.module('test_files.interface.implement_import');
 var module = module || { id: 'test_files/interface/implement_import.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_interface_1 = goog.requireType("test_files.interface.interface");
 const interface_1 = goog.require('test_files.interface.interface');
 /**

--- a/test_files/interface/interface.js
+++ b/test_files/interface/interface.js
@@ -6,6 +6,7 @@
 goog.module('test_files.interface.interface');
 var module = module || { id: 'test_files/interface/interface.ts' };
 module = module;
+goog.require('tslib');
 /**
  * Used by implement_import.ts
  * @record

--- a/test_files/interface/interface_extends.js
+++ b/test_files/interface/interface_extends.js
@@ -6,6 +6,7 @@
 goog.module('test_files.interface.interface_extends');
 var module = module || { id: 'test_files/interface/interface_extends.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/interface/interface_type_params.js
+++ b/test_files/interface/interface_type_params.js
@@ -6,6 +6,7 @@
 goog.module('test_files.interface.interface_type_params');
 var module = module || { id: 'test_files/interface/interface_type_params.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/invalid_closure_properties/invalid_closure_properties.js
+++ b/test_files/invalid_closure_properties/invalid_closure_properties.js
@@ -14,5 +14,6 @@
 goog.module('test_files.invalid_closure_properties.invalid_closure_properties');
 var module = module || { id: 'test_files/invalid_closure_properties/invalid_closure_properties.ts' };
 module = module;
+goog.require('tslib');
 /** @type {(null|{otherField: string})} */
 exports.x = null;

--- a/test_files/iterator/iterator.js
+++ b/test_files/iterator/iterator.js
@@ -7,6 +7,7 @@
 goog.module('test_files.iterator.iterator');
 var module = module || { id: 'test_files/iterator/iterator.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @implements {IterableIterator}
  */

--- a/test_files/jsdoc/enum_tag.js
+++ b/test_files/jsdoc/enum_tag.js
@@ -14,6 +14,7 @@
 goog.module('test_files.jsdoc.enum_tag');
 var module = module || { id: 'test_files/jsdoc/enum_tag.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {number} */
 const A = {
     A: 0,

--- a/test_files/jsdoc/jsdoc.js
+++ b/test_files/jsdoc/jsdoc.js
@@ -25,6 +25,7 @@
 goog.module('test_files.jsdoc.jsdoc');
 var module = module || { id: 'test_files/jsdoc/jsdoc.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {string} foo a string.
  * @param {string} baz

--- a/test_files/jsdoc_types.untyped/default.js
+++ b/test_files/jsdoc_types.untyped/default.js
@@ -6,6 +6,7 @@
 goog.module('test_files.jsdoc_types.untyped.default');
 var module = module || { id: 'test_files/jsdoc_types.untyped/default.ts' };
 module = module;
+goog.require('tslib');
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types.untyped/jsdoc_types.js
+++ b/test_files/jsdoc_types.untyped/jsdoc_types.js
@@ -10,6 +10,7 @@
 goog.module('test_files.jsdoc_types.untyped.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types.untyped/jsdoc_types.ts' };
 module = module;
+goog.require('tslib');
 const module1 = goog.require('test_files.jsdoc_types.untyped.module1');
 const module2_1 = goog.require('test_files.jsdoc_types.untyped.module2');
 const module2_2 = module2_1;

--- a/test_files/jsdoc_types.untyped/module1.js
+++ b/test_files/jsdoc_types.untyped/module1.js
@@ -8,6 +8,7 @@
 goog.module('test_files.jsdoc_types.untyped.module1');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module1.ts' };
 module = module;
+goog.require('tslib');
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types.untyped/module2.js
+++ b/test_files/jsdoc_types.untyped/module2.js
@@ -6,6 +6,7 @@
 goog.module('test_files.jsdoc_types.untyped.module2');
 var module = module || { id: 'test_files/jsdoc_types.untyped/module2.ts' };
 module = module;
+goog.require('tslib');
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types.untyped/nevertyped.js
+++ b/test_files/jsdoc_types.untyped/nevertyped.js
@@ -8,6 +8,7 @@
 goog.module('test_files.jsdoc_types.untyped.nevertyped');
 var module = module || { id: 'test_files/jsdoc_types.untyped/nevertyped.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/jsdoc_types/default.js
+++ b/test_files/jsdoc_types/default.js
@@ -6,6 +6,7 @@
 goog.module('test_files.jsdoc_types.default');
 var module = module || { id: 'test_files/jsdoc_types/default.ts' };
 module = module;
+goog.require('tslib');
 class DefaultClass {
 }
 exports.default = DefaultClass;

--- a/test_files/jsdoc_types/initialized_unknown.js
+++ b/test_files/jsdoc_types/initialized_unknown.js
@@ -10,6 +10,7 @@
 goog.module('test_files.jsdoc_types.initialized_unknown');
 var module = module || { id: 'test_files/jsdoc_types/initialized_unknown.ts' };
 module = module;
+goog.require('tslib');
 const initializedUntyped = {
     foo: 1
 };

--- a/test_files/jsdoc_types/jsdoc_types.js
+++ b/test_files/jsdoc_types/jsdoc_types.js
@@ -8,6 +8,7 @@
 goog.module('test_files.jsdoc_types.jsdoc_types');
 var module = module || { id: 'test_files/jsdoc_types/jsdoc_types.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_default_1 = goog.requireType("test_files.jsdoc_types.default");
 const tsickle_module1_2 = goog.requireType("test_files.jsdoc_types.module1");
 const tsickle_module2_3 = goog.requireType("test_files.jsdoc_types.module2");

--- a/test_files/jsdoc_types/module1.js
+++ b/test_files/jsdoc_types/module1.js
@@ -8,6 +8,7 @@
 goog.module('test_files.jsdoc_types.module1');
 var module = module || { id: 'test_files/jsdoc_types/module1.ts' };
 module = module;
+goog.require('tslib');
 class Class {
 }
 exports.Class = Class;

--- a/test_files/jsdoc_types/module2.js
+++ b/test_files/jsdoc_types/module2.js
@@ -6,6 +6,7 @@
 goog.module('test_files.jsdoc_types.module2');
 var module = module || { id: 'test_files/jsdoc_types/module2.ts' };
 module = module;
+goog.require('tslib');
 class ClassOne {
 }
 exports.ClassOne = ClassOne;

--- a/test_files/jsdoc_types/nevertyped.js
+++ b/test_files/jsdoc_types/nevertyped.js
@@ -8,6 +8,7 @@
 goog.module('test_files.jsdoc_types.nevertyped');
 var module = module || { id: 'test_files/jsdoc_types/nevertyped.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/jsx/jsx.js
+++ b/test_files/jsx/jsx.js
@@ -6,6 +6,7 @@
 goog.module('test_files.jsx.jsx.tsx');
 var module = module || { id: 'test_files/jsx/jsx.tsx' };
 module = module;
+goog.require('tslib');
 /** @type {!JSX.Element} */
 let simple = React.createElement("div", null);
 /** @type {string} */

--- a/test_files/methods/methods.js
+++ b/test_files/methods/methods.js
@@ -6,6 +6,7 @@
 goog.module('test_files.methods.methods');
 var module = module || { id: 'test_files/methods/methods.ts' };
 module = module;
+goog.require('tslib');
 class HasMethods {
     /**
      * @return {void}

--- a/test_files/module/module.js
+++ b/test_files/module/module.js
@@ -6,6 +6,7 @@
 goog.module('test_files.module.module');
 var module = module || { id: 'test_files/module/module.ts' };
 module = module;
+goog.require('tslib');
 // tslint:disable-next-line:no-namespace
 var Reflect;
 (function (Reflect) {

--- a/test_files/namespaced/ambient_namespaced.js
+++ b/test_files/namespaced/ambient_namespaced.js
@@ -6,5 +6,6 @@
 goog.module('test_files.namespaced.ambient_namespaced');
 var module = module || { id: 'test_files/namespaced/ambient_namespaced.ts' };
 module = module;
+goog.require('tslib');
 /** @type {!decl.ns.one.NamespacedClass} */
 let user;

--- a/test_files/namespaced/export_enum_in_namespace.js
+++ b/test_files/namespaced/export_enum_in_namespace.js
@@ -10,6 +10,7 @@
 goog.module('test_files.namespaced.export_enum_in_namespace');
 var module = module || { id: 'test_files/namespaced/export_enum_in_namespace.ts' };
 module = module;
+goog.require('tslib');
 var foo;
 (function (foo) {
     let Bar;

--- a/test_files/namespaced/export_namespace.js
+++ b/test_files/namespaced/export_namespace.js
@@ -7,6 +7,7 @@
 goog.module('test_files.namespaced.export_namespace');
 var module = module || { id: 'test_files/namespaced/export_namespace.ts' };
 module = module;
+goog.require('tslib');
 var valueNamespace;
 (function (valueNamespace) {
     class ValueClass {

--- a/test_files/namespaced/local_namespace.js
+++ b/test_files/namespaced/local_namespace.js
@@ -6,6 +6,7 @@
 goog.module('test_files.namespaced.local_namespace');
 var module = module || { id: 'test_files/namespaced/local_namespace.ts' };
 module = module;
+goog.require('tslib');
 var unexported;
 (function (unexported) {
     class Unexported {

--- a/test_files/namespaced/reopen_ns.js
+++ b/test_files/namespaced/reopen_ns.js
@@ -6,6 +6,7 @@
 goog.module('test_files.namespaced.reopen_ns');
 var module = module || { id: 'test_files/namespaced/reopen_ns.ts' };
 module = module;
+goog.require('tslib');
 // TODO(#132): 'export namespace' currently don't emit properly.
 // This workaround at least makes them compile.
 // It's useful to keep at least one instance of this workaround

--- a/test_files/namespaced/user.js
+++ b/test_files/namespaced/user.js
@@ -6,6 +6,7 @@
 goog.module('test_files.namespaced.user');
 var module = module || { id: 'test_files/namespaced/user.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_namespace_1 = goog.requireType("test_files.namespaced.export_namespace");
 const export_namespace_1 = goog.require('test_files.namespaced.export_namespace');
 /** @type {?} */

--- a/test_files/nonnull_generics/nonnull_generics.js
+++ b/test_files/nonnull_generics/nonnull_generics.js
@@ -6,6 +6,7 @@
 goog.module('test_files.nonnull_generics.nonnull_generics');
 var module = module || { id: 'test_files/nonnull_generics/nonnull_generics.ts' };
 module = module;
+goog.require('tslib');
 /**
  * getOrDefault removes the |null branch from its input. In TypeScript, this works, but in Closure,
  * generics like T are always nullable, and there's no syntax to specify a non-nullable generic.

--- a/test_files/nullable/nullable.js
+++ b/test_files/nullable/nullable.js
@@ -6,6 +6,7 @@
 goog.module('test_files.nullable.nullable');
 var module = module || { id: 'test_files/nullable/nullable.ts' };
 module = module;
+goog.require('tslib');
 class Primitives {
 }
 if (false) {

--- a/test_files/optional/optional.js
+++ b/test_files/optional/optional.js
@@ -6,6 +6,7 @@
 goog.module('test_files.optional.optional');
 var module = module || { id: 'test_files/optional/optional.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {number} x
  * @param {(undefined|string)=} y

--- a/test_files/parameter_properties/parameter_properties.js
+++ b/test_files/parameter_properties/parameter_properties.js
@@ -6,6 +6,7 @@
 goog.module('test_files.parameter_properties.parameter_properties');
 var module = module || { id: 'test_files/parameter_properties/parameter_properties.ts' };
 module = module;
+goog.require('tslib');
 class ParamProps {
     // The @export below should not show up in the output ctor.
     /**

--- a/test_files/partial/partial.js
+++ b/test_files/partial/partial.js
@@ -7,6 +7,7 @@
 goog.module('test_files.partial.partial');
 var module = module || { id: 'test_files/partial/partial.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/promiseconstructor/promiseconstructor.js
+++ b/test_files/promiseconstructor/promiseconstructor.js
@@ -6,6 +6,7 @@
 goog.module('test_files.promiseconstructor.promiseconstructor');
 var module = module || { id: 'test_files/promiseconstructor/promiseconstructor.ts' };
 module = module;
+goog.require('tslib');
 // typeof Promise actually resolves to "PromiseConstructor" in TypeScript, which
 // is a type that doesn't exist in Closure's type world. This code passes the
 // e2e test because closure_externs.js declares PromiseConstructor.

--- a/test_files/promisectorlike/promisectorlike.js
+++ b/test_files/promisectorlike/promisectorlike.js
@@ -6,6 +6,7 @@
 goog.module('test_files.promisectorlike.promisectorlike');
 var module = module || { id: 'test_files/promisectorlike/promisectorlike.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {function(new:PromiseLike<?>, function(function((undefined|?|!PromiseLike<?>)=): void, function(?=): void): void)} ctorLike
  * @return {!Promise<string>}

--- a/test_files/promiselike/promiselike.js
+++ b/test_files/promiselike/promiselike.js
@@ -6,5 +6,6 @@
 goog.module('test_files.promiselike.promiselike');
 var module = module || { id: 'test_files/promiselike/promiselike.ts' };
 module = module;
+goog.require('tslib');
 /** @type {!PromiseLike<string>} */
 let promiseLikeOfString;

--- a/test_files/protected/protected.js
+++ b/test_files/protected/protected.js
@@ -7,6 +7,7 @@
 goog.module('test_files.protected.protected');
 var module = module || { id: 'test_files/protected/protected.ts' };
 module = module;
+goog.require('tslib');
 class Protected {
     /**
      * @param {string} anotherPrivate

--- a/test_files/rest_parameters_any/rest_parameters_any.js
+++ b/test_files/rest_parameters_any/rest_parameters_any.js
@@ -12,6 +12,7 @@
 goog.module('test_files.rest_parameters_any.rest_parameters_any');
 var module = module || { id: 'test_files/rest_parameters_any/rest_parameters_any.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
+++ b/test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.js
@@ -8,6 +8,7 @@
 goog.module('test_files.rest_parameters_generic_empty.rest_parameters_generic_empty');
 var module = module || { id: 'test_files/rest_parameters_generic_empty/rest_parameters_generic_empty.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @template A
  * @param {function(!Array<?>): void} fn

--- a/test_files/rest_parameters_tuple/rest_parameters_tuple.js
+++ b/test_files/rest_parameters_tuple/rest_parameters_tuple.js
@@ -10,6 +10,7 @@
 goog.module('test_files.rest_parameters_tuple.rest_parameters_tuple');
 var module = module || { id: 'test_files/rest_parameters_tuple/rest_parameters_tuple.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {...?} args
  * @return {void}

--- a/test_files/return_this/return_this.js
+++ b/test_files/return_this/return_this.js
@@ -6,6 +6,7 @@
 goog.module('test_files.return_this.return_this');
 var module = module || { id: 'test_files/return_this/return_this.ts' };
 module = module;
+goog.require('tslib');
 class UnrelatedClass {
     constructor() {
         this.a = 1;

--- a/test_files/single_value_enum/single_value_enum.js
+++ b/test_files/single_value_enum/single_value_enum.js
@@ -11,6 +11,7 @@
 goog.module('test_files.single_value_enum.single_value_enum');
 var module = module || { id: 'test_files/single_value_enum/single_value_enum.ts' };
 module = module;
+goog.require('tslib');
 /** @enum {number} */
 const FirstEnum = {
     A: 0,

--- a/test_files/static/static.js
+++ b/test_files/static/static.js
@@ -6,6 +6,7 @@
 goog.module('test_files.static.static');
 var module = module || { id: 'test_files/static/static.ts' };
 module = module;
+goog.require('tslib');
 class Static {
 }
 // This should not become a stub declaration.

--- a/test_files/structural.untyped/structural.untyped.js
+++ b/test_files/structural.untyped/structural.untyped.js
@@ -6,6 +6,7 @@
 goog.module('test_files.structural.untyped.structural.untyped');
 var module = module || { id: 'test_files/structural.untyped/structural.untyped.ts' };
 module = module;
+goog.require('tslib');
 // Ensure that a class is structurally equivalent to an object literal
 // with the same fields.
 class StructuralTest {

--- a/test_files/super/super.js
+++ b/test_files/super/super.js
@@ -6,6 +6,7 @@
 goog.module('test_files.super.super');
 var module = module || { id: 'test_files/super/super.ts' };
 module = module;
+goog.require('tslib');
 class SuperTestBaseNoArg {
     constructor() { }
 }

--- a/test_files/symbol/symbol.js
+++ b/test_files/symbol/symbol.js
@@ -6,6 +6,7 @@
 goog.module('test_files.symbol.symbol');
 var module = module || { id: 'test_files/symbol/symbol.ts' };
 module = module;
+goog.require('tslib');
 /** @type {symbol} */
 const uniqueSymbol = Symbol('my symbol');
 /**

--- a/test_files/this_type/this_type.js
+++ b/test_files/this_type/this_type.js
@@ -6,6 +6,7 @@
 goog.module('test_files.this_type.this_type');
 var module = module || { id: 'test_files/this_type/this_type.ts' };
 module = module;
+goog.require('tslib');
 class SomeClass {
 }
 if (false) {

--- a/test_files/transitive_symbol_type_only/exporter.js
+++ b/test_files/transitive_symbol_type_only/exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.transitive_symbol_type_only.exporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/exporter.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/transitive_symbol_type_only/reexporter.js
+++ b/test_files/transitive_symbol_type_only/reexporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.transitive_symbol_type_only.reexporter');
 var module = module || { id: 'test_files/transitive_symbol_type_only/reexporter.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_exporter_1 = goog.requireType("test_files.transitive_symbol_type_only.exporter");
 /** @typedef {(null|string|!tsickle_exporter_1.ExportedInterface)} */
 exports.UsesExportedInterface;

--- a/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
+++ b/test_files/transitive_symbol_type_only/transitive_symbol_type_only.js
@@ -10,6 +10,7 @@
 goog.module('test_files.transitive_symbol_type_only.transitive_symbol_type_only');
 var module = module || { id: 'test_files/transitive_symbol_type_only/transitive_symbol_type_only.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_reexporter_1 = goog.requireType("test_files.transitive_symbol_type_only.reexporter");
 const tsickle_exporter_2 = goog.requireType("test_files.transitive_symbol_type_only.exporter");
 /** @type {(null|string|!tsickle_exporter_2.ExportedInterface)} */

--- a/test_files/type/type.js
+++ b/test_files/type/type.js
@@ -7,6 +7,7 @@
 goog.module('test_files.type.type');
 var module = module || { id: 'test_files/type/type.ts' };
 module = module;
+goog.require('tslib');
 /** @type {?} */
 let typeAny;
 /** @type {!Array<?>} */

--- a/test_files/type_alias_imported/elided_comment.js
+++ b/test_files/type_alias_imported/elided_comment.js
@@ -6,6 +6,7 @@
 goog.module('test_files.type_alias_imported.elided_comment');
 var module = module || { id: 'test_files/type_alias_imported/elided_comment.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_type_alias_exporter_1 = goog.requireType("test_files.type_alias_imported.type_alias_exporter");
 const tsickle_type_alias_declare_2 = goog.requireType("test_files.type_alias_imported.type_alias_declare");
 /** @type {(null|!tsickle_type_alias_declare_2.X|!tsickle_type_alias_exporter_1.Y)} */

--- a/test_files/type_alias_imported/export_constant.js
+++ b/test_files/type_alias_imported/export_constant.js
@@ -6,5 +6,6 @@
 goog.module('test_files.type_alias_imported.export_constant');
 var module = module || { id: 'test_files/type_alias_imported/export_constant.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.SOME_CONSTANT = 1;

--- a/test_files/type_alias_imported/type_alias_declare.js
+++ b/test_files/type_alias_imported/type_alias_declare.js
@@ -9,6 +9,7 @@
 goog.module('test_files.type_alias_imported.type_alias_declare');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_declare.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @record
  */

--- a/test_files/type_alias_imported/type_alias_default_exporter.js
+++ b/test_files/type_alias_imported/type_alias_default_exporter.js
@@ -9,6 +9,7 @@
 goog.module('test_files.type_alias_imported.type_alias_default_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_default_exporter.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_type_alias_declare_1 = goog.requireType("test_files.type_alias_imported.type_alias_declare");
 class Z {
 }

--- a/test_files/type_alias_imported/type_alias_exporter.js
+++ b/test_files/type_alias_imported/type_alias_exporter.js
@@ -6,6 +6,7 @@
 goog.module('test_files.type_alias_imported.type_alias_exporter');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_exporter.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_type_alias_declare_1 = goog.requireType("test_files.type_alias_imported.type_alias_declare");
 // Export a type alias that references types from this file that, in turn, are
 // not imported at the use site in type_alias_imported. This is a regression

--- a/test_files/type_alias_imported/type_alias_imported.js
+++ b/test_files/type_alias_imported/type_alias_imported.js
@@ -6,6 +6,7 @@
 goog.module('test_files.type_alias_imported.type_alias_imported');
 var module = module || { id: 'test_files/type_alias_imported/type_alias_imported.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_constant_1 = goog.requireType("test_files.type_alias_imported.export_constant");
 const tsickle_type_alias_exporter_2 = goog.requireType("test_files.type_alias_imported.type_alias_exporter");
 const tsickle_type_alias_default_exporter_3 = goog.requireType("test_files.type_alias_imported.type_alias_default_exporter");

--- a/test_files/type_and_value/module.js
+++ b/test_files/type_and_value/module.js
@@ -9,6 +9,7 @@
 goog.module('test_files.type_and_value.module');
 var module = module || { id: 'test_files/type_and_value/module.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.TypeAndValue = 3;
 // WARNING: interface has both a type and a value, skipping emit

--- a/test_files/type_and_value/type_and_value.js
+++ b/test_files/type_and_value/type_and_value.js
@@ -13,6 +13,7 @@
 goog.module('test_files.type_and_value.type_and_value');
 var module = module || { id: 'test_files/type_and_value/type_and_value.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_module_1 = goog.requireType("test_files.type_and_value.module");
 const conflict = goog.require('test_files.type_and_value.module');
 // This test deals with symbols that are simultaneously types and values.

--- a/test_files/type_guard_fn/type_guard_fn.js
+++ b/test_files/type_guard_fn/type_guard_fn.js
@@ -6,6 +6,7 @@
 goog.module('test_files.type_guard_fn.type_guard_fn');
 var module = module || { id: 'test_files/type_guard_fn/type_guard_fn.ts' };
 module = module;
+goog.require('tslib');
 /**
  * @param {*} a
  * @return {boolean}

--- a/test_files/type_propaccess.no_externs/type_propaccess.js
+++ b/test_files/type_propaccess.no_externs/type_propaccess.js
@@ -6,6 +6,7 @@
 goog.module('test_files.type_propaccess.no_externs.type_propaccess');
 var module = module || { id: 'test_files/type_propaccess.no_externs/type_propaccess.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_clazz_1 = goog.requireType("type_propaccess.nested.clazz");
 /** @type {(null|!tsickle_clazz_1.ClutzedClassWithNested.NestedClutzedClass)} */
 const x = null;

--- a/test_files/typedef.untyped/typedef.js
+++ b/test_files/typedef.untyped/typedef.js
@@ -6,6 +6,7 @@
 goog.module('test_files.typedef.untyped.typedef');
 var module = module || { id: 'test_files/typedef.untyped/typedef.ts' };
 module = module;
+goog.require('tslib');
 /** @typedef {?} */
 var MyType;
 /** @type {?} */

--- a/test_files/typedef/typedef.js
+++ b/test_files/typedef/typedef.js
@@ -6,6 +6,7 @@
 goog.module('test_files.typedef.typedef');
 var module = module || { id: 'test_files/typedef/typedef.ts' };
 module = module;
+goog.require('tslib');
 /** @typedef {number} */
 var MyType;
 /** @type {number} */

--- a/test_files/underscore/export_underscore.js
+++ b/test_files/underscore/export_underscore.js
@@ -6,5 +6,6 @@
 goog.module('test_files.underscore.export_underscore');
 var module = module || { id: 'test_files/underscore/export_underscore.ts' };
 module = module;
+goog.require('tslib');
 /** @type {number} */
 exports.__test = 1;

--- a/test_files/underscore/underscore.js
+++ b/test_files/underscore/underscore.js
@@ -6,6 +6,7 @@
 goog.module('test_files.underscore.underscore');
 var module = module || { id: 'test_files/underscore/underscore.ts' };
 module = module;
+goog.require('tslib');
 const tsickle_export_underscore_1 = goog.requireType("test_files.underscore.export_underscore");
 // Verify that double-underscored names in various places don't get corrupted.
 // See getIdentifierText() in tsickle.ts.

--- a/test_files/use_closure_externs/use_closure_externs.js
+++ b/test_files/use_closure_externs/use_closure_externs.js
@@ -9,6 +9,7 @@
 goog.module('test_files.use_closure_externs.use_closure_externs');
 var module = module || { id: 'test_files/use_closure_externs/use_closure_externs.ts' };
 module = module;
+goog.require('tslib');
 /** @type {!NodeListOf<!HTMLElement>} */
 let x = document.getElementsByName('p');
 console.log(x);

--- a/test_files/variables/variables.js
+++ b/test_files/variables/variables.js
@@ -6,6 +6,7 @@
 goog.module('test_files.variables.variables');
 var module = module || { id: 'test_files/variables/variables.ts' };
 module = module;
+goog.require('tslib');
 /** @type {string} */
 var v1;
 /** @type {string} */


### PR DESCRIPTION
As the comment in the code says, we need to always emit a goog.require('tslib') so that module manifests of Development mode contains the necessary 'tslib' module.