### PR TITLE
Prepare for upgrading the Jasmine typings.

### DIFF
--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -338,7 +338,7 @@ declare global {
  */
 export function addDiffMatchers() {
   jasmine.addMatchers({
-    toEqualWithDiff(util: jasmine.MatchersUtil, cet: jasmine.CustomEqualityTester[]) {
+    toEqualWithDiff(util: jasmine.MatchersUtil, cet: readonly jasmine.CustomEqualityTester[]) {
       return {compare: diffStrings};
     },
   });


### PR DESCRIPTION
In the latest version, the callback must accept a readonly array.