### PR TITLE
Replace usage of deprecated ts.createStatement

### DIFF
--- a/src/googmodule.ts
+++ b/src/googmodule.ts
@@ -459,7 +459,7 @@ export function commonJsToGoogmoduleTransformer(
         const exportedName = stmt.expression.left.name;
         const exportStmt = ts.setOriginalNode(
             ts.setTextRange(
-                ts.createStatement(ts.createAssignment(
+                ts.createExpressionStatement(ts.createAssignment(
                     ts.createPropertyAccess(ts.createIdentifier('exports'), exportedName), ident)),
                 stmt),
             stmt);


### PR DESCRIPTION
PR #1134 introduced a new usage of a deprecated method. This replaces it with the recommended alternative, `ts.createExpressionStatement`.