### PR TITLE
Add EventListenerObject to closure_externs

### DIFF
--- a/src/closure_externs.js
+++ b/src/closure_externs.js
@@ -112,3 +112,6 @@ function CanvasDrawImage() {}
 function CryptoKey() {};
 /** @constructor */
 function CryptoKeyPair() {};
+
+/** @typedef {!{handleEvent: function(Event):void}} */
+var EventListenerObject;


### PR DESCRIPTION
Adds `EventListenerObject` to `closure_externs.js`. This has already been synced inside of Google since April 13th, this is PR is just exporting the internal change.