### PR TITLE
forbid '@protected' in TypeScript comments

### DIFF
--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -144,7 +144,7 @@ const JSDOC_TAGS_OUTPUT_WHITELIST = new Set([
  */
 const JSDOC_TAGS_INPUT_BLACKLIST = new Set([
   'augments', 'class',      'constructs', 'constructor', 'enum',      'extends', 'field',
-  'function', 'implements', 'interface',  'lends',       'namespace', 'private', 'public',
+  'function', 'implements', 'interface',  'lends',       'namespace', 'private', 'protected', 'public',
   'record',   'static',     'template',   'this',        'type',      'typedef',
 ]);
 


### PR DESCRIPTION
We already forbade @private and @public; I think this was an oversight.

The reason we forbid these is because there are TS builtin equivalents,
and some users aren't aware of them.  I have already fixed the existing
users to make this change safe to land.

PiperOrigin-RevId: 309953800