### PR TITLE
Repair the tsickle demo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,5 +208,5 @@ From the master branch run:
 ```
 npm config set registry https://wombat-dressing-room.appspot.com
 npm login
-npm publish -- --registry https://wombat-dressing-room.appspot.com
+npm publish
 ```

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "minimist": "^1.2.3",
-    "tsickle": "^0.37.0",
-    "typescript": "~3.5.3"
+    "tsickle": "^0.41.0",
+    "typescript": "~4.3"
   },
   "devDependencies": {
     "@types/minimist": "1.2.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -7,43 +7,29 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/minimist@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
+  integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
 "@types/node@^10.5.6":
   version "10.14.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.18.tgz#b7d45fc950e6ffd7edc685e890d13aa7b8535dce"
   integrity sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.2.0, minimist@^1.2.3:
+minimist@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
   integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
-mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+tsickle@^0.41.0:
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.41.0.tgz#ab4f168a7168db6ce8fcdd306a44fa07270368ee"
+  integrity sha512-IRfRP3efl6E19MxqOwkty/hoqudAxd91tO75VmIZqXtVeiDyi3l3b8OqrC0/JagnJvqe+fHyefM5cbMR2lyEjw==
   dependencies:
-    minimist "0.0.8"
+    "@types/minimist" "^1.2.1"
 
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-tsickle@^0.37.0:
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.37.0.tgz#cc8a174310ac349913c62477b346db4f342c87d1"
-  integrity sha512-ufUZqLUNqh+kOfr52N/hJ5JbiDO32/CO7ZCteZBX9HA2kiejwEgDaJeJe1GAj2TIu683IgTA/LPKvlns6Liw0w==
-  dependencies:
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map "^0.7.3"
-
-typescript@~3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@~4.3:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "tsc ",
     "clean": "rm -r out",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "jasmine out/test/*.js && npm run lint"
+    "test": "jasmine out/test/*.js && (cd demo && yarn && tsc) && npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We forgot to publish an updated version that works after the latest API
changes.

This change moves demo to a new release that's compatible, adjusts its
TypeScript & tsickle version, and also includes its basic build in the
yarn test target (that, independently, we might want to break into
smaller tasks at some point).

It also fixes an incorrect argument in the release instructions.

Fixes #1272.